### PR TITLE
Reorganize API usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,4 +194,4 @@ to message us, or email us (first name at run.house), or create an issue.
 
 ## 👷‍♀️ Contributing
 
-We welcome contributions! Please check out out [contributing](CONTRIBUTING.md) if you're interested.
+We welcome contributions! Please check out [contributing](CONTRIBUTING.md) if you're interested.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Keep reading on to see how Runhouse achieves this, or explore our
 :ref:`Architecture Section <Compute>`, :ref:`Python API`, and `Tutorials <https://github.com/run-house/tutorials>`_.
 
 .. warning::
-    **This is an Alpha**
+    **This is an Alpha:**
     Runhouse is heavily under development and we expect to iterate on the APIs before reaching beta (version 0.1.0).
 
 
@@ -60,6 +60,7 @@ Table of Contents
 
    REST API Guide <https://api.run.house/docs>
    Dashboard <https://api.run.house>
+   Funhouse <https://github.com/run-house/funhouse>
 
 .. toctree::
    :maxdepth: 1

--- a/docs/overview/accessibility.rst
+++ b/docs/overview/accessibility.rst
@@ -32,45 +32,9 @@ service we call the Runhouse RNS API. Both have their advantages:
     Not every resource in Runhouse is named. You can use the Runhouse APIs if you like the ergonomics without ever
     naming anything. Anonymous resources are simply never written to a metadata store.
 
-
-Every named resource has a name and "full name" at :code:`resource.rns_address`, which is organized into
-hierarchical folders. When you create a resource, you can name it with just a name (we will resolve it as being in
-the :code:`rh.current_folder()`) or the full address. Resources in the local RNS begin with the :code:`~` folder.
-Resources built-into the Runhouse Python package begin with :code:`^` (like a house). All other addresses are in the
-Runhouse RNS. By default, the only top-level folders in the Runhouse RNS you have permission to write to are your
-username and any organizations you are in. The :code:`@` alises to your username - for example:
-
-.. code-block:: python
-
-   my_resource.save(name='@/myresource')
-
-To persist a resource, call:
-
-.. code-block:: python
-
-    resource.save()
-    resource.save(name='new_name')  # Saves to rh.current_folder()
-    resource.save(name='@/my_full/new_name')  # Saves to Runhouse RNS
-    resource.save(name='~/my_full/new_name')  # Saves to Local RNS
-
-
-
-To load a resource, you can call :code:`rh.load('my_name')`, or use the resource factory constructor with
-only the name, e.g.
-
-.. code-block:: python
-
-    rh.function(name='my_function')
-    rh.cluster(name='~/my_name')
-    rh.table(name='@/my_datasets/my_table')
-
-You may need to pass the full rns_address if the resource is not in :code:`rh.current_folder()`. To check if a resource exists, you can call:
-
-.. code-block:: python
-
-    rh.exists(name='my_function')
-    rh.exists(name='~/local_resource')
-    rh.exists(name='@/my/rns_path/to/my_table')
+.. note::
+    By default, the only top-level folders in the Runhouse RNS you have permission to write to are your
+    username and any organizations you are in.
 
 We're still early in uncovering the patterns and antipatterns for a global shared environment for compute and data resources (shocker),
 but for now we generally encourage OSS projects to publish resources in the local RNS of their package, and individuals and teams to largely rely on Runhouse RNS.
@@ -90,13 +54,13 @@ to use Runhouse's APIs in a single environment, and don't plan to share resource
 
 **Logging In:**
 
-.. code-block:: console
-
-    $ runhouse login
-
 Run this wherever your cloud credentials are already saved, such as your laptop.
 Follow the prompts to log in. If this is your first time logging in, you should probably upload
 your secrets, and none of the other prompts will have any real effect (you probably haven't set any defaults yet):
+
+.. code-block:: console
+
+    $ runhouse login
 
 or in Python (e.g. in a notebook)
 
@@ -107,11 +71,11 @@ or in Python (e.g. in a notebook)
 
 **Logging Out:**
 
+Run this wherever your cloud credentials are already saved.
+
 .. code-block:: console
 
     $ runhouse logout
-
-Run this wherever your cloud credentials are already saved.
 
 or in Python
 
@@ -215,4 +179,4 @@ If you want to sync down your code or data to local from the cluster afterwards:
 
 .. code-block:: python
 
-    rh.folder(path='remote_directory', system=rh.cluster('my_cluster').to('here', path='local_directory')
+    rh.folder(path='remote_directory', system=rh.cluster('my_cluster').to('here', path='local_directory'))

--- a/docs/overview/compute.rst
+++ b/docs/overview/compute.rst
@@ -11,8 +11,7 @@ and rich debugging and accessibility interfaces built-in.
 Functions
 ---------
 
-Runhouse allows you to send function code to a cluster, but still interact with it as a native runnable :ref:`Function` object
-(see `tutorial 01 <https://github.com/run-house/tutorials/tree/main/t01_Stable_Diffusion/>`_).
+Runhouse allows you to send function code to a cluster, but still interact with it as a native runnable :ref:`Function` object.
 When you do this, the following steps occur:
 
 1. We check if the cluster is up, and bring up the cluster if not (only possible for :ref:`OnDemandClusters <OnDemandCluster>`)
@@ -24,54 +23,7 @@ When you run your function module, we send a gRPC request to the cluster with th
 The gRPC server adds the module to its python path, imports the module, grabs the function entrypoint, runs it,
 and returns your results.
 
-You can stream in logs from the cluster as your module runs by passing :code:`stream_logs=True` into your call line:
-
-
-.. code-block:: python
-
-    images = generate_gpu('A dog.', num_images=1, steps=50, stream_logs=True)
-
-
 We plan to support additional form factors for modules beyond "remote Python function" shortly, including HTTP endpoints, custom ASGIs, and more.
-
-
-Advanced Function Usage
-~~~~~~~~~~~~~~~~~~~~~~~
-There are a number of ways to call a Function beyond just :code:`__call__`.
-
-:code:`.remote` will call the function async (using Ray) and return a reference (`Ray ObjectRef <https://docs.ray.io/en/latest/ray-core/objects.html>`_)
-to the object on the cluster. You can pass the ref into another function and it will be automatically
-dereferenced once on the cluster. This is a convenient way to avoid passing large objects back and forth to your
-laptop, or to run longer execution in notebooks without locking up the kernel.
-
-.. code-block:: python
-
-    images_ref = generate_gpu.remote('A dog.', num_images=1, steps=50)
-    images = rh.get(images_ref)
-    # or
-    my_other_function(images_ref)
-
-
-:code:`.enqueue` will queue up your function call on the cluster to make sure it doesn't run simultaneously with other
-calls, but will wait until the execution completes.
-
-:code:`.map` and :code:`.starmap` are easy way to parallelize your function (again using Ray on the cluster).
-
-.. code-block:: python
-
-    generate_gpu.map(['A dog.', 'A cat.', 'A biscuit.'], num_images=[1]*3, steps=[50]*3)
-
-
-will run the function on each of the three prompts, and return a list of the results.
-Note that the :code:`num_images` and :code:`steps` arguments are broadcasted to each prompt, so the first prompt will get 1 image.
-
-
-.. code-block:: python
-
-    generate_gpu.starmap([('A dog.', 1), ('A cat.', 2), ('A biscuit.', 3)], steps=50)
-
-is the same as :code:`map` as above, but we can pass the arguments as a list of tuples, and the steps argument as a
-single value, since it's the same for all three prompts.
 
 
 Clusters
@@ -89,37 +41,13 @@ or data through the Runhouse APIs. This is useful if you have an on-prem instanc
 `CoreWeave <https://www.coreweave.com/>`_, or another vertical provider, or simply want to spin up machines
 yourself through the cloud UI.
 
-You can use the :ref:`Cluster Factory Method` constructor like so:
-
-.. code-block:: python
-
-    gpu = rh.cluster(ips=['<ip of the cluster>'],
-                     ssh_creds={'ssh_user': '...', 'ssh_private_key':'<path_to_key>'},
-                     name='rh-a10x')
-
 
 On-Demand Clusters
 ~~~~~~~~~~~~~~~~~~
 Runhouse can spin up and down boxes for you as needed using `SkyPilot <https://github.com/skypilot-org/skypilot/>`_.
 When you define a SkyPilot "cluster,"
 you're primarily defining the configuration for us to spin up the compute resources on-demand.
-When someone then calls a function or similar, we'll spin the box back up for you. You can also create these through the
-cluster factory constructor:
-
-You can use the cluster factory constructor like so:
-
-.. code-block:: python
-
-    gpu = rh.cluster(name='rh-4-a100s',
-                     instance_type='A100:4',    # Can also be 'CPU:8' or cloud-specific strings, like 'g5.2xlarge'
-                     provider='gcp',            # defaults to default_provider or cheapest if left empty
-                     autostop_mins=-1,          # Defaults to 30 mins or default_autostop_mins, -1 suspends autostop
-                     use_spot=True,             # You must have spot quota approved to use this
-                     image_id='my_ami_string',  # Generally defaults to basic deep-learning AMIs through SkyPilot
-                     region='us-east-1'         # Looks for cheapest on your continent if empty
-                     )
-
-
+When someone then calls a function or similar, we'll spin the box back up for you.
 
 SkyPilot also provides an excellent suite of CLI commands for basic instance management operations.
 Some important ones are:
@@ -138,7 +66,7 @@ don't have any machines left running is always to check the cloud provider's UI.
 SkyPilot cleverly adds the host information to your :code:`~/.ssh/config file`, so ssh will just work.
 
 :code:`sky autostop -i <minutes, or -1> <cluster_name>`: This will set the cluster to autostop after that many minutes of inactivity.
-By default this number is 10 minutes, but you can set it to -1 to disable autostop entirely. You can set your default autostop in :code:`~/.rh/config.yaml`.
+You can set it to -1 to disable autostop entirely. You can set your default autostop in :code:`~/.rh/config.yaml`.
 
 
 Existing Clusters
@@ -160,67 +88,6 @@ You can load an existing cluster by name from local or Runhouse RNS simply by:
     gpu = rh.cluster(name='^rh-v100', dryrun=True)
 
 
-
-Advanced Cluster Usage
-~~~~~~~~~~~~~~~~~~~~~~
-
-To start an ssh session into the cluster so you can poke around or debug:
-
-.. code-block:: console
-
-    $ ssh rh-v100
-
-or in Python:
-
-.. code-block:: python
-
-    my_cluster.ssh()
-    # or
-    # my_function.ssh()
-
-If you prefer to work in notebooks, you can tunnel a JupyterLab server into your local browser:
-
-.. code-block:: console
-
-    $ runhouse notebook my_cluster
-
-or in Python:
-
-.. code-block:: python
-
-    my_function.notebook()
-    # or
-    my_cluster.notebook()
-
-
-The :ref:`Notebooks` section goes more in depth on notebooks.
-
-To run a shell command on the cluster:
-
-.. code-block:: python
-
-    gpu.run(['git clone ...', 'pip install ...'])
-
-This is useful for installing more complex dependencies. :code:`gpu.run_setup(...)` will make sure the command is
-only run once when the cluster is first created.
-
-To run any Python on the cluster:
-
-.. code-block:: python
-
-    gpu.run_python(['import torch', 'print(torch.__version__)'])
-
-This is useful for debugging, or for running a script that you don't want to send to the cluster
-(e.g. because it has too many dependencies).
-
-If you want to run an application on the cluster that requires a port to be open,
-e.g. `Tensorboard <https://www.tensorflow.org/tensorboard/>`_, `Gradio <https://gradio.app/>`_.
-
-.. code-block:: python
-
-    gpu.ssh_tunnel(local_port=7860, remote_port=7860)
-
-
 Packages
 --------
 A :ref:`Package` represents the way we share code between various systems (ex: s3, cluster, local),
@@ -231,13 +98,7 @@ the :ref:`Function`.
 At a high level, we dump the list of packages into gRPC, and the packages are installed on the gRPC server
 on the cluster.
 
-We currently provide four package install methods:
-
-- :code:`local`: Install packages to a Folder or a given path to a directory.
-- :code:`reqs`: Install a :code:`requirements.txt` file from the working directory.
-- :code:`pip`: Runs :code:`pip install` for the provided packages.
-- :code:`conda`: Runs :code:`conda install` for the provided packages.
-
+We currently provide four general package install methods: local, requiements.txt, pip, and conda.
 
 GitPackage
 ~~~~~~~~~~
@@ -245,15 +106,4 @@ GitPackage
 Runhouse offers support for using a GitHub URL as GitPackage object, a subclass of :ref:`Package`.
 Instead of cloning down code from GitHub and copying it directly into your existing code base, you can provide a link
 to a specific :code:`git_url` (with support for a :code:`revision` version), and Runhouse handles all the installations
-for you!
-
-For example:
-
-.. code-block:: python
-
-    rh.GitPackage(git_url='https://github.com/huggingface/diffusers.git',
-                  install_method='pip',
-                  revision='v0.11.1')
-
-
-See a more detailed example of working with a GitPackage in our `Dreambooth Tutorial <https://github.com/run-house/tutorials/blob/main/t02_Dreambooth/p01_dreambooth_train.py/>`_
+for you.

--- a/docs/overview/data.rst
+++ b/docs/overview/data.rst
@@ -46,6 +46,7 @@ We currently support a variety of systems where a folder can live:
 - :code:`sftp` / :code:`ssh`: On a :ref:`Cluster`.
 - :code:`s3`: Bucket in AWS.
 - :code:`gs`: Bucket in GCS.
+- :code:`azure`: Bucket in Azure.
 
 
 Tables

--- a/docs/overview/data.rst
+++ b/docs/overview/data.rst
@@ -48,32 +48,6 @@ We currently support a variety of systems where a folder can live:
 - :code:`gs`: Bucket in GCS.
 
 
-Advanced Folder Usage
-~~~~~~~~~~~~~~~~~~~~~
-Let's demonstrate how you can easily copy a folder from one system to another. In this example we'll
-copy a local folder to a cluster.
-
-.. code-block:: python
-
-    local_folder = rh.folder(Path.cwd(), name='my_local_folder')
-
-    # Use a Runhouse builtin cluster, make sure the cluster is up if it isn't already
-    c = rh.cluster("^rh-cpu").up_if_not()
-
-    # `from_cluster` will create a remote folder from our path on the cluster
-    cluster_folder = local_folder.to(system=c).from_cluster(c)
-
-    # Confirm that the folder contents are now saved on the `rh-cpu` cluster
-    print(cluster_folder.ls(full_paths=False))
-
-
-We can just as easily send this local folder to a cloud storage system, such as s3:
-
-.. code-block:: python
-
-    s3_folder = rh.folder(name='my_local_folder').to(system="s3")
-
-
 Tables
 ------
 Runhouse supports a variety of different :ref:`Table` types based on the table's underlying data type.
@@ -90,42 +64,6 @@ convenient APIs for writing, partitioning, fetching and streaming the data:
     In the near term, we plan on supporting Spark, Rapids, and BigQuery. Please let us know if there is a
     particular Table abstraction that would be useful to you.
 
-
-Advanced Table Usage
-~~~~~~~~~~~~~~~~~~~~
-Let's demonstrate how we can easily create a Table backed by a Pandas DataFrame that lives in s3,
-and access that data from any other system:
-
-.. code-block:: python
-
-    data = pd.DataFrame(...)
-    my_table = rh.table(
-        data=data,
-        name="@/my_pandas_table",
-        path=f"/preproc-data/pandas", # path to s3 folder where the table will live
-        system="s3",
-        mkdir=True,
-    ).save()
-
-
-Now we can easily stream this table from our laptop, an existing cluster, a notebook, etc:
-
-.. code-block:: python
-
-    reloaded_table = rh.table(name="my_pandas_table")
-
-This :code:`reloaded_table` holds a reference to the table's path.
-
-.. code-block:: python
-
-    batches = reloaded_table.stream(batch_size=100)
-        for batch in batches:
-            ....
-
-Our `BERT Pipeline Preprocessing Tutorial <https://github.com/run-house/tutorials/blob/main/t05_BERT_pipeline/p01_preprocess.py>`_
-showcases the accessibility and portability that a Table can provide. We create a tokenized dataset Table object on a
-cluster, then stream that data in directly from the cluster.
-
 Blobs
 -----
 A :ref:`Blob` represents a single serialized file stored in a particular system.
@@ -134,10 +72,6 @@ handling saving down and retrieving the Blob for you.
 
 For example, if you want to save a model checkpoint for future reuse, use the Blob interface
 to easily save it in your desired cloud storage system.
-
-Our `BERT Pipeline Fine-Tuning Tutorial <https://github.com/run-house/tutorials/blob/main/t05_BERT_pipeline/p02_fine_tune.py/>`_
-shows how we can use a Blob to save a trained BERT fine tuning model locally on a cluster.
-When finished, we can send the Blob from the cluster directly to an s3 bucket for persistence.
 
 Please note Runhouse does not make any assumptions about deserializing the underlying blob data.
 In this example we load an existing blob and deserialize ourselves with :code:`pickle`:

--- a/docs/rh_primitives/blob.rst
+++ b/docs/rh_primitives/blob.rst
@@ -8,8 +8,8 @@ Blob Factory Method
 
 .. autofunction:: runhouse.blob
 
-Blob Docs
-~~~~~~~~~
+Blob Class
+~~~~~~~~~~
 
 .. autoclass:: runhouse.Blob
    :members:

--- a/docs/rh_primitives/blob.rst
+++ b/docs/rh_primitives/blob.rst
@@ -2,19 +2,53 @@ Blob
 ====================================
 A Blob is a Runhouse primitive that represents an entity for storing data and lives inside of a :ref:`Folder`.
 
-For more details see the :ref:`Data <Blobs>` section.
-
 
 Blob Factory Method
 ~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: runhouse.blob
 
-Blob
-~~~~
+Blob Docs
+~~~~~~~~~
 
 .. autoclass:: runhouse.Blob
    :members:
    :exclude-members:
 
     .. automethod:: __init__
+
+
+API Usage
+~~~~~~~~~
+
+To initalize a Blob, use ``rh.blob``:
+
+.. code:: python
+
+   data = json.dumps(list(range(50)))
+
+   # Remote blob with name and no path (saved to bucket called runhouse/blobs/my-blob)
+   rh.blob(name="@/my-blob", data=data, data_source='s3', dryrun=False)
+
+   # Remote blob with name and path
+   rh.blob(name='@/my-blob', path='/runhouse-tests/my_blob.pickle', data=data, system='s3', dryrun=False)
+
+   # Local blob with name and path, save to local filesystem
+   rh.blob(name=name, data=data, path=str(Path.cwd() / "my_blob.pickle"), dryrun=False)
+
+   # Local blob with name and no path (saved to ~/.cache/blobs/my-blob)
+   rh.blob(name="~/my-blob", data=data, dryrun=False)
+
+To load an existing blob by name:
+
+.. code:: python
+
+   my_local_blob = rh.blob(name="~/my_blob")
+   my_s3_blob = rh.blob(name="@/my_blob")
+
+To get the contets from the blob:
+
+.. code:: python
+
+   raw_data = my_local_blob.fetch()
+   result = pickle.loads(raw_data)  # deserialization

--- a/docs/rh_primitives/cluster.rst
+++ b/docs/rh_primitives/cluster.rst
@@ -6,15 +6,13 @@ This can be either an :ref:`on-demand cluster <OnDemandCluster>` (requires valid
 
 A cluster is assigned a name, through which it can be accessed and reused later on.
 
-For more details see the :ref:`Compute <Clusters>` section.
-
 Cluster Factory Method
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: runhouse.cluster
 
-Cluster
-~~~~~~~
+Cluster Docs
+~~~~~~~~~~~~
 
 .. autoclass:: runhouse.Cluster
   :members:
@@ -22,8 +20,8 @@ Cluster
 
     .. automethod:: __init__
 
-OnDemandCluster
-~~~~~~~~~~~~~~~
+OnDemandCluster Docs
+~~~~~~~~~~~~~~~~~~~~
 A OnDemandCluster is a cluster that uses SkyPilot functionality underneath to handle
 various cluster properties.
 
@@ -32,3 +30,107 @@ various cluster properties.
    :exclude-members:
 
     .. automethod:: __init__
+
+Basic API Usage
+~~~~~~~~~~~~~~~
+For On Demand Clusters, which use SkyPilot to spin up and down clusters, use the ``rh.cluster`` factory
+method as follows.
+
+.. code-block:: python
+
+  my_cluster = rh.cluster(name='rh-4-a100s',
+                          instance_type='A100:4',    # or 'CPU:8', 'g5.2xlarge', etc
+                          provider='gcp',            # Defaults to `cheapest` if empty
+                          autostop_mins=-1,          # Defaults to default_autostop_mins, -1 suspends autostop
+                          use_spot=True,             # You must have spot quota approved to use this
+                          image_id='my_ami_string',  # Generally defaults to basic deep-learning AMIs
+                          region='us-east-1'         # Looks for cheapest on your continent if empty
+                          )
+
+For BYO Clusters, which are specified by IP addresses and SSH credentials, use the ``rh.cluster`` factory
+method as follows:
+
+.. code-block:: python
+
+  my_cluster = rh.cluster(ips=['<ip of the cluster>'],
+                          ssh_creds={'ssh_user': '...', 'ssh_private_key':'<path_to_key>'},
+                          name='rh-a10x')
+
+For existing clusters, which can mean either a saved OnDemandCluster config (which will be brought back
+up if needed), or a BYO or OnDemandCluster tha is already up, you can simply pass in the name to
+``rh.cluster`` as follows:
+
+.. code-block:: python
+
+  my_cluster = rh.cluster(name='~/my-local-a100')
+  my_cluster = rh.cluster(name='@/my-a100-in-rh-rns')
+
+  # or, if you just want to load the Cluster object without refreshing its status
+  my_cluster = rh.cluster(name='^rh-v100', dryrun=True)
+
+Advanced API Usage
+~~~~~~~~~~~~~~~~~~
+Additional utilites for On Demand Clusters include
+:ref:`setting custom default configs <Setting Config Options>` and
+:ref:`SkyPilot CLI commands for instance management <On-Demand Clusters>`.
+
+To start an ssh session into the cluster so you can poke around or debug:
+
+.. code-block:: cli
+
+  $ # In CLI
+  $ ssh my_cluster_name
+
+.. code-block:: python
+
+  # In Python
+  my_cluster.ssh()
+
+After ``ssh``, you can then use ``screen -r`` to view logs on the Cluster. The server
+runs inside that screen instance, so logs are written to there.
+
+.. note::
+   Use ``control A+D`` to exit ``screen``. ``control-C`` will stop the GRPC server.
+
+.. code-block:: console
+
+   $ screen -r
+   $ # control A+D to exit screen
+
+To restart the RPC server, in the case that it crashes or you want to update a package that the server
+has already imported:
+
+.. code-block:: python
+
+    my_cluster.restart_grpc_server()
+
+For notebook users, to tunnel a JupyterLab server into your local browser:
+
+.. code-block:: cli
+
+  $ # In CLI
+  $ runhouse notebook my_cluster
+
+.. code-block:: python
+
+  # In Python
+  my_cluster.notebook()
+
+To run a Shell command on the cluster:
+
+.. code-block:: python
+
+  my_cluster.run(['git clone ...', 'pip install ...'])
+
+To run a Python on the cluster:
+
+.. code-block:: python
+
+  my_cluster.run_python(['import torch', 'print(torch.__version__)'])
+
+To open a port, if you want to run an application on the cluster that requires a port to be open,
+e.g. `Tensorboard <https://www.tensorflow.org/tensorboard/>`_, `Gradio <https://gradio.app/>`_.
+
+.. code-block:: python
+
+  my_cluster.ssh_tunnel(local_port=7860, remote_port=7860)

--- a/docs/rh_primitives/cluster.rst
+++ b/docs/rh_primitives/cluster.rst
@@ -11,8 +11,8 @@ Cluster Factory Method
 
 .. autofunction:: runhouse.cluster
 
-Cluster Docs
-~~~~~~~~~~~~
+Cluster Class
+~~~~~~~~~~~~~
 
 .. autoclass:: runhouse.Cluster
   :members:
@@ -20,8 +20,8 @@ Cluster Docs
 
     .. automethod:: __init__
 
-OnDemandCluster Docs
-~~~~~~~~~~~~~~~~~~~~
+OnDemandCluster Class
+~~~~~~~~~~~~~~~~~~~~~
 A OnDemandCluster is a cluster that uses SkyPilot functionality underneath to handle
 various cluster properties.
 
@@ -57,7 +57,7 @@ method as follows:
                           name='rh-a10x')
 
 For existing clusters, which can mean either a saved OnDemandCluster config (which will be brought back
-up if needed), or a BYO or OnDemandCluster tha is already up, you can simply pass in the name to
+up if needed), or a BYO or OnDemandCluster that is already up, you can simply pass in the name to
 ``rh.cluster`` as follows:
 
 .. code-block:: python
@@ -70,7 +70,7 @@ up if needed), or a BYO or OnDemandCluster tha is already up, you can simply pas
 
 Advanced API Usage
 ~~~~~~~~~~~~~~~~~~
-Additional utilites for On Demand Clusters include
+Additional utilites for on-demand Clusters include
 :ref:`setting custom default configs <Setting Config Options>` and
 :ref:`SkyPilot CLI commands for instance management <On-Demand Clusters>`.
 
@@ -95,10 +95,9 @@ runs inside that screen instance, so logs are written to there.
 .. code-block:: console
 
    $ screen -r
-   $ # control A+D to exit screen
 
-To restart the RPC server, in the case that it crashes or you want to update a package that the server
-has already imported:
+You can restart the RPC server, in the case that it crashes or you want to update a package that the
+server has already imported. This runs much more quickly than shutting down and restarting a cluster.
 
 .. code-block:: python
 
@@ -129,7 +128,7 @@ To run a Python on the cluster:
   my_cluster.run_python(['import torch', 'print(torch.__version__)'])
 
 To open a port, if you want to run an application on the cluster that requires a port to be open,
-e.g. `Tensorboard <https://www.tensorflow.org/tensorboard/>`_, `Gradio <https://gradio.app/>`_.
+e.g. `Tensorboard <https://www.tensorflow.org/tensorboard/>`_, `Gradio <https://gradio.app/>`_:
 
 .. code-block:: python
 

--- a/docs/rh_primitives/folder.rst
+++ b/docs/rh_primitives/folder.rst
@@ -3,8 +3,6 @@ Folder
 A Folder represents a specified location for organizing and storing other Runhouse primitives
 across various systems.
 
-For more details see the :ref:`Data <Folders>` section.
-
 
 Folder Factory Method
 ~~~~~~~~~~~~~~~~~~~~~
@@ -12,11 +10,34 @@ Folder Factory Method
 .. autofunction:: runhouse.folder
 
 
-Folder
-~~~~~~
+Folder Docs
+~~~~~~~~~~~
 
 .. autoclass:: runhouse.Folder
    :members:
    :exclude-members:
 
     .. automethod:: __init__
+
+API Usage
+~~~~~~~~~
+
+To initalize a Folder, use the ``rh.folder`` factory method.
+
+.. code:: python
+
+   rh.folder(name='folder_name', path='remote_directory/path_to_folder', system='s3')
+
+To copy a folder from one system to another (in this case, from local to a cluster or s3):
+
+.. code:: python
+
+   local_cluster = rh.cluster(...).up_if_not()  # Instantiate cluster and check that it is up
+   local_folder = rh.folder(Path.cwd(), name='my_local_folder')
+
+   # Send the folder to my_cluster
+   # `from_cluster` will create a remote folder from our path on the cluster
+   cluster_folder = local_folder.to(system=local_cluster).from_cluster(local_cluster)
+
+   # Send the folder to s3
+   s3_folder = rh.folder(name='my_local_folder').to(system="s3")

--- a/docs/rh_primitives/folder.rst
+++ b/docs/rh_primitives/folder.rst
@@ -10,8 +10,8 @@ Folder Factory Method
 .. autofunction:: runhouse.folder
 
 
-Folder Docs
-~~~~~~~~~~~
+Folder Class
+~~~~~~~~~~~~
 
 .. autoclass:: runhouse.Folder
    :members:

--- a/docs/rh_primitives/function.rst
+++ b/docs/rh_primitives/function.rst
@@ -4,18 +4,94 @@ Function
 A Function is a portable code block that can be sent to remote hardware to run as a subroutine or service.
 It is comprised of the entrypoint, system (:ref:`Cluster`), and requirements necessary to run it.
 
-For more details see the :ref:`Compute <Functions>` section.
 
 Function Factory Method
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: runhouse.function
 
-Function
-~~~~
+Function Docs
+~~~~~~~~~~~~~
 
 .. autoclass:: runhouse.Function
    :members:
    :exclude-members:
 
     .. automethod:: __init__
+
+Basic API Usage
+~~~~~~~~~~~~~~~
+To initialize a function, from a local function:
+
+.. code-block:: python
+
+   def local_function(arg1, arg2):  # standard local Python method
+      ...
+
+   # Runhouse Function, to be run on my_cluster Cluster
+   my_function = rh.function(fn=local_function, system=my_cluster, reqs=['requirements.txt'])
+   # or, equivalently
+   my_function = rh.function(fn=local_function).to(my_cluster, reqs=['requirements.txt'])
+
+To use the function, simply call it as you would the local function.
+
+.. code-block:: python
+
+   result = my_function(arg1, arg2)  # runs the function on my_cluster, and returns the result locally
+
+To intialize a function, from an existing Github function:
+
+.. code-block:: python
+
+   my_github_function = rh.function(
+                           fn='https://github.com/huggingface/diffusers/blob/v0.11.1/examples/dreambooth/train_dreambooth.py:main',
+                           system=my_cluster,
+                           reqs=['requirements.txt'],
+                        )
+
+To name the function, to be accessed by name later on, pass in the `name` argument to the factory method.
+
+.. code-block:: python
+
+   my_function = rh.function(fn=local_function, system=my_cluster, reqs=['requirements.txt'], name="my_function_name")
+
+Advanced API Usage
+~~~~~~~~~~~~~~~~~~
+Logging: To stream logs, you can pass in ``stream_logs=True`` to the function call. or `. Note that
+
+.. code-block:: python
+
+   my_function(arg1, arg2, stream_logs=True)
+
+``.remote()``: Call the function async (using Ray) and return a reference (Ray ObjectRef) to the object
+on the cluster. This ref can be passed into another function, and will be automatically dereferenced
+once on the cluster. This is a convenient way to avoid passing large objects back and forth to your
+laptop, or to run longer execution in notebooks without locking up the kernel.
+
+.. code-block:: python
+
+   result_ref = my_function.remote(arg1, arg2)
+
+   result = rh.get(result_ref)  # load the result to local
+   my_other_function(result_ref)  # pass in ref to another function
+
+``.enqueue()``: Queue up the function call on the cluster. This ensures it doesn’t run simultaneously with other calls, but will wait until the execution completes.
+
+.. code-block:: python
+
+   my_function.enqueue()
+
+``.map()`` and ``.starmap()`` are easy way to parallelize your function (again using Ray on the cluster).
+``.map`` maps a function over a list of arguments, while ``.starmap`` unpacks the elements of the iterable
+while mapping.
+
+.. code-block:: python
+
+   # .map
+   arg1_map = [1, 2]
+   arg2_map = [2, 5]
+   map_results = my_function.map(arg1=arg1_map, arg2=arg2_map)
+
+   # .starmap
+   starmap_args = [[1, 2], [1, 3], [1, 4]]
+   starmap_results = my_function.starmap(starmap_args)

--- a/docs/rh_primitives/function.rst
+++ b/docs/rh_primitives/function.rst
@@ -10,8 +10,8 @@ Function Factory Method
 
 .. autofunction:: runhouse.function
 
-Function Docs
-~~~~~~~~~~~~~
+Function Class
+~~~~~~~~~~~~~~
 
 .. autoclass:: runhouse.Function
    :members:
@@ -57,7 +57,7 @@ To name the function, to be accessed by name later on, pass in the `name` argume
 
 Advanced API Usage
 ~~~~~~~~~~~~~~~~~~
-Logging: To stream logs, you can pass in ``stream_logs=True`` to the function call. or `. Note that
+To stream logs, pass in ``stream_logs=True`` to the function call.
 
 .. code-block:: python
 
@@ -81,7 +81,7 @@ laptop, or to run longer execution in notebooks without locking up the kernel.
 
    my_function.enqueue()
 
-``.map()`` and ``.starmap()`` are easy way to parallelize your function (again using Ray on the cluster).
+``.map()`` and ``.starmap()`` are easy way to parallelize a function (again using Ray on the cluster).
 ``.map`` maps a function over a list of arguments, while ``.starmap`` unpacks the elements of the iterable
 while mapping.
 

--- a/docs/rh_primitives/package.rst
+++ b/docs/rh_primitives/package.rst
@@ -9,8 +9,8 @@ Package Factory Method
 .. autofunction:: runhouse.package
 
 
-Package Docs
-~~~~~~~~~~~~
+Package Class
+~~~~~~~~~~~~~
 
 .. autoclass:: runhouse.Package
    :members:
@@ -45,7 +45,7 @@ Packages are often times installed onto clusters using ``my_cluster.install_pack
               reqs=['local:./',          # local
                     'requirements.txt',  # reqs
                     'pip:diffusers',     # pip
-                    'conda:pytorhch',    # conda
+                    'conda:pytorh',    # conda
               ])
 
 To install a Git package using just the GitHub URL (and optionally, the revision), without needing

--- a/docs/rh_primitives/package.rst
+++ b/docs/rh_primitives/package.rst
@@ -3,17 +3,14 @@ Package
 A Package is a Runhouse primitive for sharing code between various systems (ex: s3, cluster, local).
 
 
-For more details see the :ref:`Compute <Packages>` section.
-
-
 Package Factory Method
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: runhouse.package
 
 
-Package
-~~~~~~~~~~
+Package Docs
+~~~~~~~~~~~~
 
 .. autoclass:: runhouse.Package
    :members:
@@ -22,11 +19,40 @@ Package
     .. automethod:: __init__
 
 
-GitPackage
-~~~~~~~~~~
+GitPackage Docs
+~~~~~~~~~~~~~~~
 
 .. autoclass:: runhouse.GitPackage
    :members:
    :exclude-members:
 
     .. automethod:: __init__
+
+API Usage
+~~~~~~~~~
+
+Packages are often times installed onto clusters using ``my_cluster.install_packages()``, or by setting the
+``reqs`` of a Cluster or Function. There are currently four package install methods:
+
+- ``local``: Install packages to a Folder or a given path to a directory.
+- ``reqs``: Install a ``requirements.txt`` file from the working directory.
+- ``pip``: Runs ``pip install`` for the provided packages.
+- ``conda``: Runs ``conda install`` for the provided packages.
+
+.. code:: python
+
+   my_cluster(name,
+              reqs=['local:./',          # local
+                    'requirements.txt',  # reqs
+                    'pip:diffusers',     # pip
+                    'conda:pytorhch',    # conda
+              ])
+
+To install a Git package using just the GitHub URL (and optionally, the revision), without needing
+to clone or copy down the code yourself:
+
+.. code:: python
+
+   rh.GitPackage(git_url='https://github.com/huggingface/diffusers.git',
+                 install_method='pip',
+                 revision='v0.11.1')

--- a/docs/rh_primitives/resource.rst
+++ b/docs/rh_primitives/resource.rst
@@ -3,8 +3,8 @@ Resource
 Resources are the Runhouse abstraction for objects that can be saved, shared, and reused.
 
 
-Resource Docs
-~~~~~~~~~~~~~
+Resource Class
+~~~~~~~~~~~~~~
 .. autoclass:: runhouse.rns.resource.Resource
    :members:
    :exclude-members:

--- a/docs/rh_primitives/resource.rst
+++ b/docs/rh_primitives/resource.rst
@@ -2,8 +2,50 @@ Resource
 ====================================
 Resources are the Runhouse abstraction for objects that can be saved, shared, and reused.
 
+
+Resource Docs
+~~~~~~~~~~~~~
 .. autoclass:: runhouse.rns.resource.Resource
    :members:
    :exclude-members:
 
     .. automethod:: __init__
+
+Resource API Usage
+~~~~~~~~~~~~~~~~~~
+Every named resource has a name ``my_resource.name`` and "full name" ``my_resource.rns_address``, and
+is organized into heirarchical folders. By default, providing a ``name`` resolves it as being in
+``rh.current_folder()`` or the full address. Resources in the local RNS begin with the ``~`` folder,
+and Resources built-into the Runhouse Python package begin with ``^`` (like a house). ``@`` aliases to
+your username.
+
+.. code-block:: python
+
+   my_resource.save(name='@/myresource')
+
+To persist a resource, call:
+
+.. code-block:: python
+
+    resource.save()
+    resource.save(name='new_name')  # Saves to rh.current_folder()
+    resource.save(name='@/my_full/new_name')  # Saves to Runhouse RNS
+    resource.save(name='~/my_full/new_name')  # Saves to Local RNS
+
+To load a resource, you can call :code:`rh.load('my_name')`, or use the resource factory constructor with
+just the name.
+
+.. code-block:: python
+
+    rh.function(name='my_function')
+    rh.cluster(name='~/my_name')
+    rh.table(name='@/my_datasets/my_table')
+
+You may need to pass the full rns_address if the resource is not in :code:`rh.current_folder()`. To check
+if a resource exists, you can call:
+
+.. code-block:: python
+
+    rh.exists(name='my_function')
+    rh.exists(name='~/local_resource')
+    rh.exists(name='@/my/rns_path/to/my_table')

--- a/docs/rh_primitives/table.rst
+++ b/docs/rh_primitives/table.rst
@@ -8,8 +8,8 @@ Table Factory Method
 
 .. autofunction:: runhouse.table
 
-Table Docs
-~~~~~~~~~~
+Table Class
+~~~~~~~~~~~
 
 .. autoclass:: runhouse.Table
    :members:

--- a/docs/rh_primitives/table.rst
+++ b/docs/rh_primitives/table.rst
@@ -2,19 +2,44 @@ Table
 ====================================
 A Table is a Runhouse primitive used for abstracting a particular tabular data storage configuration.
 
-For more details see the :ref:`Data <Tables>` section.
-
 
 Table Factory Method
 ~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: runhouse.table
 
-Table
-~~~~~
+Table Docs
+~~~~~~~~~~
 
 .. autoclass:: runhouse.Table
    :members:
    :exclude-members:
 
     .. automethod:: __init__
+
+
+API Usage
+~~~~~~~~~
+To initialize a Runhouse Table, use the factory method ``rh.table``
+
+.. code:: python
+
+   my_table = rh.table(data=data,
+                     name="~/my_pandas_table",
+                     path="table/my_pandas_table.parquet",
+                     system="file",
+                    mkdir=True)
+
+To load an existing table by name:
+
+.. code:: python
+
+   reloaded_table = rh.table(name="~/my_pandas_table", dryrun=True)
+
+This ``reloaded_table`` holds a reference to the Table's path, and can be used as follows:
+
+.. code:: python
+
+   batches = reloaded_table.stream(batch_size=100)
+      for batch in batches:
+         ....

--- a/docs/secrets/vault_secrets.rst
+++ b/docs/secrets/vault_secrets.rst
@@ -6,9 +6,9 @@ Saving Secrets
 There are a few ways to save secrets to Runhouse to make them available conveniently across environments.
 
 If your secrets are saved into your local environment (e.g. :code:`~/.aws/...`), the fastest way to save them is to run
-runhouse login in your command line (or runhouse.login() in a Python interpreter), which will prompt you for your
-Runhouse token and ask if you'd like to upload secrets. It will then extract secrets from your environment and upload
-them to Vault. Alternatively, you can run:
+:code:`runhouse login` in your command line (or :code:`runhouse.login()`` in a Python interpreter), which will prompt
+you for your Runhouse token and ask if you'd like to upload secrets. It will then extract secrets from your environment
+and upload them to Vault. Alternatively, you can run:
 
 
 .. code-block:: python

--- a/runhouse/rns/folders/folder.py
+++ b/runhouse/rns/folders/folder.py
@@ -704,12 +704,9 @@ class Folder(Resource):
     def open(self, name, mode="rb", encoding=None):
         """Returns an fsspec file, which must be used as a content manager to be opened.
 
-        For example,
-
-        .. code-block:: python
-
-            with my_folder.open('obj_name') as my_file:
-                pickle.load(my_file)
+        Example:
+            >>> with my_folder.open('obj_name') as my_file:
+            >>>        pickle.load(my_file)
         """
         return self.fsspec_fs.open(self.path + "/" + name, mode=mode, encoding=encoding)
 

--- a/runhouse/rns/function.py
+++ b/runhouse/rns/function.py
@@ -614,10 +614,7 @@ def function(
         system (Optional[str or Cluster]): Hardware (cluster) on which to execute the Function.
             This can be either the string name of a Cluster object, or a Cluster object.
         reqs (Optional[List[str]]): List of requirements to install on the remote cluster, or path to the
-            requirements.txt file. If a list of pypi packages is provided, including 'requirements.txt' in
-            the list will install the requirements in `package`. By default, we'll set it to ['requirements.txt'],
-            which installs just the requirements of package. If set to an empty list, no requirements will be installed.
-            # TODO: reword this a bit
+            requirements.txt file.
         dryrun (bool): Whether to create the Function if it doesn't exist, or load the Function object as a dryrun.
             (Default: ``False``)
         load_secrets (bool): Whether or not to send secrets; only applicable if `dryrun` is set to ``False``.

--- a/runhouse/rns/packages/package.py
+++ b/runhouse/rns/packages/package.py
@@ -287,9 +287,6 @@ def package(
 
     Returns:
         Package: The resulting package.
-
-    Example:
-        >>> # TODO
     """
     config = rh_config.rns_client.load_config(name)
     config["name"] = name or config.get("rns_address", None) or config.get("name")


### PR DESCRIPTION
move majority of API usage code snippets out from architecture overview, into corresponding Python API sections, in an effort to consolidate useful code into relevant section.

Currently, API usage is located under API docs, and accessible by scrolling or on the right sidebar.

<img width="954" alt="Screenshot 2023-02-27 at 3 55 14 PM" src="https://user-images.githubusercontent.com/16568633/221683473-f4072056-4b47-4a0a-aeee-252cc896c9c0.png">
