### PR TITLE
Prevent RecursionError in import (for Windows, path dependent)

### DIFF
--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -80,13 +80,20 @@ class RNSClient:
             )
 
     @classmethod
-    def find_parent_with_file(cls, dir_path, file):
+    def find_parent_with_file(cls, dir_path, file, searched_dirs=None):
         if Path(dir_path) == Path.home() or dir_path == Path("/"):
             return None
         if Path(dir_path, file).exists():
             return str(dir_path)
         else:
-            return cls.find_parent_with_file(Path(dir_path).parent, file)
+            if searched_dirs is None:
+                searched_dirs = {dir_path,}
+            else:
+                searched_dirs.add(dir_path)
+            parent_path = Path(dir_path).parent
+            if parent_path in searched_dirs:
+                return None
+            return cls.find_parent_with_file(parent_path, file, searched_dirs=searched_dirs)
 
     @classmethod
     def locate_working_dir(cls, cwd=os.getcwd()):


### PR DESCRIPTION
in Windows, if Python path is `C:\\Python`, then it can throw RecursionError on startup. 