### PR TITLE
Proxy tunnel support, including subclassing SSHCommandRunner

### DIFF
--- a/runhouse/rns/folders/folder.py
+++ b/runhouse/rns/folders/folder.py
@@ -206,12 +206,13 @@ class Folder(Resource):
             )
             password = creds.get("password", None)
             config_creds = {
-                "host": self.system.address,
-                "username": creds["ssh_user"],
+                "host": creds.get("ssh_host") or self.system.address,
+                "username": creds.get("ssh_user"),
                 # 'key_filename': str(Path(creds['ssh_private_key']).expanduser())}  # For SFTP
                 "client_keys": client_keys,  # For SSHFS
                 "password": password,
                 "connect_timeout": "3s",
+                "proxy_command": creds.get("ssh_proxy_command"),
             }
             ret_config = self._data_config.copy()
             ret_config.update(config_creds)

--- a/runhouse/rns/folders/folder.py
+++ b/runhouse/rns/folders/folder.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -427,10 +428,10 @@ class Folder(Resource):
         src_str = local
         if not up:
             src_str, dest_str = dest_str, src_str
-        subprocess.check_call(
-            f"rsync {src_str} {dest_str} "
-            f'--password_file {data_config["key_filename"]}'
+        cmd = (
+            f'rsync {src_str} {dest_str} --password_file {data_config["key_filename"]}'
         )
+        subprocess.check_call(shlex.split(cmd))
 
     def mkdir(self):
         """Create the folder in specified file system if it doesn't already exist."""

--- a/runhouse/rns/function.py
+++ b/runhouse/rns/function.py
@@ -563,8 +563,7 @@ def function(
         )
         env = Env(reqs=reqs, setup_cmds=setup_cmds, working_dir="./")
     elif not isinstance(env, Env):
-        env = _get_env_from(env) or Env()
-        env.working_dir = env.working_dir or "./"
+        env = _get_env_from(env) or Env(working_dir="./")
 
     fn_pointers = None
     if callable(fn):

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -688,9 +688,9 @@ class Cluster(Resource):
         if contents:
             source = source + "/" if not source.endswith("/") else source
             dest = dest + "/" if not dest.endswith("/") else dest
-        
+
         ssh_credentials = copy.copy(self.ssh_creds())
-        host = ssh_credentials.pop("ssh_host", self.address)
+        ssh_credentials.pop("ssh_host", self.address)
 
         if not ssh_credentials.get("password"):
             # Use SkyPilot command runner

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import logging
 import os
 import pkgutil
@@ -11,14 +12,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import requests.exceptions
 import sshtunnel
 
-from sky.utils import command_runner
 from sshtunnel import HandlerSSHTunnelForwarderError, SSHTunnelForwarder
 
 from runhouse.rh_config import obj_store, open_cluster_tunnels, rns_client
 from runhouse.rns.packages.package import Package
 from runhouse.rns.resource import Resource
 from runhouse.rns.utils.env import _get_env_from
-from runhouse.rns.utils.hardware import _current_cluster
+from runhouse.rns.utils.hardware import _current_cluster, SkySSHRunner
 
 from runhouse.servers.http import DEFAULT_SERVER_PORT, HTTPClient
 
@@ -153,18 +153,13 @@ class Cluster(Resource):
             local_rh_package_path = local_rh_package_path.parent
             dest_path = f"~/{local_rh_package_path.name}"
 
-            # temp update rsync filters to exclude docs, when syncing over runhouse folder
-            org_rsync_filter = command_runner.RSYNC_FILTER_OPTION
-            command_runner.RSYNC_FILTER_OPTION = (
-                "--filter='dir-merge,- .gitignore,- docs/'"
-            )
             self._rsync(
                 source=str(local_rh_package_path),
                 dest=dest_path,
                 up=True,
                 contents=True,
+                filter_options="dir-merge,- .gitignore,- docs/",
             )
-            command_runner.RSYNC_FILTER_OPTION = org_rsync_filter
 
             rh_install_cmd = "pip install ./runhouse"
         # elif local_rh_package_path.parent.name == 'site-packages':
@@ -420,20 +415,28 @@ class Cluster(Resource):
                         f"Failed to create SSH tunnel after {num_ports_to_try} attempts"
                     )
 
-                ssh_tunnel = SSHTunnelForwarder(
-                    self.address,
-                    ssh_username=creds.get("ssh_user"),
-                    ssh_pkey=creds.get("ssh_private_key"),
-                    ssh_password=creds.get("password"),
-                    local_bind_address=("", local_port),
-                    remote_bind_address=(
-                        "127.0.0.1",
-                        remote_port or local_port,
-                    ),
-                    set_keepalive=1,
-                    # mute_exceptions=True,
-                )
-                ssh_tunnel.start()
+                if creds.get("ssh_proxy_command"):
+                    # Start a tunnel using self.run in a thread, instead of ssh_tunnel
+                    ssh_credentials = copy.copy(self.ssh_creds())
+                    host = ssh_credentials.pop("ssh_host", self.address)
+                    runner = SkySSHRunner(host, **ssh_credentials)
+                    runner.tunnel(local_port, remote_port)
+                    ssh_tunnel = runner  # Just to keep the object in memory
+                else:
+                    ssh_tunnel = SSHTunnelForwarder(
+                        self.address,
+                        ssh_username=creds.get("ssh_user"),
+                        ssh_pkey=creds.get("ssh_private_key"),
+                        ssh_password=creds.get("password"),
+                        local_bind_address=("", local_port),
+                        remote_bind_address=(
+                            "127.0.0.1",
+                            remote_port or local_port,
+                        ),
+                        set_keepalive=1,
+                        # mute_exceptions=True,
+                    )
+                    ssh_tunnel.start()
                 connected = True
             except HandlerSSHTunnelForwarderError:
                 # try connecting with a different port - most likely the issue is the port is already taken
@@ -666,7 +669,14 @@ class Cluster(Resource):
                 files = fs.find(source)
                 fs.get(files, dest, recursive=True, create_dir=True)
 
-    def _rsync(self, source: str, dest: str, up: bool, contents: bool = False):
+    def _rsync(
+        self,
+        source: str,
+        dest: str,
+        up: bool,
+        contents: bool = False,
+        filter_options: str = None,
+    ):
         """
         Sync the contents of the source directory into the destination.
 
@@ -678,18 +688,22 @@ class Cluster(Resource):
         if contents:
             source = source + "/" if not source.endswith("/") else source
             dest = dest + "/" if not dest.endswith("/") else dest
+        
+        ssh_credentials = copy.copy(self.ssh_creds())
+        host = ssh_credentials.pop("ssh_host", self.address)
 
-        ssh_credentials = self.ssh_creds()
         if not ssh_credentials.get("password"):
             # Use SkyPilot command runner
             if not ssh_credentials.get("ssh_private_key"):
                 ssh_credentials["ssh_private_key"] = None
-            runner = command_runner.SSHCommandRunner(self.address, **ssh_credentials)
+            runner = SkySSHRunner(self.address, **ssh_credentials)
             if up:
                 runner.run(["mkdir", "-p", dest], stream_logs=False)
             else:
                 Path(dest).expanduser().parent.mkdir(parents=True, exist_ok=True)
-            runner.rsync(source, dest, up=up, stream_logs=False)
+            runner.rsync(
+                source, dest, up=up, filter_options=filter_options, stream_logs=False
+            )
         else:
             if dest.startswith("~/"):
                 dest = dest[2:]
@@ -727,7 +741,7 @@ class Cluster(Resource):
         commands: List[str],
         env: Union["Env", str] = None,
         stream_logs: bool = True,
-        port_forward: Optional[int] = None,
+        port_forward: Union[None, int, Tuple[int, int]] = None,
         require_outputs: bool = True,
         run_name: Optional[str] = None,
     ) -> list:
@@ -777,10 +791,11 @@ class Cluster(Resource):
     ):
         return_codes = []
 
-        ssh_credentials = self.ssh_creds()
+        ssh_credentials = copy.copy(self.ssh_creds())
+        host = ssh_credentials.pop("ssh_host", self.address)
 
         if not ssh_credentials.get("password"):
-            runner = command_runner.SSHCommandRunner(self.address, **ssh_credentials)
+            runner = SkySSHRunner(host, **ssh_credentials)
             for command in commands:
                 command = f"{cmd_prefix} {command}" if cmd_prefix else command
                 logger.info(f"Running command on {self.name}: {command}")

--- a/runhouse/rns/packages/package.py
+++ b/runhouse/rns/packages/package.py
@@ -299,6 +299,7 @@ class Package(Resource):
             raise TypeError(
                 "`install_target` must be a Folder in order to copy the package to a system."
             )
+    
         system = _get_cluster_from(system)
         if self.install_target.system == system:
             return self

--- a/runhouse/rns/packages/package.py
+++ b/runhouse/rns/packages/package.py
@@ -299,7 +299,7 @@ class Package(Resource):
             raise TypeError(
                 "`install_target` must be a Folder in order to copy the package to a system."
             )
-    
+
         system = _get_cluster_from(system)
         if self.install_target.system == system:
             return self

--- a/runhouse/rns/utils/env.py
+++ b/runhouse/rns/utils/env.py
@@ -42,6 +42,8 @@ def _get_env_from(env):
     from runhouse.rns.envs import Env
 
     if isinstance(env, List):
+        if len(env) == 0:
+            return Env(reqs=env, working_dir=None)
         return Env(reqs=env, working_dir="./")
     elif isinstance(env, Dict):
         return Env.from_config(env)

--- a/runhouse/rns/utils/hardware.py
+++ b/runhouse/rns/utils/hardware.py
@@ -1,7 +1,17 @@
+import logging
+import os
+import subprocess
+import time
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional
+
+import sky.utils.command_runner as cr
 
 import yaml
+
+from sky.utils.command_runner import ssh_options_list, SSHCommandRunner, SshMode
+
+logger = logging.getLogger(__name__)
 
 RESERVED_SYSTEM_NAMES = ["file", "s3", "gs", "azure", "here", "ssh", "sftp"]
 
@@ -43,3 +53,88 @@ def _get_cluster_from(system, dryrun=False):
             pass
 
     return system
+
+
+class SkySSHRunner(SSHCommandRunner):
+    def __init__(
+        self,
+        ip,
+        ssh_user=None,
+        ssh_private_key=None,
+        ssh_control_name=None,
+        ssh_proxy_command=None,
+    ):
+        super().__init__(
+            ip, ssh_user, ssh_private_key, ssh_control_name, ssh_proxy_command
+        )
+        self._tunnel_procs = []
+
+    def _ssh_base_command(
+        self, *, ssh_mode: SshMode, port_forward: Optional[List[int]]
+    ) -> List[str]:
+        ssh = ["ssh"]
+        if ssh_mode == SshMode.NON_INTERACTIVE:
+            # Disable pseudo-terminal allocation. Otherwise, the output of
+            # ssh will be corrupted by the user's input.
+            ssh += ["-T"]
+        else:
+            # Force pseudo-terminal allocation for interactive/login mode.
+            ssh += ["-tt"]
+        if port_forward is not None:
+            for fwd in port_forward:
+                if isinstance(fwd, int):
+                    local, remote = fwd, fwd
+                else:
+                    local, remote = fwd
+                logger.info(f"Forwarding port {local} to port {remote} on localhost.")
+                ssh += ["-L", f"{remote}:localhost:{local}"]
+        return (
+            ssh
+            + ssh_options_list(
+                self.ssh_private_key,
+                self.ssh_control_name,
+                ssh_proxy_command=self._ssh_proxy_command,
+            )
+            + [f"{self.ssh_user}@{self.ip}"]
+        )
+
+    def tunnel(self, local_port, remote_port):
+        base_cmd = self._ssh_base_command(
+            ssh_mode=SshMode.NON_INTERACTIVE, port_forward=[local_port, remote_port]
+        )
+        command = base_cmd + ["tail -f /dev/null"]
+        proc = subprocess.Popen(command)
+
+        time.sleep(3)
+        self._tunnel_procs.append(proc)
+
+    def __del__(self):
+        for proc in self._tunnel_procs:
+            proc.kill()
+
+    def rsync(
+        self,
+        source: str,
+        target: str,
+        *,
+        up: bool,
+        # Advanced options.
+        filter_options: Optional[str] = None,
+        log_path: str = os.devnull,
+        stream_logs: bool = True,
+        max_retry: int = 1,
+    ) -> None:
+        # temp update rsync filters to exclude docs, when syncing over runhouse folder
+        org_rsync_filter = cr.RSYNC_FILTER_OPTION
+        if filter_options:
+            cr.RSYNC_FILTER_OPTION = f"--filter='{filter_options}'"
+        super().rsync(
+            source,
+            target,
+            up=up,
+            log_path=log_path,
+            stream_logs=stream_logs,
+            max_retry=max_retry,
+        )
+        if filter_options:
+            cr.RSYNC_FILTER_OPTION = org_rsync_filter

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -200,7 +200,11 @@ class HTTPClient:
             elif output_type == OutputType.CONFIG:
                 # If this was a `.remote` call, we don't need to recreate the system and connection, which can be
                 # slow, we can just set it explicitly.
-                if system and "system" in result and system.rns_address == result["system"]:
+                if (
+                    system
+                    and "system" in result
+                    and system.rns_address == result["system"]
+                ):
                     result["system"] = system
                 non_generator_result = Resource.from_config(result, dryrun=True)
             elif output_type == OutputType.RESULT:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,7 @@ def byo_cpu():
             instance_type="m5.xlarge",
             provider="aws",
             region="us-east-1",
-            image_id="ami-0a313d6098716f372",
+            # image_id="ami-0a313d6098716f372",  # Upgraded to python 3.11.4 which is not compatible with ray 2.4.0
             name="test-byo-cluster",
         )
         .up_if_not()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -6,8 +6,7 @@ import pytest
 import runhouse as rh
 from runhouse.rns.hardware import OnDemandCluster
 
-from .conftest import cpu_clusters
-from .conftest import summer
+from .conftest import cpu_clusters, summer
 
 
 def is_on_cluster(cluster):
@@ -79,9 +78,8 @@ def test_on_same_cluster(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
-def test_on_diff_cluster(cluster, byo_cpu):
-    func_hw = rh.function(is_on_cluster).to(cluster)
+def test_on_diff_cluster(ondemand_cpu_cluster, byo_cpu):
+    func_hw = rh.function(is_on_cluster).to(ondemand_cpu_cluster)
     assert not func_hw(byo_cpu)
 
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -7,6 +7,7 @@ import runhouse as rh
 from runhouse.rns.hardware import OnDemandCluster
 
 from .conftest import cpu_clusters
+from .conftest import summer
 
 
 def is_on_cluster(cluster):
@@ -82,6 +83,48 @@ def test_on_same_cluster(cluster):
 def test_on_diff_cluster(cluster, byo_cpu):
     func_hw = rh.function(is_on_cluster).to(cluster)
     assert not func_hw(byo_cpu)
+
+
+@pytest.mark.clustertest
+def test_byo_cluster(byo_cpu, local_folder):
+    assert byo_cpu.is_up()
+
+    summer_func = rh.function(summer).to(byo_cpu)
+    assert summer_func(1, 2) == 3
+
+    byo_cpu.put("test_obj", list(range(10)))
+    assert byo_cpu.get("test_obj") == list(range(10))
+
+    local_folder = local_folder.to(byo_cpu)
+    assert "sample_file_0.txt" in local_folder.ls(full_paths=False)
+
+
+@pytest.mark.clustertest
+def test_byo_proxy(byo_cpu, local_folder):
+    rh.rh_config.open_cluster_tunnels.pop(byo_cpu.address)
+    byo_cpu.client = None
+    # byo_cpu._rpc_tunnel.close()
+    byo_cpu._rpc_tunnel = None
+
+    byo_cpu._ssh_creds["ssh_host"] = "127.0.0.1"
+    byo_cpu._ssh_creds.update(
+        {"ssh_proxy_command": "ssh -W %h:%p ubuntu@test-byo-cluster"}
+    )
+    assert byo_cpu.up_if_not()
+
+    status, stdout, _ = byo_cpu.run(["echo hi"])[0]
+    assert status == 0
+    assert stdout == "hi\n"
+
+    summer_func = rh.function(summer, env=rh.env(working_dir="local:./")).to(byo_cpu)
+    assert summer_func(1, 2) == 3
+
+    byo_cpu.put("test_obj", list(range(10)))
+    assert byo_cpu.get("test_obj") == list(range(10))
+
+    # TODO: uncomment out when in-mem lands
+    # local_folder = local_folder.to(byo_cpu)
+    # assert "sample_file_0.txt" in local_folder.ls(full_paths=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add ssh_proxy support, except for folders (due to sshfs issues). cluster.run, cluster.rsync, and forming tunnels all work through SSHCommandRunner.
- Create a subclass of SSHCommandRunner for cleanliness and richer options.
- Tweak working_dir behavior slightly more

Pending - allowing more ssh options, replace cluster.ssh with CommandRunner.