### PR TITLE
add `resources` property for Function object to pass into ray.remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ if __name__ == "__main__":
 
     images = generate_gpu('A digital illustration of a woman running on the roof of a house.', num_images=2, steps=50)
     [image.show() for image in images]
-    
+
     generate_gpu.save(name='sd_generate')
 ```
-By saving, I or anyone I share with can load and call into this service with a single line of code, from anywhere 
+By saving, I or anyone I share with can load and call into this service with a single line of code, from anywhere
 with a Python interpreter and internet connection (notebook, IDE, CI/CD, orchestrator node, etc.):
 ```python
 generate_gpu = rh.function(name='sd_generate')

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -76,10 +76,11 @@ def cancel(
     cluster_name: str,
     run_key: str,
     force: Optional[bool] = typer.Option(False, help="Force cancel"),
+    all: Optional[bool] = typer.Option(False, help="Cancel all jobs"),
 ):
     """Cancel a run on a cluster."""
     c = cluster(name=cluster_name)
-    c.cancel(run_key, force=force)
+    c.cancel(run_key, force=force, all=all)
 
 
 @app.command()

--- a/runhouse/rns/function.py
+++ b/runhouse/rns/function.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import requests
 
@@ -296,7 +296,7 @@ class Function(Resource):
                 "Function.starmap only works with Write or Read access, not Proxy access"
             )
 
-    def enqueue(self, resources: Optional[dict] = None, *args, **kwargs):
+    def enqueue(self, resources: Optional[Dict] = None, *args, **kwargs):
         """Enqueue a Function call to be run later."""
         # Add resources one-off without setting as a Function param
         if self.access in [ResourceAccess.WRITE, ResourceAccess.READ]:

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -221,10 +221,10 @@ class Cluster(Resource):
 
     # TODO [DG] add a method to list all the keys in the cluster
 
-    def cancel(self, key, force=False):
-        """Cancel the given run on cluster."""
+    def cancel(self, key: Optional[str] = None, force=False, all=False):
+        """Cancel the given run on cluster. If``all`` is set to ``True``, will cancel all jobs on the cluster."""
         self.check_grpc()
-        return self.client.cancel_runs(key, force=force)
+        return self.client.cancel_runs(key, force=force, all=all)
 
     def clear_pins(self, pins: Optional[List[str]] = None):
         """Remove the given pinned items from the cluster. If `pins` is set to ``None``, then

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -455,10 +455,12 @@ class Cluster(Resource):
         there is no autostop."""
         pass
 
-    def run_module(self, relative_path, module_name, fn_name, fn_type, args, kwargs):
+    def run_module(
+        self, relative_path, module_name, fn_name, fn_type, resources, args, kwargs
+    ):
         self.check_grpc()
         return self.client.run_module(
-            relative_path, module_name, fn_name, fn_type, args, kwargs
+            relative_path, module_name, fn_name, fn_type, resources, args, kwargs
         )
 
     def is_connected(self):

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -219,10 +219,15 @@ class Cluster(Resource):
         self.check_grpc()
         return self.client.put_object(key, obj)
 
-    # TODO [DG] add a method to list all the keys in the cluster
+    def list_keys(self):
+        """List all keys in the cluster's object store."""
+        self.check_grpc()
+        res = self.client.list_keys()
+        return res
 
     def cancel(self, key: Optional[str] = None, force=False, all=False):
-        """Cancel the given run on cluster. If``all`` is set to ``True``, will cancel all jobs on the cluster."""
+        """Cancel a given run on cluster by its key. If `all` is set to ``True``, then all jobs on the
+        cluster will be cancelled."""
         self.check_grpc()
         return self.client.cancel_runs(key, force=force, all=all)
 

--- a/runhouse/rns/run_module_utils.py
+++ b/runhouse/rns/run_module_utils.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def call_fn_by_type(
-    fn, fn_type, fn_name, resources, module_path=None, args=None, kwargs=None
+    fn, fn_type, fn_name, module_path, resources, args=None, kwargs=None
 ):
     run_key = f"{fn_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 

--- a/runhouse/rns/run_module_utils.py
+++ b/runhouse/rns/run_module_utils.py
@@ -13,7 +13,9 @@ from runhouse import rh_config
 logger = logging.getLogger(__name__)
 
 
-def call_fn_by_type(fn, fn_type, fn_name, module_path=None, args=None, kwargs=None):
+def call_fn_by_type(
+    fn, fn_type, fn_name, resources, module_path=None, args=None, kwargs=None
+):
     run_key = f"{fn_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
     # TODO other possible fn_types: 'batch', 'streaming'
@@ -41,11 +43,9 @@ def call_fn_by_type(fn, fn_type, fn_name, module_path=None, args=None, kwargs=No
         # We need to add the module_path to the PYTHONPATH because ray runs remotes in a new process
         # We need to set max_calls to make sure ray doesn't cache the remote function and ignore changes to the module
         # See: https://docs.ray.io/en/releases-2.2.0/ray-core/package-ref.html#ray-remote
-        # We need non-zero cpus and gpus for Ray to allow access to the compute.
-        # We should see if there's a more elegant way to specify this.
         ray_fn = ray.remote(
-            num_cpus=0.0001,
-            num_gpus=0.0001 if has_gpus else None,
+            num_cpus=resources.get("num_cpus") or 0.0001,
+            num_gpus=resources.get("num_gpus") or 0.0001 if has_gpus else None,
             max_calls=len(args) if fn_type in ["map", "starmap"] else 1,
             runtime_env={"env_vars": {"PYTHONPATH": module_path or ""}},
         )(logging_wrapped_fn)

--- a/runhouse/servers/grpc/unary.proto
+++ b/runhouse/servers/grpc/unary.proto
@@ -10,6 +10,7 @@ service Unary{
   rpc InstallPackages(Message) returns (MessageResponse) {}
   rpc ClearPins(Message) returns (MessageResponse) {}
   rpc CancelRun(Message) returns (MessageResponse) {}
+  rpc ListKeys(Message) returns (MessageResponse) {}
   rpc PutObject(Message) returns (MessageResponse) {}
   rpc AddSecrets(Message) returns (MessageResponse) {}
 

--- a/runhouse/servers/grpc/unary_client.py
+++ b/runhouse/servers/grpc/unary_client.py
@@ -74,6 +74,10 @@ class UnaryClient(object):
         res = self.stub.CancelRun(message)
         return pickle.loads(res.message)
 
+    def list_keys(self):
+        res = self.stub.ListKeys(pb2.Message())
+        return pickle.loads(res.message)
+
     # TODO [DG]: maybe just merge cancel into this so we can get log streaming back as we cancel a job
     def get_object(self, key, stream_logs=False):
         """

--- a/runhouse/servers/grpc/unary_client.py
+++ b/runhouse/servers/grpc/unary_client.py
@@ -123,13 +123,15 @@ class UnaryClient(object):
         message = pb2.Message(message=pickle.dumps(pins or []))
         self.stub.ClearPins(message)
 
-    def run_module(self, relative_path, module_name, fn_name, fn_type, args, kwargs):
+    def run_module(
+        self, relative_path, module_name, fn_name, fn_type, resources, args, kwargs
+    ):
         """
         Client function to call the rpc for RunModule
         """
         # Measure the time it takes to send the message
         serialized_module = pickle.dumps(
-            [relative_path, module_name, fn_name, fn_type, args, kwargs]
+            [relative_path, module_name, fn_name, fn_type, resources, args, kwargs]
         )
         start = time.time()
         message = pb2.Message(message=serialized_module)

--- a/runhouse/servers/grpc/unary_client.py
+++ b/runhouse/servers/grpc/unary_client.py
@@ -69,8 +69,8 @@ class UnaryClient(object):
         server_res = self.stub.AddSecrets(message)
         return pickle.loads(server_res.message)
 
-    def cancel_runs(self, keys, force=False):
-        message = pb2.Message(message=pickle.dumps((keys, force)))
+    def cancel_runs(self, keys, force=False, all=False):
+        message = pb2.Message(message=pickle.dumps((keys, force, all)))
         res = self.stub.CancelRun(message)
         return pickle.loads(res.message)
 

--- a/runhouse/servers/grpc/unary_pb2.py
+++ b/runhouse/servers/grpc/unary_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n\x0bunary.proto\x12\x05unary"B\n\x07Message\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x13\n\x0bmodule_name\x18\x02 \x01(\t\x12\x11\n\tfunc_name\x18\x03 \x01(\t"I\n\x0fMessageResponse\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x10\n\x08received\x18\x02 \x01(\x08\x12\x13\n\x0boutput_type\x18\x03 \x01(\t2\x91\x03\n\x05Unary\x12\x35\n\tRunModule\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12;\n\x0fInstallPackages\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x35\n\tClearPins\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x35\n\tCancelRun\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x35\n\tPutObject\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x36\n\nAddSecrets\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x37\n\tGetObject\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x30\x01\x62\x06proto3',
+    serialized_pb=b'\n\x0bunary.proto\x12\x05unary"B\n\x07Message\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x13\n\x0bmodule_name\x18\x02 \x01(\t\x12\x11\n\tfunc_name\x18\x03 \x01(\t"I\n\x0fMessageResponse\x12\x0f\n\x07message\x18\x01 \x01(\x0c\x12\x10\n\x08received\x18\x02 \x01(\x08\x12\x13\n\x0boutput_type\x18\x03 \x01(\t2\xc7\x03\n\x05Unary\x12\x35\n\tRunModule\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12;\n\x0fInstallPackages\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x35\n\tClearPins\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x35\n\tCancelRun\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x34\n\x08ListKeys\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x35\n\tPutObject\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x36\n\nAddSecrets\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x12\x37\n\tGetObject\x12\x0e.unary.Message\x1a\x16.unary.MessageResponse"\x00\x30\x01\x62\x06proto3',
 )
 
 
@@ -216,7 +216,7 @@ _UNARY = _descriptor.ServiceDescriptor(
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
     serialized_start=166,
-    serialized_end=567,
+    serialized_end=621,
     methods=[
         _descriptor.MethodDescriptor(
             name="RunModule",
@@ -259,9 +259,19 @@ _UNARY = _descriptor.ServiceDescriptor(
             create_key=_descriptor._internal_create_key,
         ),
         _descriptor.MethodDescriptor(
+            name="ListKeys",
+            full_name="unary.Unary.ListKeys",
+            index=4,
+            containing_service=None,
+            input_type=_MESSAGE,
+            output_type=_MESSAGERESPONSE,
+            serialized_options=None,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.MethodDescriptor(
             name="PutObject",
             full_name="unary.Unary.PutObject",
-            index=4,
+            index=5,
             containing_service=None,
             input_type=_MESSAGE,
             output_type=_MESSAGERESPONSE,
@@ -271,7 +281,7 @@ _UNARY = _descriptor.ServiceDescriptor(
         _descriptor.MethodDescriptor(
             name="AddSecrets",
             full_name="unary.Unary.AddSecrets",
-            index=5,
+            index=6,
             containing_service=None,
             input_type=_MESSAGE,
             output_type=_MESSAGERESPONSE,
@@ -281,7 +291,7 @@ _UNARY = _descriptor.ServiceDescriptor(
         _descriptor.MethodDescriptor(
             name="GetObject",
             full_name="unary.Unary.GetObject",
-            index=6,
+            index=7,
             containing_service=None,
             input_type=_MESSAGE,
             output_type=_MESSAGERESPONSE,

--- a/runhouse/servers/grpc/unary_pb2_grpc.py
+++ b/runhouse/servers/grpc/unary_pb2_grpc.py
@@ -34,6 +34,11 @@ class UnaryStub(object):
             request_serializer=unary__pb2.Message.SerializeToString,
             response_deserializer=unary__pb2.MessageResponse.FromString,
         )
+        self.ListKeys = channel.unary_unary(
+            "/unary.Unary/ListKeys",
+            request_serializer=unary__pb2.Message.SerializeToString,
+            response_deserializer=unary__pb2.MessageResponse.FromString,
+        )
         self.PutObject = channel.unary_unary(
             "/unary.Unary/PutObject",
             request_serializer=unary__pb2.Message.SerializeToString,
@@ -81,6 +86,12 @@ class UnaryServicer(object):
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
+    def ListKeys(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
     def PutObject(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -119,6 +130,11 @@ def add_UnaryServicer_to_server(servicer, server):
         ),
         "CancelRun": grpc.unary_unary_rpc_method_handler(
             servicer.CancelRun,
+            request_deserializer=unary__pb2.Message.FromString,
+            response_serializer=unary__pb2.MessageResponse.SerializeToString,
+        ),
+        "ListKeys": grpc.unary_unary_rpc_method_handler(
+            servicer.ListKeys,
             request_deserializer=unary__pb2.Message.FromString,
             response_serializer=unary__pb2.MessageResponse.SerializeToString,
         ),
@@ -252,6 +268,35 @@ class Unary(object):
             request,
             target,
             "/unary.Unary/CancelRun",
+            unary__pb2.Message.SerializeToString,
+            unary__pb2.MessageResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
+
+    @staticmethod
+    def ListKeys(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/unary.Unary/ListKeys",
             unary__pb2.Message.SerializeToString,
             unary__pb2.MessageResponse.FromString,
             options,

--- a/runhouse/servers/grpc/unary_server.py
+++ b/runhouse/servers/grpc/unary_server.py
@@ -157,8 +157,11 @@ class UnaryService(pb2_grpc.UnaryServicer):
 
     def CancelRun(self, request, context):
         self.register_activity()
-        run_keys, force = pickle.loads(request.message)
-        if not hasattr(run_keys, "len"):
+        run_keys, force, all = pickle.loads(request.message)
+        if all:
+            # Cancel all runs
+            run_keys = obj_store.keys()
+        elif not hasattr(run_keys, "len"):
             run_keys = [run_keys]
         obj_refs = obj_store.get_obj_refs_list(run_keys)
         [
@@ -199,8 +202,8 @@ class UnaryService(pb2_grpc.UnaryServicer):
                 fn,
                 fn_type=fn_type,
                 fn_name=fn_name,
-                resources=resources,
                 module_path=module_path,
+                resources=resources,
                 args=args,
                 kwargs=kwargs,
             )

--- a/runhouse/servers/grpc/unary_server.py
+++ b/runhouse/servers/grpc/unary_server.py
@@ -163,12 +163,13 @@ class UnaryService(pb2_grpc.UnaryServicer):
             run_keys = obj_store.keys()
         elif not hasattr(run_keys, "len"):
             run_keys = [run_keys]
-        obj_refs = obj_store.get_obj_refs_list(run_keys)
-        [
-            ray.cancel(obj_ref, force=force, recursive=True)
-            for obj_ref in obj_refs
-            if isinstance(obj_ref, ray.ObjectRef)
-        ]
+
+        for obj_ref in obj_store.get_obj_refs_list(run_keys):
+            obj_store.cancel(obj_ref)
+
+        if all:
+            obj_store.clear()
+
         return pb2.MessageResponse(
             message=pickle.dumps("Cancelled"),
             received=True,

--- a/runhouse/servers/grpc/unary_server.py
+++ b/runhouse/servers/grpc/unary_server.py
@@ -175,6 +175,13 @@ class UnaryService(pb2_grpc.UnaryServicer):
             output_type=OutputType.RESULT,
         )
 
+    def ListKeys(self, request, context):
+        self.register_activity()
+        keys: list = obj_store.keys()
+        return pb2.MessageResponse(
+            message=pickle.dumps(keys), received=True, output_type=OutputType.RESULT
+        )
+
     def RunModule(self, request, context):
         self.register_activity()
         # get the function result from the incoming request

--- a/runhouse/servers/grpc/unary_server.py
+++ b/runhouse/servers/grpc/unary_server.py
@@ -176,9 +176,15 @@ class UnaryService(pb2_grpc.UnaryServicer):
         self.register_activity()
         # get the function result from the incoming request
         try:
-            [relative_path, module_name, fn_name, fn_type, args, kwargs] = pickle.loads(
-                request.message
-            )
+            [
+                relative_path,
+                module_name,
+                fn_name,
+                fn_type,
+                resources,
+                args,
+                kwargs,
+            ] = pickle.loads(request.message)
 
             module_path = (
                 str((Path.home() / relative_path).resolve()) if relative_path else None
@@ -189,7 +195,15 @@ class UnaryService(pb2_grpc.UnaryServicer):
             else:
                 fn = get_fn_by_name(module_name, fn_name, module_path)
 
-            res = call_fn_by_type(fn, fn_type, fn_name, module_path, args, kwargs)
+            res = call_fn_by_type(
+                fn,
+                fn_type=fn_type,
+                fn_name=fn_name,
+                resources=resources,
+                module_path=module_path,
+                args=args,
+                kwargs=kwargs,
+            )
             # [res, None, None] is a silly hack for packaging result alongside exception and traceback
             result = {"message": pickle.dumps([res, None, None]), "received": True}
 


### PR DESCRIPTION
_Current behavior_: By default, Runhouse passes in fractional resources `{"num_cpus": 0.0001, "num_gpus": 0.0001}` when calling `ray.remote()` on a particular Function. This results in the scheduling and queueing not always working properly,  since we are basically telling Ray that each job doesn't need any resources.  

This change gives users control over the resources allocated to a particular Function, by adding a`resource` parameter to the `Function` object. Users can specify `num_cpus` (number of CPU cores to reserve for the task) or `num_gpus` (number of GPUs to reserve). 