### PR TITLE
Reqs to Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ def sd_generate(prompt, num_images=1, steps=100, guidance_scale=7.5, model_id='s
 
 if __name__ == "__main__":
     gpu = rh.cluster(name='rh-v100', instance_type='V100:1', provider='gcp')
-    generate_gpu = rh.function(fn=sd_generate).to(gpu, reqs=['./', 'torch==1.12.0', 'diffusers'])
+    generate_gpu = rh.function(fn=sd_generate).to(gpu, env=['./', 'torch==1.12.0', 'diffusers'])
 
     images = generate_gpu('A digital illustration of a woman running on the roof of a house.', num_images=2, steps=50)
     [image.show() for image in images]

--- a/docs/main.rst
+++ b/docs/main.rst
@@ -17,7 +17,7 @@ This includes both compute abstractions (clusters, functions, packages) and data
 
 Compute Abstractions
 ------------------------------------
-The Function, Cluster, and Package APIs allow a seamless flow of code and execution across local and remote compute.
+The Function, Cluster, Env, and Package APIs allow a seamless flow of code and execution across local and remote compute.
 They blur the line between program execution and deployment, providing both a path of least resistence for running
 a sub-routine on specific hardware, while unceremoniously turning that sub-routine into a reusable service.
 They also provide convenient dependency isolation and management, provider-agnostic provisioning and termination,
@@ -32,6 +32,11 @@ and rich debugging and accessibility interfaces built-in.
    :maxdepth: 1
 
    rh_primitives/cluster
+
+.. toctree::
+   :maxdepth: 1
+
+   rh_primitives/env
 
 .. toctree::
    :maxdepth: 1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,11 @@
 sphinx==4.5.0
 sphinx-rtd-theme==1.1.1
-sphinx-book-theme==1.0.0
+sphinx-book-theme==0.2.0
 sphinx-thebe==0.1.2
 sphinx-click==4.3.0
 sphinx-copybutton==0.5.1
 sphinx_autodoc_typehints==1.17.0
+pydata-sphinx-theme==0.7.2
 myst-parser==0.18.1
 pyarrow==9.0.0
 Pint==0.20.1

--- a/docs/rh_primitives/env.rst
+++ b/docs/rh_primitives/env.rst
@@ -1,0 +1,44 @@
+Env
+====================================
+An Env is a Runhouse primitive that represents an compute environment.
+
+
+Env Factory Method
+~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: runhouse.env
+
+Env Class
+~~~~~~~~~~
+
+.. autoclass:: runhouse.Env
+   :members:
+   :exclude-members:
+
+    .. automethod:: __init__
+
+
+API Usage
+~~~~~~~~~
+
+To initalize an Env, use ``rh.env``:
+
+.. code:: python
+
+    # Python env
+    python_env = rh.env(name="pyenv_from_list", py_env="requirements.txt")
+    # or
+    python_env = rh.env(name="pyenv_from_list", py_env=['torch', 'numpy', 'diffusers'])
+
+
+To setup and use an environment on a cluster, or for running a Function:
+
+.. code:: python
+
+    env = rh.env(...)
+
+    gpu = rh.cluster(name="rh-a10x")
+    env.to(gpu)
+
+    rh_func = rh.function(name="sd_generate")
+    rh_func.to(env)  # equivalent to env.to(rh_func.system), when running the function

--- a/docs/rh_primitives/function.rst
+++ b/docs/rh_primitives/function.rst
@@ -29,9 +29,9 @@ To initialize a function, from a local function:
       ...
 
    # Runhouse Function, to be run on my_cluster Cluster
-   my_function = rh.function(fn=local_function, system=my_cluster, reqs=['requirements.txt'])
+   my_function = rh.function(fn=local_function, system=my_cluster, env=['requirements.txt'])
    # or, equivalently
-   my_function = rh.function(fn=local_function).to(my_cluster, reqs=['requirements.txt'])
+   my_function = rh.function(fn=local_function).to(my_cluster, env=['requirements.txt'])
 
 To use the function, simply call it as you would the local function.
 
@@ -46,14 +46,14 @@ To intialize a function, from an existing Github function:
    my_github_function = rh.function(
                            fn='https://github.com/huggingface/diffusers/blob/v0.11.1/examples/dreambooth/train_dreambooth.py:main',
                            system=my_cluster,
-                           reqs=['requirements.txt'],
+                           env=['requirements.txt'],
                         )
 
 To name the function, to be accessed by name later on, pass in the `name` argument to the factory method.
 
 .. code-block:: python
 
-   my_function = rh.function(fn=local_function, system=my_cluster, reqs=['requirements.txt'], name="my_function_name")
+   my_function = rh.function(fn=local_function, system=my_cluster, env=['requirements.txt'], name="my_function_name")
 
 Advanced API Usage
 ~~~~~~~~~~~~~~~~~~

--- a/docs/rh_primitives/package.rst
+++ b/docs/rh_primitives/package.rst
@@ -42,10 +42,10 @@ Packages are often times installed onto clusters using ``my_cluster.install_pack
 .. code:: python
 
    my_cluster(name,
-              reqs=['local:./',          # local
+              env=['local:./',          # local
                     'requirements.txt',  # reqs
                     'pip:diffusers',     # pip
-                    'conda:pytorh',    # conda
+                    'conda:pytorch',    # conda
               ])
 
 To install a Git package using just the GitHub URL (and optionally, the revision), without needing

--- a/runhouse/__init__.py
+++ b/runhouse/__init__.py
@@ -15,7 +15,7 @@ from runhouse.rns.top_level_rns_fns import (
 from .rh_config import configs, obj_store, rns_client
 from .rns.blob import blob, Blob
 from .rns.defaults import Defaults
-
+from .rns.envs.env import env, Env
 from .rns.folders.folder import folder, Folder
 from .rns.function import function, Function
 from .rns.hardware import cluster, Cluster, OnDemandCluster

--- a/runhouse/rns/envs/__init__.py
+++ b/runhouse/rns/envs/__init__.py
@@ -1,0 +1,1 @@
+from .env import Env

--- a/runhouse/rns/envs/env.py
+++ b/runhouse/rns/envs/env.py
@@ -1,0 +1,101 @@
+from typing import List, Optional, Union
+
+from runhouse.rh_config import rns_client
+from runhouse.rns.hardware import Cluster
+from runhouse.rns.packages import Package
+from runhouse.rns.resource import Resource
+
+
+def process_reqs(reqs):
+    preprocessed_reqs = []
+    for req in reqs:
+        # TODO [DG] the following is wrong. RNS address doesn't have to start with '/'. However if we check if each
+        #  string exists in RNS this will be incredibly slow, so leave it for now.
+        if isinstance(req, str) and req[0] == "/" and rns_client.exists(req):
+            # If req is an rns address
+            req = rns_client.load_config(req)
+        preprocessed_reqs.append(req)
+    return preprocessed_reqs
+
+
+class Env(Resource):
+    RESOURCE_TYPE = "env"
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        reqs: List[Union[str, Package]] = None,
+        setup_cmds: List[str] = None,
+        dryrun: bool = True,
+        **kwargs,  # We have this here to ignore extra arguments when calling from_config
+    ):
+        """
+        Runhouse Env object.
+
+        .. note::
+            To create an Env, please use the factory method :func:`env`.
+        """
+        super().__init__(name=name, dryrun=dryrun)
+        self.reqs = process_reqs(reqs)
+        self.setup_cmds = setup_cmds
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = True):
+        """Create an Env object from a config dict"""
+        return Env(**config, dryrun=dryrun)
+
+    @property
+    def config_for_rns(self):
+        config = super().config_for_rns
+        config.update(
+            {
+                "reqs": [
+                    self._resource_string_for_subconfig(package)
+                    for package in self.reqs
+                ],
+                "setup_cmds": self.setup_cmds,
+            }
+        )
+        return config
+
+    def to(self, system: Union[str, Cluster]):
+        # env doesn't have a concept of system, so this just sets up the environment on the given cluster
+        system.install_packages(self.reqs)
+
+        if self.setup_cmds:
+            system.run(self.setup_cmds)
+
+
+def env(
+    reqs: List[Union[str, Package]] = None,
+    name: Optional[str] = None,
+    setup_cmds: List[str] = None,
+    dryrun: bool = True,
+    load: bool = True,
+):
+    """Factory method for creating a Runhouse Env object.
+
+    Args:
+        reqs (List[str]): List of package names to install in this environment.
+        conda_env (Union[str, Dict], optional): Path to a conda environment file or Dict representing conda env.
+        name (Optional[str], optional): Name of the environment.
+        dryrun (bool, optional): Whether to run in dryrun mode. (Default: ``True``)
+        load (bool, optional): Whether to load the environment. (Default: ``True``)
+
+    Returns:
+        Env: The resulting Env object.
+
+    Example:
+        >>> # regular python env
+        >>> env = rh.env(reqs=["pytorch", "pip"])
+        >>> env = rh.env(reqs=["requirements.txt"], name="myenv")
+    """
+
+    config = rns_client.load_config(name) if load else {}
+    config["name"] = name or config.get("rns_address", None) or config.get("name")
+    config["reqs"] = reqs if reqs is not None else config.get("reqs", [])
+    config["setup_cmds"] = (
+        setup_cmds if setup_cmds is not None else config.get("setup_cmds")
+    )
+
+    return Env.from_config(config, dryrun=dryrun)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,51 @@
+import runhouse as rh
+
+
+pip_reqs = ["torch", "numpy"]
+
+# Note: this is currently failing. need to add resource type to rns_server
+def test_create_env_from_name_local():
+    env_name = "~/local_env"
+    local_env = rh.env(name=env_name, reqs=pip_reqs).save()
+    del local_env
+
+    remote_env = rh.env(name=env_name)
+    assert remote_env.reqs == pip_reqs
+
+
+def test_create_env_from_name_rns():
+    env_name = "rns_env"
+    env = rh.env(name=env_name, reqs=pip_reqs).save()
+    del env
+
+    remote_env = rh.env(name=env_name)
+    assert remote_env.req == pip_reqs
+
+
+def test_create_env():
+    test_env = rh.env(name="test_env", reqs=pip_reqs)
+    assert len(test_env.reqs) == 2
+    assert test_env.reqs == pip_reqs
+
+
+def test_to_system():
+    test_env = rh.env(name="test_env", reqs=["numpy"])
+    system = rh.cluster("^rh-cpu").up_if_not()
+
+    test_env.to(system)
+    res = system.run_python(["import numpy"])
+    assert res[0][0] == 0  # import was successful
+
+
+def test_function_to_env():
+    system = rh.cluster("^rh-cpu").up_if_not()
+    test_env = rh.env(name="test_env", reqs=pip_reqs)
+
+    def summer(a, b):
+        return a + b
+
+    function = rh.function(summer).to(system, test_env)
+    assert set(pip_reqs).issubset(set(function.env.reqs))
+
+    res = system.run_python(["import numpy"])
+    assert res[0][0] == 0

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -30,7 +30,7 @@ def summer(a, b):
 
 def test_create_function_from_name_local():
     local_sum = rh.function(
-        fn=summer, name="local_function", system="^rh-cpu", reqs=["local:./"]
+        fn=summer, name="local_function", system="^rh-cpu", env=["local:./"]
     ).save()
     del local_sum
 
@@ -44,7 +44,7 @@ def test_create_function_from_name_local():
 
 def test_create_function_from_rns():
     remote_sum = rh.function(
-        fn=summer, name="@/remote_function", system="^rh-cpu", reqs=[], dryrun=True
+        fn=summer, name="@/remote_function", system="^rh-cpu", env=[], dryrun=True
     ).save()
     del remote_sum
 
@@ -59,7 +59,7 @@ def test_create_function_from_rns():
 @unittest.skip("Not yet implemented.")
 def test_running_function_as_proxy():
     remote_sum = rh.function(
-        fn=summer, name="@/remote_function", system="^rh-cpu", reqs=[]
+        fn=summer, name="@/remote_function", system="^rh-cpu", env=[]
     ).save()
     del remote_sum
 
@@ -74,17 +74,17 @@ def test_running_function_as_proxy():
 
 def test_get_function_history():
     remote_sum = rh.function(
-        fn=summer, name="@/remote_function", system="^rh-cpu", reqs=[], dryrun=True
+        fn=summer, name="@/remote_function", system="^rh-cpu", env=[], dryrun=True
     ).save()
     remote_sum = rh.function(
         fn=summer,
         name="@/remote_function",
         system="^rh-cpu",
-        reqs=["torch"],
+        env=["torch"],
         dryrun=True,
     ).save()
     remote_sum = rh.function(
-        fn=summer, name="@/remote_function", system="^rh-cpu", reqs=[], dryrun=True
+        fn=summer, name="@/remote_function", system="^rh-cpu", env=[], dryrun=True
     ).save()
     name = "@/remote_function"
     remote_sum = rh.function(name=name)
@@ -108,7 +108,7 @@ def test_remote_function_with_multiprocessing():
         multiproc_torch_sum,
         name="test_function",
         system="^rh-cpu",
-        reqs=["./", "torch==1.12.1"],
+        env=["./", "torch==1.12.1"],
     )
     summands = list(zip(range(5), range(4, 9)))
     res = re_fn(summands)
@@ -151,7 +151,7 @@ def test_function_git_fn():
         fn="https://github.com/huggingface/diffusers/blob/"
         "main/examples/dreambooth/train_dreambooth.py:parse_args",
         system="^rh-cpu",
-        reqs=[
+        env=[
             "torch==1.12.1 --verbose",
             "torchvision==0.13.1",
             "transformers",
@@ -174,12 +174,27 @@ def test_function_git_fn():
     assert args.pretrained_model_name_or_path == "stabilityai/stable-diffusion-2-base"
 
 
+def np_array(list):
+    import numpy as np
+
+    return np.array(list)
+
+
+def test_function_to_env():
+    np_func = rh.function(np_array, system="^rh-cpu")
+    np_func.to(env=["numpy"])
+
+    list = [1, 2, 3]
+    res = np_func(list)
+    assert res.tolist() == list
+
+
 @unittest.skip("Not working properly.")
 def test_function_external_fn():
     """Test functioning a module from reqs, not from working_dir"""
     import torch
 
-    re_fn = rh.function(torch.sum, system="^rh-cpu", reqs=["torch"])
+    re_fn = rh.function(torch.sum, system="^rh-cpu", env=["torch"])
     res = re_fn(torch.arange(5))
     assert int(res) == 10
 
@@ -188,7 +203,7 @@ def test_function_external_fn():
 def test_notebook():
     nb_sum = lambda x: multiproc_torch_sum(x)
     re_fn = rh.function(
-        nb_sum, system="^rh-cpu", reqs=["./", "torch==1.12.1"], dryrun=True
+        nb_sum, system="^rh-cpu", env=["./", "torch==1.12.1"], dryrun=True
     )
     re_fn.notebook()
     summands = list(zip(range(5), range(4, 9)))
@@ -286,7 +301,7 @@ def test_byo_cluster_function():
     del c
     byo_cluster = rh.cluster(name="different-cluster", ips=[ip], ssh_creds=creds).save()
     re_fn = rh.function(
-        multiproc_torch_sum, system=byo_cluster, reqs=["./", "torch==1.12.1"]
+        multiproc_torch_sum, system=byo_cluster, env=["./", "torch==1.12.1"]
     )
     summands = list(zip(range(5), range(4, 9)))
     res = re_fn(summands)
@@ -323,7 +338,7 @@ def test_byo_cluster_maps():
 def test_load_function_in_new_env():
     rh.cluster(name="rh-cpu").save(name="@/rh-cpu")
     remote_sum = rh.function(
-        fn=summer, name="@/remote_function", system="@/rh-cpu", reqs=[], dryrun=True
+        fn=summer, name="@/remote_function", system="@/rh-cpu", env=[], dryrun=True
     ).save()
 
     byo_cluster = rh.cluster(name="different-cluster")
@@ -349,6 +364,23 @@ def test_nested_function():
     kwargs = {"a": 1, "b": 5}
     res = call_function_cpu(summer_cpu, **kwargs)
     assert res == 6
+
+
+# test that deprecated arguments are still backwards compatible for now
+def test_reqs_backwards_compatible():
+    summer_cpu = rh.function(fn=summer, system="^rh-cpu", reqs=[])
+    res = summer_cpu(1, 5)
+    assert res == 6
+
+    torch_summer_cpu = rh.function(fn=summer, system="^rh-cpu", reqs=["torch"])
+    torch_res = torch_summer_cpu(1, 5)
+    assert torch_res == 6
+
+
+def test_setup_cmds_backwards_compatible():
+    torch_summer_cpu = rh.function(fn=summer, system="^rh-cpu", reqs=["torch"])
+    torch_res = torch_summer_cpu(1, 5)
+    assert torch_res == 6
 
 
 if __name__ == "__main__":

--- a/tests/test_obj_store.py
+++ b/tests/test_obj_store.py
@@ -63,7 +63,7 @@ def test_stream_logs():
 def test_multiprocessing_streaming():
     cluster = get_test_cluster()
     re_fn = rh.function(
-        multiproc_torch_sum, system=cluster, reqs=["./", "torch==1.12.1"]
+        multiproc_torch_sum, system=cluster, env=["./", "torch==1.12.1"]
     )
     summands = list(zip(range(5), range(4, 9)))
     res = re_fn(summands, stream_logs=True)


### PR DESCRIPTION
Splitting API design from #20 into iterative PRs.

Initial PR for base Env class
* focus on deprecating `reqs` arg to `env` arg, with minimal functional and underlying changes
* `setup_cmds` in function class also deprecated, to be used in `env` instead
* backwards compatible for now, with warning thrown

TODO for this PR: more testing with new interface + ensure BC

Follow up PRs
* Adding CondaEnv class -- (1) minimal conda env, (2) conda env with additional requirements, (3) conda env from reqs
* Adding DockerEnv class -- design TBD
* Add new system functions (`system.activate/deactivate/remove(env)`)
