### PR TITLE
Correctly add relative path to sys.path

### DIFF
--- a/runhouse/rns/function.py
+++ b/runhouse/rns/function.py
@@ -254,7 +254,11 @@ class Function(Resource):
         if self.access in [ResourceAccess.write, ResourceAccess.read]:
             if not self.system or self.system.name == rh_config.obj_store.cluster_name:
                 [relative_path, module_name, fn_name] = self.fn_pointers
-                fn = get_fn_by_name(module_name=module_name, fn_name=fn_name)
+                fn = get_fn_by_name(
+                    module_name=module_name,
+                    fn_name=fn_name,
+                    relative_path=relative_path,
+                )
                 return call_fn_by_type(
                     fn, fn_type, fn_name, relative_path, args, kwargs
                 )

--- a/runhouse/rns/run_module_utils.py
+++ b/runhouse/rns/run_module_utils.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import sys
 from datetime import datetime
 from functools import wraps
 from pathlib import Path
@@ -68,7 +69,7 @@ def call_fn_by_type(fn, fn_type, fn_name, module_path=None, args=None, kwargs=No
     return res
 
 
-def get_fn_by_name(module_name, fn_name):
+def get_fn_by_name(module_name, fn_name, relative_path=None):
     if module_name in rh_config.obj_store.imported_modules:
         importlib.invalidate_caches()
         rh_config.obj_store.imported_modules[module_name] = importlib.reload(
@@ -76,10 +77,15 @@ def get_fn_by_name(module_name, fn_name):
         )
         logger.info(f"Reloaded module {module_name}")
     else:
+        if relative_path:
+            module_path = str((Path.home() / relative_path).resolve())
+            sys.path.append(module_path)
+            logger.info(f"Appending {module_path} to sys.path")
+
+        logger.info(f"Importing module {module_name}")
         rh_config.obj_store.imported_modules[module_name] = importlib.import_module(
             module_name
         )
-        logger.info(f"Importing module {module_name}")
     fn = getattr(rh_config.obj_store.imported_modules[module_name], fn_name)
     return fn
 

--- a/runhouse/servers/grpc/unary_server.py
+++ b/runhouse/servers/grpc/unary_server.py
@@ -1,8 +1,6 @@
 import logging
-import sys
 import traceback
 from concurrent import futures
-from pathlib import Path
 
 import grpc
 
@@ -172,11 +170,6 @@ class UnaryService(pb2_grpc.UnaryServicer):
             module_path = None
 
             if module_name == "notebook":
-                # If relative_path is None, the module is not in the working dir, and should be in the reqs
-                if relative_path:
-                    module_path = str((Path.home() / relative_path).resolve())
-                    sys.path.append(module_path)
-                    logger.info(f"Appending {module_path} to sys.path")
                 fn = fn_name  # Already unpickled above
             else:
                 fn = get_fn_by_name(module_name, fn_name, relative_path)

--- a/runhouse/servers/grpc/unary_server.py
+++ b/runhouse/servers/grpc/unary_server.py
@@ -170,16 +170,16 @@ class UnaryService(pb2_grpc.UnaryServicer):
             )
 
             module_path = None
-            # If relative_path is None, the module is not in the working dir, and should be in the reqs
-            if relative_path:
-                module_path = str((Path.home() / relative_path).resolve())
-                sys.path.append(module_path)
-                logger.info(f"Appending {module_path} to sys.path")
 
             if module_name == "notebook":
+                # If relative_path is None, the module is not in the working dir, and should be in the reqs
+                if relative_path:
+                    module_path = str((Path.home() / relative_path).resolve())
+                    sys.path.append(module_path)
+                    logger.info(f"Appending {module_path} to sys.path")
                 fn = fn_name  # Already unpickled above
             else:
-                fn = get_fn_by_name(module_name, fn_name)
+                fn = get_fn_by_name(module_name, fn_name, relative_path)
 
             res = call_fn_by_type(fn, fn_type, fn_name, module_path, args, kwargs)
             # [res, None, None] is a silly hack for packaging result alongside exception and traceback


### PR DESCRIPTION
Move adding relative path to sys.path from `RunModule` to `_get_fn_name`. In [multi gpu tutorial example](https://github.com/run-house/tutorials/blob/main/t04_Distributed/p01a_accelerate_multigpu_example.py), where there is nested function calls, only the external relative path (`tutorials/t04_Distributed`) was added to sys.path, and not relative path for the internal rh function (`accelerate/examples`)