### PR TITLE
Enable cross cluster resource sharing

### DIFF
--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -559,8 +559,15 @@ class Cluster(Resource):
         return return_codes
 
     def send_secrets(self, providers: Optional[List[str]] = None):
-        """Send secrets for the given providers. If none provided will send secrets for providers that have been
-        configured in the environment."""
+        """Send secrets for the given providers. If none are provided will send secrets for providers that have been
+        configured in the local environment."""
+        from runhouse import OnDemandCluster
+
+        if "sky" in providers and isinstance(self, OnDemandCluster):
+            # If we are using an on-demand cluster, add the configs for other on-demand clusters
+            # to the current cluster in order to enable cross cluster resource sharing.
+            self._add_all_sky_cluster_configs()
+
         from runhouse import Secrets
 
         Secrets.to(hardware=self, providers=providers)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -29,7 +29,7 @@ def test_cluster_sharing():
 
 
 def test_read_shared_cluster():
-    c = cluster(name="/jlewitt1/rh-cpu")
+    c = cluster(name="@/rh-cpu")
     res = c.run_python(["import numpy", "print(numpy.__version__)"])
     assert res[0][1]
 
@@ -44,6 +44,18 @@ def test_install():
             # 'gh:pytorch/vision'
         ]
     )
+
+
+def test_enable_cross_cluster_resource_sharing():
+    c1 = rh.cluster(name="^rh-cpu").up_if_not()
+
+    c2 = rh.cluster(name="c2", instance_type="^CPU:2+").up_if_not()
+    c2.send_secrets(providers=["sky"])
+
+    return_codes = c2.run(commands=["sky status"])
+    c2.teardown()
+
+    assert c1.name in return_codes[0][1]
 
 
 def test_basic_run():


### PR DESCRIPTION
By default sharing resources between clusters is not enabled. 

If we want to stream data saved on one cluster (c1) from another cluster (c2), the sky keys + sky cluster yaml from c1 must be present on c2 in order to facilitate this sharing. 

By calling `c2.send_secrets(['sky'])` we load up the user's sky keys + cluster yaml configs for other upped sky clusters and save them to path: `~/.sky/generated` on c2. 