### PR TITLE
Support clusters w/ passwords

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 rich
-fsspec==2023.1.0
+fsspec<=2023.5.0
 pyarrow
 sshtunnel>=0.3.0
 sshfs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 rich
-fsspec
+fsspec==2023.1.0
 pyarrow
 sshtunnel>=0.3.0
 sshfs

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -81,7 +81,7 @@ def ssh(cluster_name: str, up: bool = typer.Option(False, help="Start the cluste
             f"Cluster {cluster_name} is not up. Please run `runhouse ssh {cluster_name} --up`."
         )
         raise typer.Exit(1)
-    subprocess.call(f"ssh {c.name}", shell=True)
+    c.ssh()
 
 
 @app.command()

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 import webbrowser
 from typing import Optional
@@ -132,10 +133,10 @@ def start(
         subprocess.run(["ray", "stop"])
         subprocess.run(["ray", "start", "--head"])
 
-    start_server_cmd = http_server_cmd.split()
-    if screen:
-        start_server_cmd = ["screen", "-dm", "bash", "-c"] + start_server_cmd
-    subprocess.run(start_server_cmd)
+    start_server_cmd = (
+        f'screen -dm bash -c "{http_server_cmd}"' if screen else http_server_cmd
+    )
+    subprocess.run(shlex.split(start_server_cmd))
 
 
 @app.command()

--- a/runhouse/rns/envs/conda_env.py
+++ b/runhouse/rns/envs/conda_env.py
@@ -80,7 +80,7 @@ class CondaEnv(Env):
                 "import yaml",
                 "from pathlib import Path",
                 f"path = Path('{path}').expanduser()",
-                f"yaml.dump({self.conda_yaml}, open(path/'{self.env_name}.yml', 'w'))",
+                f"yaml.dump({self.conda_yaml}, open(path / '{self.env_name}.yml', 'w'))",
             ]
         )
 

--- a/runhouse/rns/envs/conda_env.py
+++ b/runhouse/rns/envs/conda_env.py
@@ -86,8 +86,10 @@ class CondaEnv(Env):
 
         if f"\n{self.env_name} " not in system.run(["conda info --envs"])[0][1]:
             system.run([f"conda env create -f {path}/{self.env_name}.yml"])
-        # TODO [CC]: throw an error if environment is not constructed correctly
         system.run(['eval "$(conda shell.bash hook)"'])
+        if f"\n{self.env_name} " not in system.run(["conda info --envs"])[0][1]:
+            raise RuntimeError(f"conda env {self.env_name} not created properly.")
+
         system._sync_runhouse_to_cluster(env=self)
 
         if self.reqs:

--- a/runhouse/rns/envs/env.py
+++ b/runhouse/rns/envs/env.py
@@ -122,7 +122,6 @@ class Env(Resource):
         new_env.reqs, new_env.working_dir = self._reqs_to(system, path, mount)
 
         if isinstance(system, Cluster):
-            system.check_server()
             new_env._setup_env(system)
 
         return new_env

--- a/runhouse/rns/folders/folder.py
+++ b/runhouse/rns/folders/folder.py
@@ -200,13 +200,19 @@ class Folder(Resource):
                         "Cluster must be started before copying data from it."
                     )
             creds = self.system.ssh_creds()
+
+            client_keys = (
+                [str(Path(creds["ssh_private_key"]).expanduser())]
+                if creds.get("ssh_private_key")
+                else []
+            )
+            password = creds.get("password", None)
             config_creds = {
                 "host": self.system.address,
                 "username": creds["ssh_user"],
                 # 'key_filename': str(Path(creds['ssh_private_key']).expanduser())}  # For SFTP
-                "client_keys": [
-                    str(Path(creds["ssh_private_key"]).expanduser())
-                ],  # For SSHFS
+                "client_keys": client_keys,  # For SSHFS
+                "password": password,
                 "connect_timeout": "3s",
             }
             ret_config = self._data_config.copy()
@@ -498,6 +504,7 @@ class Folder(Resource):
         return dest_folder
 
     def _cluster_to_cluster(self, dest_cluster, dest_path):
+        # TODO [CC] this part also needs to support password, using fsspec
         src_path = self.path
 
         cluster_creds = self.system.ssh_creds()

--- a/runhouse/rns/folders/folder.py
+++ b/runhouse/rns/folders/folder.py
@@ -508,7 +508,9 @@ class Folder(Resource):
 
         cluster_creds = self.system.ssh_creds()
 
-        if not cluster_creds.get("password"):
+        if not cluster_creds.get("password") and not dest_cluster.ssh_creds().get(
+            "password"
+        ):
             creds_file = cluster_creds.get("ssh_private_key")
             creds_cmd = f"-i '{creds_file}' " if creds_file else ""
 
@@ -528,7 +530,7 @@ class Folder(Resource):
                     f"For example: `rh.Secrets.to({self.system.name}, providers=['aws'])`"
                 )
         else:
-            # TODO [CC]: look into fsspec copy
+            # TODO: fsspec copy function might be able to do this as well
             local_folder = self._cluster_to_local(self.system, self.path)
             local_folder._to_cluster(dest_cluster, dest_path)
 

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -49,7 +49,6 @@ class Cluster(Resource):
 
         super().__init__(name=name, dryrun=dryrun)
 
-        # TODO [CC]: replace "ips" with "host"/"hostname"
         self.address = ips[0] if ips else None
         self._ssh_creds = ssh_creds
         self.ips = ips
@@ -831,7 +830,12 @@ class Cluster(Resource):
         """Run a list of python commands on the cluster.
 
         Example:
-            >>> cpu.run_python(['import numpy', 'print(numpy.__version__)'])([""])
+            >>> cpu.run_python(['import numpy', 'print(numpy.__version__)'])
+            >>> cpu.run_python(["print('hello')"])
+
+        Note:
+            Running Python commands with nested quotes can be finicky. If using nested quotes,
+            try to wrap the outer quote with double quotes (") and the inner quotes with a single quote (').
         """
         cmd_prefix = "python3 -c"
         if env:

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -636,11 +636,9 @@ class Cluster(Resource):
                 files = files.split()
                 fs.get(files, dest, recursive=True, create_dir=True)
             else:
-                # the following errors {source} is a directory so currently working around by extracting files
+                # the following errors if {source} is a directory so currently working around by extracting files
                 # fs.get(source, dest, recursive=True, create_dir=True)
-
                 files = fs.find(source)
-                files = [file for file in files]
                 fs.get(files, dest, recursive=True, create_dir=True)
 
     def _rsync(self, source: str, dest: str, up: bool, contents: bool = False):

--- a/runhouse/rns/hardware/cluster_factory.py
+++ b/runhouse/rns/hardware/cluster_factory.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List, Optional, Union
 
 from ..utils.hardware import RESERVED_SYSTEM_NAMES
@@ -9,7 +10,7 @@ from .on_demand_cluster import OnDemandCluster
 # Cluster factory method
 def cluster(
     name: str,
-    ips: List[str] = None,
+    host: List[str] = None,
     ssh_creds: Optional[dict] = None,
     dryrun: bool = False,
     **kwargs,
@@ -19,7 +20,7 @@ def cluster(
 
     Args:
         name (str): Name for the cluster, to re-use later on.
-        ips (List[str], optional): List of IP addresses for the BYO cluster.
+        host (List[str], optional): List of IP addresses for the BYO cluster.
         ssh_creds (dict, optional): Dictionary mapping SSH credentials.
             Example: ``ssh_creds={'ssh_user': '...', 'ssh_private_key':'<path_to_key>'}``
         dryrun (bool): Whether to create the Cluster if it doesn't exist, or load a Cluster object as a dryrun.
@@ -30,14 +31,20 @@ def cluster(
 
     Example:
         >>> import runhouse as rh
-        >>> gpu = rh.cluster(ips=['<ip of the cluster>'],
+        >>> gpu = rh.cluster(host=['<ip of the cluster>'],
         >>>                  ssh_creds={'ssh_user': '...', 'ssh_private_key':'<path_to_key>'},
         >>>                  name='rh-a10x').save()
 
         >>> # Load cluster from above
         >>> reloaded_cluster = rh.cluster(name="rh-a10x")
     """
-    if name and ips is None and ssh_creds is None and not kwargs:
+    if "ips" in kwargs:
+        host = kwargs["ips"]
+        warnings.warn(
+            "``ips`` argument has been deprecated. Please use ``host`` to refer to the cluster IPs or host instead."
+        )
+
+    if name and host is None and ssh_creds is None and not kwargs:
         # If only the name is provided and dryrun is set to True
         return Cluster.from_name(name, dryrun)
 
@@ -56,7 +63,7 @@ def cluster(
         # )
         return ondemand_cluster(name=name, **kwargs)
 
-    return Cluster(ips=ips, ssh_creds=ssh_creds, name=name, dryrun=dryrun)
+    return Cluster(ips=host, ssh_creds=ssh_creds, name=name, dryrun=dryrun)
 
 
 # OnDemandCluster factory method

--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -353,7 +353,13 @@ class RNSClient:
 
     def _save_config_in_rns(self, config, resource_name):
         """Update or create resource config in database"""
-        logger.info(f"Saving config to RNS: {config}")
+        # if config.get("ssh_creds"):
+        #     temp_config = config.copy()
+        #     for cred in temp_config["ssh_creds"]:
+        #         temp_config["ssh_creds"][cred] = "***"
+        #     logger.info(f"Saving config to RNS: {temp_config}")
+        if not config.get("ssh_creds"):
+            logger.info(f"Saving config to RNS: {config}")
 
         resource_uri = self.resource_uri(resource_name)
         uri = f"resource/{resource_uri}"

--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -353,13 +353,11 @@ class RNSClient:
 
     def _save_config_in_rns(self, config, resource_name):
         """Update or create resource config in database"""
-        # if config.get("ssh_creds"):
-        #     temp_config = config.copy()
-        #     for cred in temp_config["ssh_creds"]:
-        #         temp_config["ssh_creds"][cred] = "***"
-        #     logger.info(f"Saving config to RNS: {temp_config}")
+        # TODO [CC]: can maybe asterik out sensitive info instead of this approach
         if not config.get("ssh_creds"):
             logger.info(f"Saving config to RNS: {config}")
+        else:
+            logger.info(f"Saving config for {resource_name} to RNS")
 
         resource_uri = self.resource_uri(resource_name)
         uri = f"resource/{resource_uri}"

--- a/runhouse/rns/run.py
+++ b/runhouse/rns/run.py
@@ -425,7 +425,7 @@ class Run(Resource):
             system=folder_system,
         )
 
-        existing_folder.rm()
+        existing_folder.rm(recursive=True)
 
     @staticmethod
     def _create_new_run_name(name: str = None) -> str:

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -18,9 +18,10 @@ class HTTPClient:
     MAX_MESSAGE_LENGTH = 1 * 1024 * 1024 * 1024  # 1 GB
     CHECK_TIMEOUT_SEC = 5
 
-    def __init__(self, host, port=DEFAULT_PORT):
+    def __init__(self, host, port=DEFAULT_PORT, auth=None):
         self.host = host
         self.port = port
+        self.auth = auth
 
     def request(self, endpoint, req_type="post", data=None, err_str=None, timeout=None):
         req_fn = (
@@ -36,6 +37,7 @@ class HTTPClient:
             f"http://{self.host}:{self.port}/{endpoint}/",
             json={"data": data},
             timeout=timeout,
+            auth=self.auth,
         )
         if response.status_code != 200:
             raise ValueError(

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -16,7 +16,7 @@ class HTTPClient:
 
     DEFAULT_PORT = 50052
     MAX_MESSAGE_LENGTH = 1 * 1024 * 1024 * 1024  # 1 GB
-    CHECK_TIMEOUT_SEC = 5
+    CHECK_TIMEOUT_SEC = 10
 
     def __init__(self, host, port=DEFAULT_PORT, auth=None):
         self.host = host

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ extras_require = {
         "boto3==1.24.59",
         "pycryptodome==3.12.0",
         "s3fs==2023.1.0",
+        "fsspec==2023.1.0",
     ],
     "azure": ["azure-cli==2.31.0", "azure-core"],
     "gcp": ["google-api-python-client", "google-cloud-storage", "gcsfs"],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def parse_readme(readme: str) -> str:
 install_requires = [
     "wheel",
     "rich",
-    "fsspec",
+    "fsspec<=2023.5.0",
     "pyarrow",
     "sshtunnel>=0.3.0",
     "sshfs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,8 @@ def local_folder(tmp_path):
 
 
 @pytest.fixture
-def cluster_folder(cpu_cluster, local_folder):
-    return local_folder.to(system=cpu_cluster)
+def cluster_folder(ondemand_cpu_cluster, local_folder):
+    return local_folder.to(system=ondemand_cpu_cluster)
 
 
 @pytest.fixture
@@ -119,8 +119,8 @@ def cluster(request):
 
 
 @pytest.fixture(scope="session")
-def cpu_cluster():
-    c = rh.cluster("^rh-cpu")
+def ondemand_cpu_cluster():
+    c = rh.cluster("test-cluster")
     c.up_if_not()
     c.install_packages(["pytest"])
     # Save to RNS - to be loaded in other tests (ex: Runs)
@@ -148,7 +148,7 @@ def byo_cpu():
     ).save()
 
     c.install_packages(["pytest"])
-    c.send_secrets(["ssh"])
+    c.sync_secrets(["ssh"])
 
     return c
 
@@ -206,8 +206,8 @@ def password_cluster():
     return cluster
 
 
-parametrize_cpu_clusters = pytest.mark.parametrize(
-    "cluster", ["cpu_cluster", "password_cluster"], indirect=True
+cpu_clusters = pytest.mark.parametrize(
+    "cluster", ["ondemand_cpu_cluster", "password_cluster"], indirect=True
 )
 
 
@@ -253,21 +253,23 @@ def slow_running_func(a, b):
 
 
 @pytest.fixture(scope="session")
-def summer_func(cpu_cluster):
-    return rh.function(summer, name="summer_func").to(cpu_cluster, env=["pytest"])
-
-
-@pytest.fixture(scope="session")
-def func_with_artifacts(cpu_cluster):
-    return rh.function(save_and_load_artifacts, name="artifacts_func").to(
-        cpu_cluster, env=["pytest"]
+def summer_func(ondemand_cpu_cluster):
+    return rh.function(summer, name="summer_func").to(
+        ondemand_cpu_cluster, env=["pytest"]
     )
 
 
 @pytest.fixture(scope="session")
-def slow_func(cpu_cluster):
+def func_with_artifacts(ondemand_cpu_cluster):
+    return rh.function(save_and_load_artifacts, name="artifacts_func").to(
+        ondemand_cpu_cluster, env=["pytest"]
+    )
+
+
+@pytest.fixture(scope="session")
+def slow_func(ondemand_cpu_cluster):
     return rh.function(slow_running_func, name="slow_func").to(
-        cpu_cluster, env=["pytest"]
+        ondemand_cpu_cluster, env=["pytest"]
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,61 @@ def a10g_gpu_cluster():
     ).up_if_not()
 
 
+# @pytest.fixture(scope="session")
+# def byo_cpu_no_pkey():
+#     sky_cluster = rh.cluster("temp-cluster", instance_type="CPU:4").up_if_not().save()
+
+#     sky_cluster.install_packages(["pytest"])
+#     sky_cluster.send_secrets(["ssh"])
+#     sky_cluster.run(["pip uninstall skypilot -y", "pip uninstall runhouse -y"])
+
+#     sky_cluster = rh.cluster(
+#         name="no-pkey-cluster",
+#         ips=[sky_cluster.name],
+#         ssh_creds={"ssh_user": sky_cluster.ssh_creds().get("ssh_user")},
+#     ).save()
+
+#     return c
+
+
+@pytest.fixture(scope="session")
+def password_cluster():
+    sky_cluster = (
+        rh.cluster("temp-rh-password", instance_type="CPU:4").up_if_not().save()
+    )
+
+    # set up password on remote
+    sky_cluster.run(
+        [
+            [
+                'sudo sed -i "/^[^#]*PasswordAuthentication[[:space:]]no/c\PasswordAuthentication yes" '
+                "/etc/ssh/sshd_config"
+            ]
+        ]
+    )
+    sky_cluster.run(["sudo /etc/init.d/ssh force-reload"])
+    sky_cluster.run(["sudo /etc/init.d/ssh restart"])
+    sky_cluster.run(
+        ["(echo 'cluster-pass' && echo 'cluster-pass') | sudo passwd ubuntu"]
+    )
+
+    # instantiate byo cluster with password
+    ssh_creds = {"ssh_user": "ubuntu", "password": "cluster-pass"}
+    cluster = rh.cluster(
+        name="rh-password", ips=[sky_cluster.address], ssh_creds=ssh_creds
+    ).save()
+
+    cluster.send_secrets(["ssh"])
+    cluster.run(["pip uninstall skypilot runhouse -y", "pip install pytest"])
+
+    return cluster
+
+
+parametrize_cpu_clusters = pytest.mark.parametrize(
+    "cluster", ["cpu_cluster", "password_cluster"], indirect=True
+)
+
+
 # ----------------- Envs -----------------
 
 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -163,7 +163,7 @@ def test_to_cluster_attr(cluster, tmp_path):
 @pytest.mark.clustertest
 @pytest.mark.rnstest
 @parametrize_cpu_clusters
-def l(cluster, blob_data):
+def test_local_to_cluster(cluster, blob_data):
     name = "~/my_local_blob"
     my_blob = (
         rh.blob(
@@ -197,9 +197,9 @@ def test_save_blob_to_cluster(cluster, tmp_path):
 @pytest.mark.clustertest
 @parametrize_cpu_clusters
 def test_from_cluster(cluster):
-    config_blob = rh.blob(path="/home/ubuntu/.rh/config.yaml", system=cluster)
+    config_blob = rh.blob(path="~/.rh/config.yaml", system=cluster)
     config_data = yaml.safe_load(config_blob.data)
-    assert len(config_data.keys()) > 4
+    assert len(config_data.keys()) >= 1
 
 
 @pytest.mark.awstest

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -11,6 +11,8 @@ from ray import cloudpickle as pickle
 
 from runhouse.rh_config import configs
 
+from .conftest import parametrize_cpu_clusters
+
 TEMP_LOCAL_FOLDER = Path(__file__).parents[1] / "rh-blobs"
 
 
@@ -148,18 +150,20 @@ def test_create_and_reload_rns_blob_with_path(blob_data, blob_s3_bucket):
 
 
 @pytest.mark.clustertest
-def test_to_cluster_attr(cpu_cluster, tmp_path):
+@parametrize_cpu_clusters
+def test_to_cluster_attr(cluster, tmp_path):
     local_blob = rh.blob(
         pickle.dumps(list(range(50))), path=str(tmp_path / "pipeline.pkl")
     )
-    cluster_blob = local_blob.to(system=cpu_cluster)
+    cluster_blob = local_blob.to(system=cluster)
     assert isinstance(cluster_blob.system, rh.Cluster)
     assert cluster_blob._folder._fs_str == "ssh"
 
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_local_to_cluster(cpu_cluster, blob_data):
+@parametrize_cpu_clusters
+def l(cluster, blob_data):
     name = "~/my_local_blob"
     my_blob = (
         rh.blob(
@@ -171,27 +175,29 @@ def test_local_to_cluster(cpu_cluster, blob_data):
         .save()
     )
 
-    my_blob = my_blob.to(system=cpu_cluster)
+    my_blob = my_blob.to(system=cluster)
     blob_data = pickle.loads(my_blob.data)
     assert blob_data == list(range(50))
 
 
 @pytest.mark.clustertest
-def test_save_blob_to_cluster(cpu_cluster, tmp_path):
+@parametrize_cpu_clusters
+def test_save_blob_to_cluster(cluster, tmp_path):
     # Save blob to local directory, then upload to a new "models" directory on the root path of the cluster
     model = rh.blob(
         pickle.dumps(list(range(50))), path=str(tmp_path / "pipeline.pkl")
     ).write()
-    model.to(cpu_cluster, path="models")
+    model.to(cluster, path="models")
 
     # Confirm the model is saved on the cluster in the `models` folder
-    status_codes = cpu_cluster.run(commands=["ls models"])
+    status_codes = cluster.run(commands=["ls models"])
     assert "pipeline.pkl" in status_codes[0][1]
 
 
 @pytest.mark.clustertest
-def test_from_cluster(cpu_cluster):
-    config_blob = rh.blob(path="/home/ubuntu/.rh/config.yaml", system=cpu_cluster)
+@parametrize_cpu_clusters
+def test_from_cluster(cluster):
+    config_blob = rh.blob(path="/home/ubuntu/.rh/config.yaml", system=cluster)
     config_data = yaml.safe_load(config_blob.data)
     assert len(config_data.keys()) > 4
 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -11,7 +11,7 @@ from ray import cloudpickle as pickle
 
 from runhouse.rh_config import configs
 
-from .conftest import parametrize_cpu_clusters
+from .conftest import cpu_clusters
 
 TEMP_LOCAL_FOLDER = Path(__file__).parents[1] / "rh-blobs"
 
@@ -150,7 +150,7 @@ def test_create_and_reload_rns_blob_with_path(blob_data, blob_s3_bucket):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_to_cluster_attr(cluster, tmp_path):
     local_blob = rh.blob(
         pickle.dumps(list(range(50))), path=str(tmp_path / "pipeline.pkl")
@@ -162,7 +162,7 @@ def test_to_cluster_attr(cluster, tmp_path):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_local_to_cluster(cluster, blob_data):
     name = "~/my_local_blob"
     my_blob = (
@@ -181,7 +181,7 @@ def test_local_to_cluster(cluster, blob_data):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_save_blob_to_cluster(cluster, tmp_path):
     # Save blob to local directory, then upload to a new "models" directory on the root path of the cluster
     model = rh.blob(
@@ -195,7 +195,7 @@ def test_save_blob_to_cluster(cluster, tmp_path):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_from_cluster(cluster):
     config_blob = rh.blob(path="~/.rh/config.yaml", system=cluster)
     config_data = yaml.safe_load(config_blob.data)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -4,8 +4,9 @@ import unittest
 import pytest
 
 import runhouse as rh
-
 from runhouse.rns.hardware import OnDemandCluster
+
+from .conftest import parametrize_cpu_clusters
 
 
 def is_on_cluster(cluster):
@@ -37,8 +38,9 @@ def test_read_shared_cluster(cpu_cluster):
 
 
 @pytest.mark.clustertest
-def test_install(cpu_cluster):
-    cpu_cluster.install_packages(
+@parametrize_cpu_clusters
+def test_install(cluster):
+    cluster.install_packages(
         [
             "./",
             "torch==1.12.1",
@@ -49,34 +51,36 @@ def test_install(cpu_cluster):
 
 
 @pytest.mark.clustertest
-def test_basic_run(cpu_cluster):
+@parametrize_cpu_clusters
+def test_basic_run(cluster):
     # Create temp file where fn's will be stored
     test_cmd = "echo hi"
-    cpu_cluster.up_if_not()
-    res = cpu_cluster.run(commands=[test_cmd])
+    res = cluster.run(commands=[test_cmd])
     assert "hi" in res[0][1]
 
 
 @pytest.mark.clustertest
-def test_restart_server(cpu_cluster):
-    cpu_cluster.up_if_not()
-    codes = cpu_cluster.restart_server(resync_rh=False)
+@parametrize_cpu_clusters
+def test_restart_server(cluster):
+    cluster.up_if_not()
+    codes = cluster.restart_server(resync_rh=False)
     assert codes
 
 
 @pytest.mark.clustertest
-def test_on_same_cluster(cpu_cluster):
-    hw_copy = copy.copy(cpu_cluster)
-    cpu_cluster.up_if_not()
+@parametrize_cpu_clusters
+def test_on_same_cluster(cluster):
+    hw_copy = copy.copy(cluster)
 
-    func_hw = rh.function(is_on_cluster).to(cpu_cluster)
-    assert func_hw(cpu_cluster)
+    func_hw = rh.function(is_on_cluster).to(cluster)
+    assert func_hw(cluster)
     assert func_hw(hw_copy)
 
 
 @pytest.mark.clustertest
-def test_on_diff_cluster(cpu_cluster, byo_cpu):
-    func_hw = rh.function(is_on_cluster).to(cpu_cluster)
+@parametrize_cpu_clusters
+def test_on_diff_cluster(cluster, byo_cpu):
+    func_hw = rh.function(is_on_cluster).to(cluster)
     assert not func_hw(byo_cpu)
 
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -6,7 +6,7 @@ import pytest
 import runhouse as rh
 from runhouse.rns.hardware import OnDemandCluster
 
-from .conftest import parametrize_cpu_clusters
+from .conftest import cpu_clusters
 
 
 def is_on_cluster(cluster):
@@ -14,16 +14,16 @@ def is_on_cluster(cluster):
 
 
 @pytest.mark.clustertest
-def test_cluster_config(cpu_cluster):
-    config = cpu_cluster.config_for_rns
+def test_cluster_config(ondemand_cpu_cluster):
+    config = ondemand_cpu_cluster.config_for_rns
     cluster2 = OnDemandCluster.from_config(config)
-    assert cluster2.address == cpu_cluster.address
+    assert cluster2.address == ondemand_cpu_cluster.address
 
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_cluster_sharing(cpu_cluster):
-    cpu_cluster.share(
+def test_cluster_sharing(ondemand_cpu_cluster):
+    ondemand_cpu_cluster.share(
         users=["donny@run.house", "josh@run.house"],
         access_type="write",
         notify_users=False,
@@ -32,13 +32,13 @@ def test_cluster_sharing(cpu_cluster):
 
 
 @pytest.mark.clustertest
-def test_read_shared_cluster(cpu_cluster):
-    res = cpu_cluster.run_python(["import numpy", "print(numpy.__version__)"])
+def test_read_shared_cluster(ondemand_cpu_cluster):
+    res = ondemand_cpu_cluster.run_python(["import numpy", "print(numpy.__version__)"])
     assert res[0][1]
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_install(cluster):
     cluster.install_packages(
         [
@@ -51,7 +51,7 @@ def test_install(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_basic_run(cluster):
     # Create temp file where fn's will be stored
     test_cmd = "echo hi"
@@ -60,7 +60,7 @@ def test_basic_run(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_restart_server(cluster):
     cluster.up_if_not()
     codes = cluster.restart_server(resync_rh=False)
@@ -68,7 +68,7 @@ def test_restart_server(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_on_same_cluster(cluster):
     hw_copy = copy.copy(cluster)
 
@@ -78,7 +78,7 @@ def test_on_same_cluster(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_on_diff_cluster(cluster, byo_cpu):
     func_hw = rh.function(is_on_cluster).to(cluster)
     assert not func_hw(byo_cpu)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -255,7 +255,7 @@ def test_conda_env_dict_to_system(cluster):
     assert "3.9.16" in _get_conda_python_version(test_env, cluster)
 
     # ray installed successfully
-    res = cluster.run([f"{test_env._run_cmd} python -c 'import ray'"])
+    res = cluster.run([f'{test_env._run_cmd} python -c "import ray"'])
     assert res[0][0] == 0
 
 
@@ -278,7 +278,7 @@ def test_conda_additional_reqs(cluster):
     new_conda_env = _get_conda_env(name="test-add-reqs")
     new_conda_env = rh.env(name="conda_env", reqs=["scipy"], conda_env=new_conda_env)
     new_conda_env.to(cluster)
-    res = cluster.run([f"{new_conda_env._run_cmd} python -c 'import scipy'"])
+    res = cluster.run([f'{new_conda_env._run_cmd} python -c "import scipy"'])
     assert res[0][0] == 0  # reqs successfully installed
     cluster.run([f"{new_conda_env._run_cmd} pip uninstall scipy"])
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -11,6 +11,8 @@ import yaml
 from runhouse.rns.folders.folder import Folder
 from runhouse.rns.packages import Package
 
+from .conftest import parametrize_cpu_clusters
+
 pip_reqs = ["torch", "numpy"]
 
 # -------- BASE ENV TESTS ----------- #
@@ -44,20 +46,22 @@ def test_create_env():
 
 
 @pytest.mark.clustertest
-def test_to_cluster(cpu_cluster):
+@parametrize_cpu_clusters
+def test_to_cluster(cluster):
     test_env = rh.env(name="test_env", reqs=["transformers"])
 
-    test_env.to(cpu_cluster)
-    res = cpu_cluster.run_python(["import transformers"])
+    test_env.to(cluster)
+    res = cluster.run_python(["import transformers"])
     assert res[0][0] == 0  # import was successful
 
-    cpu_cluster.run(["pip uninstall transformers -y"])
+    cluster.run(["pip uninstall transformers -y"])
 
 
 @pytest.mark.awstest
 @pytest.mark.clustertest
-def test_to_fs_to_cluster(cpu_cluster, s3_package):
-    cpu_cluster.install_packages(["s3fs"])
+@parametrize_cpu_clusters
+def test_to_fs_to_cluster(cluster, s3_package):
+    cluster.install_packages(["s3fs"])
 
     test_env_s3 = rh.env(name="test_env_s3", reqs=["s3fs", "scipy", s3_package]).to(
         "s3"
@@ -68,35 +72,36 @@ def test_to_fs_to_cluster(cpu_cluster, s3_package):
             assert req.install_target.exists_in_system()
 
     folder_name = "test_package"
-    test_env_cluster = test_env_s3.to(system=cpu_cluster, path=folder_name, mount=True)
+    test_env_cluster = test_env_s3.to(system=cluster, path=folder_name, mount=True)
     for req in test_env_cluster.reqs:
         if isinstance(req, Package) and isinstance(req.install_target, Folder):
-            assert req.install_target.system == cpu_cluster
+            assert req.install_target.system == cluster
 
-    assert "sample_file_0.txt" in cpu_cluster.run([f"ls {folder_name}"])[0][1]
-    cpu_cluster.run([f"rm -r {folder_name}"])
+    assert "sample_file_0.txt" in cluster.run([f"ls {folder_name}"])[0][1]
+    cluster.run([f"rm -r {folder_name}"])
 
 
 @pytest.mark.clustertest
-def test_function_to_env(cpu_cluster):
+@parametrize_cpu_clusters
+def test_function_to_env(cluster):
     test_env = rh.env(name="test-env", reqs=["parameterized"]).save()
 
     def summer(a, b):
         return a + b
 
-    rh.function(summer).to(cpu_cluster, test_env)
-    res = cpu_cluster.run_python(["import parameterized"])
+    rh.function(summer).to(cluster, test_env)
+    res = cluster.run_python(["import parameterized"])
     assert res[0][0] == 0
 
-    cpu_cluster.run(["pip uninstall parameterized -y"])
-    res = cpu_cluster.run_python(["import parameterized"])
+    cluster.run(["pip uninstall parameterized -y"])
+    res = cluster.run_python(["import parameterized"])
     assert res[0][0] == 1
 
-    rh.function(summer, system=cpu_cluster, env="test-env")
-    res = cpu_cluster.run_python(["import parameterized"])
+    rh.function(summer, system=cluster, env="test-env")
+    res = cluster.run_python(["import parameterized"])
     assert res[0][0] == 0
 
-    cpu_cluster.run(["pip uninstall parameterized -y"])
+    cluster.run(["pip uninstall parameterized -y"])
 
 
 def _get_env_var_value(env_var):
@@ -106,19 +111,21 @@ def _get_env_var_value(env_var):
 
 
 @pytest.mark.clustertest
-def test_function_env_vars(cpu_cluster):
+@parametrize_cpu_clusters
+def test_function_env_vars(cluster):
     test_env_var = "TEST_ENV_VAR"
     test_value = "value"
     test_env = rh.env(name="test-env", env_vars={test_env_var: test_value})
 
-    get_env_var_cpu = rh.function(_get_env_var_value).to(cpu_cluster, test_env)
+    get_env_var_cpu = rh.function(_get_env_var_value).to(cluster, test_env)
     res = get_env_var_cpu(test_env_var)
 
     assert res == test_value
 
 
 @pytest.mark.clustertest
-def test_function_env_vars_file(cpu_cluster):
+@parametrize_cpu_clusters
+def test_function_env_vars_file(cluster):
     env_file = ".env"
     contents = ["# comment", "", "ENV_VAR1=value", "# comment with =", "ENV_VAR2 =val2"]
     with open(env_file, "w") as f:
@@ -127,7 +134,7 @@ def test_function_env_vars_file(cpu_cluster):
 
     test_env = rh.env(name="test-env", env_vars=env_file)
 
-    get_env_var_cpu = rh.function(_get_env_var_value).to(cpu_cluster, test_env)
+    get_env_var_cpu = rh.function(_get_env_var_value).to(cluster, test_env)
     assert get_env_var_cpu("ENV_VAR1") == "value"
     assert get_env_var_cpu("ENV_VAR2") == "val2"
 
@@ -136,32 +143,34 @@ def test_function_env_vars_file(cpu_cluster):
 
 
 @pytest.mark.clustertest
-def test_env_git_reqs(cpu_cluster):
+@parametrize_cpu_clusters
+def test_env_git_reqs(cluster):
     git_package = rh.GitPackage(
         git_url="https://github.com/huggingface/diffusers.git",
         install_method="pip",
         revision="v0.11.1",
     )
     env = rh.env(reqs=[git_package])
-    env.to(cpu_cluster)
-    res = cpu_cluster.run(["pip freeze | grep diffusers"])
+    env.to(cluster)
+    res = cluster.run(["pip freeze | grep diffusers"])
     assert "diffusers" in res[0][1]
-    cpu_cluster.run(["pip uninstall diffusers -y"])
+    cluster.run(["pip uninstall diffusers -y"])
 
 
 @pytest.mark.clustertest
-def test_working_dir(cpu_cluster, tmp_path):
+@parametrize_cpu_clusters
+def test_working_dir(cluster, tmp_path):
     working_dir = tmp_path / "test_working_dir"
     working_dir.mkdir(exist_ok=True)
 
     env = rh.env(working_dir=str(working_dir))
     assert str(working_dir) in env.reqs
 
-    env.to(cpu_cluster)
-    assert working_dir.name in cpu_cluster.run(["ls"])[0][1]
+    env.to(cluster)
+    assert working_dir.name in cluster.run(["ls"])[0][1]
 
-    cpu_cluster.run([f"rm -r {working_dir.name}"])
-    assert working_dir.name not in cpu_cluster.run(["ls"])[0][1]
+    cluster.run([f"rm -r {working_dir.name}"])
+    assert working_dir.name not in cluster.run(["ls"])[0][1]
 
 
 # -------- CONDA ENV TESTS ----------- #
@@ -179,7 +188,6 @@ def _get_conda_env(name="rh-test", python_version="3.10.9"):
 
 
 def _get_conda_python_version(env, system):
-    system.up_if_not()
     env.to(system)
     py_version = system.run([f"{env._run_cmd} python --version"])
     return py_version[0][1]
@@ -210,7 +218,8 @@ def test_conda_env_from_name_rns():
 
 
 @pytest.mark.clustertest
-def test_conda_env_path_to_system(cpu_cluster):
+@parametrize_cpu_clusters
+def test_conda_env_path_to_system(cluster):
     env_name = "from_path"
     python_version = "3.9.16"
     tmp_path = Path.cwd() / "test-env"
@@ -223,55 +232,60 @@ def test_conda_env_path_to_system(cpu_cluster):
     conda_env = rh.env(conda_env=file_path)
     shutil.rmtree(tmp_path)
 
-    assert python_version in _get_conda_python_version(conda_env, cpu_cluster)
+    assert python_version in _get_conda_python_version(conda_env, cluster)
 
 
 @pytest.mark.clustertest
-def test_conda_env_local_to_system(cpu_cluster):
+@parametrize_cpu_clusters
+def test_conda_env_local_to_system(cluster):
     env_name = "local-env"
     python_version = "3.9.16"
     os.system(f"conda create -n {env_name} -y python=={python_version}")
 
     conda_env = rh.env(conda_env=env_name)
-    assert python_version in _get_conda_python_version(conda_env, cpu_cluster)
+    assert python_version in _get_conda_python_version(conda_env, cluster)
 
 
 @pytest.mark.clustertest
-def test_conda_env_dict_to_system(cpu_cluster):
+@parametrize_cpu_clusters
+def test_conda_env_dict_to_system(cluster):
     conda_env = _get_conda_env(python_version="3.9.16")
     test_env = rh.env(name="test_env", conda_env=conda_env)
 
-    assert "3.9.16" in _get_conda_python_version(test_env, cpu_cluster)
+    assert "3.9.16" in _get_conda_python_version(test_env, cluster)
 
     # ray installed successfully
-    res = cpu_cluster.run([f"{test_env._run_cmd} python -c 'import ray'"])
+    res = cluster.run([f"{test_env._run_cmd} python -c 'import ray'"])
     assert res[0][0] == 0
 
 
 @pytest.mark.clustertest
-def test_function_to_conda_env(cpu_cluster):
+@parametrize_cpu_clusters
+def test_function_to_conda_env(cluster):
     conda_env = _get_conda_env(python_version="3.9.16")
     test_env = rh.env(name="test_env", conda_env=conda_env)
 
     def summer(a, b):
         return a + b
 
-    rh.function(summer).to(cpu_cluster, test_env)
-    assert "3.9.16" in _get_conda_python_version(test_env, cpu_cluster)
+    rh.function(summer).to(cluster, test_env)
+    assert "3.9.16" in _get_conda_python_version(test_env, cluster)
 
 
 @pytest.mark.clustertest
-def test_conda_additional_reqs(cpu_cluster):
+@parametrize_cpu_clusters
+def test_conda_additional_reqs(cluster):
     new_conda_env = _get_conda_env(name="test-add-reqs")
     new_conda_env = rh.env(name="conda_env", reqs=["scipy"], conda_env=new_conda_env)
-    new_conda_env.to(cpu_cluster)
-    res = cpu_cluster.run([f"{new_conda_env._run_cmd} python -c 'import scipy'"])
+    new_conda_env.to(cluster)
+    res = cluster.run([f"{new_conda_env._run_cmd} python -c 'import scipy'"])
     assert res[0][0] == 0  # reqs successfully installed
-    cpu_cluster.run([f"{new_conda_env._run_cmd} pip uninstall scipy"])
+    cluster.run([f"{new_conda_env._run_cmd} pip uninstall scipy"])
 
 
 @pytest.mark.clustertest
-def test_conda_git_reqs(cpu_cluster):
+@parametrize_cpu_clusters
+def test_conda_git_reqs(cluster):
     conda_env = _get_conda_env(name="test-add-reqs")
     git_package = rh.GitPackage(
         git_url="https://github.com/huggingface/diffusers.git",
@@ -279,14 +293,15 @@ def test_conda_git_reqs(cpu_cluster):
         revision="v0.11.1",
     )
     conda_env = rh.env(conda_env=conda_env, reqs=[git_package])
-    conda_env.to(cpu_cluster)
-    res = cpu_cluster.run([f"{conda_env._run_cmd} pip freeze | grep diffusers"])
+    conda_env.to(cluster)
+    res = cluster.run([f"{conda_env._run_cmd} pip freeze | grep diffusers"])
     assert "diffusers" in res[0][1]
-    cpu_cluster.run([f"{conda_env._run_cmd} pip uninstall diffusers"])
+    cluster.run([f"{conda_env._run_cmd} pip uninstall diffusers"])
 
 
 @pytest.mark.clustertest
-def test_conda_env_to_fs_to_cluster(cpu_cluster, s3_package):
+@parametrize_cpu_clusters
+def test_conda_env_to_fs_to_cluster(cluster, s3_package):
     conda_env = _get_conda_env(name="s3-env")
     conda_env_s3 = rh.env(reqs=["s3fs", "scipy", s3_package], conda_env=conda_env).to(
         "s3"
@@ -301,20 +316,18 @@ def test_conda_env_to_fs_to_cluster(cpu_cluster, s3_package):
 
     folder_name = "test_package"
     count = 0
-    conda_env_cluster = conda_env_s3.to(
-        system=cpu_cluster, path=folder_name, mount=True
-    )
+    conda_env_cluster = conda_env_s3.to(system=cluster, path=folder_name, mount=True)
     for req in conda_env_cluster.reqs:
         if isinstance(req, Package) and isinstance(req.install_target, Folder):
-            assert req.install_target.system == cpu_cluster
+            assert req.install_target.system == cluster
             count += 1
     assert count >= 1
 
-    assert "sample_file_0.txt" in cpu_cluster.run([f"ls {folder_name}"])[0][1]
-    assert "s3-env" in cpu_cluster.run(["conda info --envs"])[0][1]
+    assert "sample_file_0.txt" in cluster.run([f"ls {folder_name}"])[0][1]
+    assert "s3-env" in cluster.run(["conda info --envs"])[0][1]
 
-    cpu_cluster.run([f"rm -r {folder_name}"])
-    cpu_cluster.run(["conda env remove -n s3-env"])
+    cluster.run([f"rm -r {folder_name}"])
+    cluster.run(["conda env remove -n s3-env"])
 
 
 # -------- CONDA ENV + FUNCTION TESTS ----------- #
@@ -327,19 +340,21 @@ def np_summer(a, b):
 
 
 @pytest.mark.clustertest
-def test_conda_call_fn(cpu_cluster):
+@parametrize_cpu_clusters
+def test_conda_call_fn(cluster):
     conda_dict = _get_conda_env(name="c")
     conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])
-    fn = rh.function(np_summer).to(system=cpu_cluster, env=conda_env)
+    fn = rh.function(np_summer).to(system=cluster, env=conda_env)
     result = fn(1, 4)
     assert result == 5
 
 
 @pytest.mark.clustertest
-def test_conda_map_fn(cpu_cluster):
+@parametrize_cpu_clusters
+def test_conda_map_fn(cluster):
     conda_dict = _get_conda_env(name="test-map-fn")
     conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])
-    map_fn = rh.function(np_summer, system=cpu_cluster, env=conda_env)
+    map_fn = rh.function(np_summer, system=cluster, env=conda_env)
     inputs = list(zip(range(5), range(4, 9)))
     results = map_fn.starmap(inputs)
     assert results == [4, 6, 8, 10, 12]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -11,7 +11,7 @@ import yaml
 from runhouse.rns.folders.folder import Folder
 from runhouse.rns.packages import Package
 
-from .conftest import parametrize_cpu_clusters
+from .conftest import cpu_clusters
 
 pip_reqs = ["torch", "numpy"]
 
@@ -46,7 +46,7 @@ def test_create_env():
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_to_cluster(cluster):
     test_env = rh.env(name="test_env", reqs=["transformers"])
 
@@ -59,7 +59,7 @@ def test_to_cluster(cluster):
 
 @pytest.mark.awstest
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_to_fs_to_cluster(cluster, s3_package):
     cluster.install_packages(["s3fs"])
 
@@ -82,7 +82,7 @@ def test_to_fs_to_cluster(cluster, s3_package):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_function_to_env(cluster):
     test_env = rh.env(name="test-env", reqs=["parameterized"]).save()
 
@@ -111,7 +111,7 @@ def _get_env_var_value(env_var):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_function_env_vars(cluster):
     test_env_var = "TEST_ENV_VAR"
     test_value = "value"
@@ -124,7 +124,7 @@ def test_function_env_vars(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_function_env_vars_file(cluster):
     env_file = ".env"
     contents = ["# comment", "", "ENV_VAR1=value", "# comment with =", "ENV_VAR2 =val2"]
@@ -143,7 +143,7 @@ def test_function_env_vars_file(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_env_git_reqs(cluster):
     git_package = rh.GitPackage(
         git_url="https://github.com/huggingface/diffusers.git",
@@ -158,7 +158,7 @@ def test_env_git_reqs(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_working_dir(cluster, tmp_path):
     working_dir = tmp_path / "test_working_dir"
     working_dir.mkdir(exist_ok=True)
@@ -218,7 +218,7 @@ def test_conda_env_from_name_rns():
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_env_path_to_system(cluster):
     env_name = "from_path"
     python_version = "3.9.16"
@@ -236,7 +236,7 @@ def test_conda_env_path_to_system(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_env_local_to_system(cluster):
     env_name = "local-env"
     python_version = "3.9.16"
@@ -247,7 +247,7 @@ def test_conda_env_local_to_system(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_env_dict_to_system(cluster):
     conda_env = _get_conda_env(python_version="3.9.16")
     test_env = rh.env(name="test_env", conda_env=conda_env)
@@ -260,7 +260,7 @@ def test_conda_env_dict_to_system(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_function_to_conda_env(cluster):
     conda_env = _get_conda_env(python_version="3.9.16")
     test_env = rh.env(name="test_env", conda_env=conda_env)
@@ -273,7 +273,7 @@ def test_function_to_conda_env(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_additional_reqs(cluster):
     new_conda_env = _get_conda_env(name="test-add-reqs")
     new_conda_env = rh.env(name="conda_env", reqs=["scipy"], conda_env=new_conda_env)
@@ -284,7 +284,7 @@ def test_conda_additional_reqs(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_git_reqs(cluster):
     conda_env = _get_conda_env(name="test-add-reqs")
     git_package = rh.GitPackage(
@@ -300,7 +300,7 @@ def test_conda_git_reqs(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_env_to_fs_to_cluster(cluster, s3_package):
     conda_env = _get_conda_env(name="s3-env")
     conda_env_s3 = rh.env(reqs=["s3fs", "scipy", s3_package], conda_env=conda_env).to(
@@ -340,7 +340,7 @@ def np_summer(a, b):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_call_fn(cluster):
     conda_dict = _get_conda_env(name="c")
     conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])
@@ -350,7 +350,7 @@ def test_conda_call_fn(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_conda_map_fn(cluster):
     conda_dict = _get_conda_env(name="test-map-fn")
     conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -10,7 +10,7 @@ import runhouse as rh
 from runhouse.rns.api_utils.resource_access import ResourceAccess
 from runhouse.rns.api_utils.utils import load_resp_content
 
-from .conftest import parametrize_cpu_clusters
+from .conftest import cpu_clusters
 
 REMOTE_FUNC_NAME = "@/remote_function"
 
@@ -38,7 +38,7 @@ def np_array(list):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_create_function_from_name_local(cluster):
     local_name = "~/local_function"
     local_sum = rh.function(summer).to(cluster).save(local_name)
@@ -55,7 +55,7 @@ def test_create_function_from_name_local(cluster):
 @unittest.skip("Not yet implemented.")
 @pytest.mark.rnstest
 @pytest.mark.clustertest
-def test_running_function_as_proxy(cpu_cluster):
+def test_running_function_as_proxy(ondemand_cpu_cluster):
     # reload the function from RNS
     remote_sum = rh.function(name=REMOTE_FUNC_NAME)
     remote_sum.access = ResourceAccess.PROXY
@@ -68,7 +68,7 @@ def test_running_function_as_proxy(cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_create_function_from_rns(cluster):
     remote_sum = rh.function(summer).to(cluster).save(REMOTE_FUNC_NAME)
     del remote_sum
@@ -84,7 +84,7 @@ def test_create_function_from_rns(cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_get_function_history(cluster):
     # reload the function from RNS
     remote_sum = rh.function(summer).to(cluster).save(REMOTE_FUNC_NAME)
@@ -101,7 +101,7 @@ def multiproc_torch_sum(inputs):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_remote_function_with_multiprocessing(cluster):
     re_fn = rh.function(multiproc_torch_sum, name="test_function").to(
         cluster, env=["torch==1.12.1"]
@@ -118,7 +118,7 @@ def getpid(a=0):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_maps(cluster):
     pid_fn = rh.function(getpid, system=cluster)
     num_pids = [1] * 10
@@ -145,7 +145,7 @@ def test_maps(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_remotes(cluster):
     pid_fn = rh.function(getpid, system=cluster)
 
@@ -159,7 +159,7 @@ def test_remotes(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_function_git_fn(cluster):
     remote_parse = rh.function(
         fn="https://github.com/huggingface/diffusers/blob/"
@@ -189,7 +189,7 @@ def test_function_git_fn(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_list_keys(cluster):
     pid_fn = rh.function(getpid).to(system=cluster)
 
@@ -206,7 +206,7 @@ def slow_getpid(a=0):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_cancel_jobs(cluster):
     pid_fn = rh.function(slow_getpid).to(cluster)
 
@@ -232,7 +232,7 @@ def test_cancel_jobs(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_function_queueing(cluster):
     pid_fn = rh.function(getpid).to(cluster)
 
@@ -241,7 +241,7 @@ def test_function_queueing(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_function_to_env(cluster):
     cluster.run(["pip uninstall numpy -y"])
 
@@ -254,20 +254,20 @@ def test_function_to_env(cluster):
 
 @unittest.skip("Not working properly.")
 @pytest.mark.clustertest
-def test_function_external_fn(cpu_cluster):
+def test_function_external_fn(ondemand_cpu_cluster):
     """Test functioning a module from reqs, not from working_dir"""
     import torch
 
-    re_fn = rh.function(torch.sum).to(cpu_cluster, env=["torch"])
+    re_fn = rh.function(torch.sum).to(ondemand_cpu_cluster, env=["torch"])
     res = re_fn(torch.arange(5))
     assert int(res) == 10
 
 
 @unittest.skip("Runs indefinitely.")
 @pytest.mark.clustertest
-def test_notebook(cpu_cluster):
+def test_notebook(ondemand_cpu_cluster):
     nb_sum = lambda x: multiproc_torch_sum(x)
-    re_fn = rh.function(nb_sum).to(cpu_cluster, env=["torch==1.12.1"])
+    re_fn = rh.function(nb_sum).to(ondemand_cpu_cluster, env=["torch==1.12.1"])
 
     re_fn.notebook()
     summands = list(zip(range(5), range(4, 9)))
@@ -287,8 +287,8 @@ def test_ssh():
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_share_function(cpu_cluster):
-    my_function = rh.function(fn=summer).to(cpu_cluster).save(REMOTE_FUNC_NAME)
+def test_share_function(ondemand_cpu_cluster):
+    my_function = rh.function(fn=summer).to(ondemand_cpu_cluster).save(REMOTE_FUNC_NAME)
 
     my_function.share(
         users=["donny@run.house", "josh@run.house"],
@@ -370,11 +370,11 @@ def test_byo_cluster_maps(byo_cpu):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_load_function_in_new_env(cpu_cluster, byo_cpu):
-    cpu_cluster.save(
-        f"@/{cpu_cluster.name}"
+def test_load_function_in_new_env(ondemand_cpu_cluster, byo_cpu):
+    ondemand_cpu_cluster.save(
+        f"@/{ondemand_cpu_cluster.name}"
     )  # Needs to be saved to rns, right now has a local name by default
-    remote_sum = rh.function(summer).to(cpu_cluster).save(REMOTE_FUNC_NAME)
+    remote_sum = rh.function(summer).to(ondemand_cpu_cluster).save(REMOTE_FUNC_NAME)
 
     remote_python = (
         "import runhouse as rh; "
@@ -389,8 +389,8 @@ def test_load_function_in_new_env(cpu_cluster, byo_cpu):
 
 
 @pytest.mark.clustertest
-def test_nested_diff_clusters(cpu_cluster, byo_cpu):
-    summer_cpu = rh.function(summer).to(cpu_cluster)
+def test_nested_diff_clusters(ondemand_cpu_cluster, byo_cpu):
+    summer_cpu = rh.function(summer).to(ondemand_cpu_cluster)
     call_function_diff_cpu = rh.function(call_function).to(byo_cpu)
 
     kwargs = {"a": 1, "b": 5}
@@ -399,7 +399,7 @@ def test_nested_diff_clusters(cpu_cluster, byo_cpu):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_nested_same_cluster(cluster):
     # When the system of a function is set to the cluster that the function is being called on, we run the function
     # locally and not via an RPC call
@@ -412,7 +412,7 @@ def test_nested_same_cluster(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_http_url(cluster):
     rh.function(summer).to(cluster).save("@/remote_function")
     tun, port = cluster.ssh_tunnel(80, 50052)
@@ -451,7 +451,7 @@ def test_http_url_with_curl():
 
 # test that deprecated arguments are still backwards compatible for now
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_reqs_backwards_compatible(cluster):
     summer_cpu = rh.function(fn=summer).to(system=cluster)
     res = summer_cpu(1, 5)
@@ -463,7 +463,7 @@ def test_reqs_backwards_compatible(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_setup_cmds_backwards_compatible(cluster):
     torch_summer_cpu = rh.function(fn=summer).to(system=cluster, env=["torch"])
     torch_res = torch_summer_cpu(1, 5)

--- a/tests/test_obj_store.py
+++ b/tests/test_obj_store.py
@@ -35,35 +35,35 @@ def do_tqdm_printing_and_logging(steps=6):
 
 
 @pytest.mark.clustertest
-def test_get_from_cluster(cpu_cluster):
-    print_fn = rh.function(fn=do_printing_and_logging, system=cpu_cluster)
+def test_get_from_cluster(ondemand_cpu_cluster):
+    print_fn = rh.function(fn=do_printing_and_logging, system=ondemand_cpu_cluster)
     run_obj = print_fn.run()
     assert isinstance(run_obj, rh.Run)
 
-    res = cpu_cluster.get(run_obj.name, stream_logs=True)
+    res = ondemand_cpu_cluster.get(run_obj.name, stream_logs=True)
     assert res == list(range(50))
 
 
 @pytest.mark.clustertest
-def test_put_and_get_on_cluster(cpu_cluster):
+def test_put_and_get_on_cluster(ondemand_cpu_cluster):
     test_list = list(range(5, 50, 2)) + ["a string"]
-    cpu_cluster.put("my_list", test_list)
-    ret = cpu_cluster.get("my_list")
+    ondemand_cpu_cluster.put("my_list", test_list)
+    ret = ondemand_cpu_cluster.get("my_list")
     assert all(a == b for (a, b) in zip(ret, test_list))
 
 
 @pytest.mark.clustertest
-def test_stream_logs(cpu_cluster):
-    print_fn = rh.function(fn=do_printing_and_logging, system=cpu_cluster)
+def test_stream_logs(ondemand_cpu_cluster):
+    print_fn = rh.function(fn=do_printing_and_logging, system=ondemand_cpu_cluster)
     res = print_fn(stream_logs=True)
     # TODO [DG] assert that the logs are streamed
     assert res == list(range(50))
 
 
 @pytest.mark.clustertest
-def test_multiprocessing_streaming(cpu_cluster):
+def test_multiprocessing_streaming(ondemand_cpu_cluster):
     re_fn = rh.function(
-        multiproc_torch_sum, system=cpu_cluster, env=["./", "torch==1.12.1"]
+        multiproc_torch_sum, system=ondemand_cpu_cluster, env=["./", "torch==1.12.1"]
     )
     summands = list(zip(range(5), range(4, 9)))
     res = re_fn(summands, stream_logs=True)
@@ -71,24 +71,24 @@ def test_multiprocessing_streaming(cpu_cluster):
 
 
 @pytest.mark.clustertest
-def test_tqdm_streaming(cpu_cluster):
+def test_tqdm_streaming(ondemand_cpu_cluster):
     # Note, this doesn't work properly in PyCharm due to incomplete
     # support for carriage returns in the PyCharm console.
-    print_fn = rh.function(fn=do_tqdm_printing_and_logging, system=cpu_cluster)
+    print_fn = rh.function(fn=do_tqdm_printing_and_logging, system=ondemand_cpu_cluster)
     res = print_fn(steps=40, stream_logs=True)
     assert res == list(range(50))
 
 
 @pytest.mark.clustertest
-def test_cancel_run(cpu_cluster):
-    print_fn = rh.function(fn=do_printing_and_logging, system=cpu_cluster)
+def test_cancel_run(ondemand_cpu_cluster):
+    print_fn = rh.function(fn=do_printing_and_logging, system=ondemand_cpu_cluster)
     run_obj = print_fn.run()
     assert isinstance(run_obj, rh.Run)
 
     key = run_obj.name
-    cpu_cluster.cancel(key)
+    ondemand_cpu_cluster.cancel(key)
     with pytest.raises(Exception) as e:
-        cpu_cluster.get(key, stream_logs=True)
+        ondemand_cpu_cluster.get(key, stream_logs=True)
     # NOTE [DG]: For some reason the exception randomly returns in different formats
     assert "ray.exceptions.TaskCancelledError" in str(
         e.value

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,7 +6,7 @@ import pytest
 
 import runhouse as rh
 
-from .conftest import parametrize_cpu_clusters
+from .conftest import cpu_clusters
 
 extra_index_url = "--extra-index-url https://pypi.python.org/simple/"
 cuda_116_url = "--index-url https://download.pytorch.org/whl/cu116"
@@ -40,8 +40,8 @@ def test_from_string():
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_share_package(cpu_cluster, local_package):
-    local_package.to(system=cpu_cluster)
+def test_share_package(ondemand_cpu_cluster, local_package):
+    local_package.to(system=ondemand_cpu_cluster)
     local_package.save("package_to_share")  # shareable resource requires a name
 
     local_package.share(
@@ -52,7 +52,7 @@ def test_share_package(cpu_cluster, local_package):
 
     # TODO test loading from a different account for real
     # Confirm the package's folder is now on the cluster
-    status_codes = cpu_cluster.run(commands=["ls tmp_package"])
+    status_codes = ondemand_cpu_cluster.run(commands=["ls tmp_package"])
     assert "sample_file_0.txt" in status_codes[0][1]
 
 
@@ -80,7 +80,7 @@ def test_load_shared_git_package():
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_local_package_function(cluster):
     function = rh.function(fn=summer).to(cluster, env=["./"])
 
@@ -91,7 +91,7 @@ def test_local_package_function(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_local_package_to_cluster(cluster):
     package = rh.Package.from_string("./").to(cluster)
 
@@ -100,7 +100,7 @@ def test_local_package_to_cluster(cluster):
 
 
 @pytest.mark.clustertest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_mount_local_package_to_cluster(cluster):
     mount_path = "package_mount"
     package = rh.Package.from_string("./").to(cluster, path=mount_path, mount=True)
@@ -112,7 +112,7 @@ def test_mount_local_package_to_cluster(cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.awstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_package_file_system_to_cluster(cluster, s3_package):
     assert s3_package.install_target.system == "s3"
     assert s3_package.install_target.exists_in_system()
@@ -279,7 +279,7 @@ def test_torch_install_command_generator():
 @pytest.mark.gputest
 @pytest.mark.parametrize(
     "cluster",
-    ["cpu_cluster", "v100_gpu_cluster", "k80_gpu_cluster", "a10g_gpu_cluster"],
+    ["ondemand_cpu_cluster", "v100_gpu_cluster", "k80_gpu_cluster", "a10g_gpu_cluster"],
     indirect=True,
 )
 def test_getting_cuda_version_on_clusters(request, cluster):
@@ -306,7 +306,7 @@ def test_getting_cuda_version_on_clusters(request, cluster):
 @pytest.mark.gputest
 @pytest.mark.parametrize(
     "cluster",
-    ["cpu_cluster", "v100_gpu_cluster", "k80_gpu_cluster", "a10g_gpu_cluster"],
+    ["ondemand_cpu_cluster", "v100_gpu_cluster", "k80_gpu_cluster", "a10g_gpu_cluster"],
     indirect=True,
 )
 def test_install_cmd_for_torch_on_cluster(request, cluster):

--- a/tests/test_rns.py
+++ b/tests/test_rns.py
@@ -83,10 +83,10 @@ def test_ls():
 
 
 @pytest.mark.rnstest
-def test_from_name(cpu_cluster):
+def test_from_name(ondemand_cpu_cluster):
     f = rh.folder(name="~/tests/bert_ft")
     assert f.path
-    assert cpu_cluster.instance_type == "CPU:2+"
+    assert ondemand_cpu_cluster.instance_type == "CPU:2+"
 
 
 if __name__ == "__main__":

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -24,9 +24,9 @@ RUN_FILES = (
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_read_fn_stdout(cpu_cluster, submitted_run):
+def test_read_fn_stdout(ondemand_cpu_cluster, submitted_run):
     """Reads the stdout for the Run."""
-    fn_run = cpu_cluster.get_run(submitted_run)
+    fn_run = ondemand_cpu_cluster.get_run(submitted_run)
     stdout = fn_run.stdout()
     pprint(stdout)
     assert stdout
@@ -34,18 +34,18 @@ def test_read_fn_stdout(cpu_cluster, submitted_run):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_load_run_result(cpu_cluster, submitted_run):
+def test_load_run_result(ondemand_cpu_cluster, submitted_run):
     """Load the Run created above directly from the cluster."""
     # Note: Run only exists on the cluster at this point (hasn't yet been saved to RNS).
-    func_run = cpu_cluster.get_run(submitted_run)
+    func_run = ondemand_cpu_cluster.get_run(submitted_run)
     assert func_run.result() == 3
 
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_read_fn_run_inputs_and_result(cpu_cluster, submitted_run):
+def test_read_fn_run_inputs_and_result(ondemand_cpu_cluster, submitted_run):
     # Load directly from the cluster
-    my_run = cpu_cluster.get_run(submitted_run)
+    my_run = ondemand_cpu_cluster.get_run(submitted_run)
     inputs = my_run.inputs()
     assert inputs == {"args": [1, 2], "kwargs": {}}
 
@@ -79,7 +79,7 @@ def test_get_or_call_no_cache(summer_func):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_invalid_fn_sync_run(summer_func, cpu_cluster):
+def test_invalid_fn_sync_run(summer_func, ondemand_cpu_cluster):
     """Test error handling for invalid function Run. The function expects to receive integers but
     does not receive any. An error should be thrown via Ray."""
     import ray
@@ -107,7 +107,7 @@ def test_invalid_fn_async_run(summer_func):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_get_fn_status_updates(cpu_cluster, slow_func):
+def test_get_fn_status_updates(ondemand_cpu_cluster, slow_func):
     """Run a function that takes a long time to run, confirming that its status changes as we refresh the Run"""
     async_run = slow_func.run(run_name="my_slow_async_run", a=1, b=2)
 
@@ -195,9 +195,9 @@ def test_get_or_run_latest(summer_func):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_delete_async_run_from_system(cpu_cluster, submitted_async_run):
+def test_delete_async_run_from_system(ondemand_cpu_cluster, submitted_async_run):
     # Load the run from the cluster and delete its dedicated folder
-    async_run = cpu_cluster.get_run(submitted_async_run)
+    async_run = ondemand_cpu_cluster.get_run(submitted_async_run)
     async_run.folder.rm()
     assert not async_run.folder.exists_in_system()
 
@@ -205,10 +205,10 @@ def test_delete_async_run_from_system(cpu_cluster, submitted_async_run):
 @pytest.mark.clustertest
 @pytest.mark.rnstest
 @pytest.mark.runstest
-def test_save_fn_run_to_rns(cpu_cluster, submitted_run):
+def test_save_fn_run_to_rns(ondemand_cpu_cluster, submitted_run):
     """Saves run config to RNS"""
     # Load run that lives on the cluster
-    func_run = cpu_cluster.get_run(submitted_run)
+    func_run = ondemand_cpu_cluster.get_run(submitted_run)
     assert func_run
 
     # Save to RNS
@@ -238,8 +238,8 @@ def test_latest_fn_run(summer_func):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_copy_fn_run_from_cluster_to_local(cpu_cluster, submitted_run):
-    my_run = cpu_cluster.get_run(submitted_run)
+def test_copy_fn_run_from_cluster_to_local(ondemand_cpu_cluster, submitted_run):
+    my_run = ondemand_cpu_cluster.get_run(submitted_run)
     my_local_run = my_run.to("here")
     assert my_local_run.folder.exists_in_system()
 
@@ -254,8 +254,10 @@ def test_copy_fn_run_from_cluster_to_local(cpu_cluster, submitted_run):
 @pytest.mark.clustertest
 @pytest.mark.awstest
 @pytest.mark.runstest
-def test_copy_fn_run_from_system_to_s3(cpu_cluster, runs_s3_bucket, submitted_run):
-    my_run = cpu_cluster.get_run(submitted_run)
+def test_copy_fn_run_from_system_to_s3(
+    ondemand_cpu_cluster, runs_s3_bucket, submitted_run
+):
+    my_run = ondemand_cpu_cluster.get_run(submitted_run)
     my_run_on_s3 = my_run.to("s3", path=f"/{runs_s3_bucket}/my_test_run")
 
     assert my_run_on_s3.folder.exists_in_system()
@@ -287,9 +289,9 @@ def test_delete_fn_run_from_rns(submitted_run):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_create_cli_python_command_run(cpu_cluster):
+def test_create_cli_python_command_run(ondemand_cpu_cluster):
     # Run python commands on the specified system. Save the run results to the .rh/logs/<run_name> folder of the system.
-    return_codes = cpu_cluster.run_python(
+    return_codes = ondemand_cpu_cluster.run_python(
         [
             "import runhouse as rh",
             "import pickle",
@@ -308,10 +310,10 @@ def test_create_cli_python_command_run(cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_create_cli_command_run(cpu_cluster):
+def test_create_cli_command_run(ondemand_cpu_cluster):
     """Run CLI command on the specified system.
     Saves the Run locally to the rh/<run_name> folder of the local file system."""
-    return_codes = cpu_cluster.run(["python --version"], run_name=CLI_RUN_NAME)
+    return_codes = ondemand_cpu_cluster.run(["python --version"], run_name=CLI_RUN_NAME)
 
     assert return_codes[0][0] == 0, "Failed to run CLI command"
     assert return_codes[0][1].strip() == "Python 3.10.6"
@@ -319,7 +321,7 @@ def test_create_cli_command_run(cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_send_cli_run_to_cluster(cpu_cluster):
+def test_send_cli_run_to_cluster(ondemand_cpu_cluster):
     """Send the CLI based Run which was initially saved on the local file system to the cpu cluster."""
     # Load the run from the local file system
     loaded_run = rh.run(
@@ -330,7 +332,7 @@ def test_send_cli_run_to_cluster(cpu_cluster):
 
     # Save to default path on the cluster (~/.rh/logs/<run_name>)
     cluster_run = loaded_run.to(
-        cpu_cluster, path=rh.Run._base_cluster_folder_path(name=CLI_RUN_NAME)
+        ondemand_cpu_cluster, path=rh.Run._base_cluster_folder_path(name=CLI_RUN_NAME)
     )
 
     assert cluster_run.folder.exists_in_system()
@@ -339,19 +341,19 @@ def test_send_cli_run_to_cluster(cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_load_cli_command_run_from_cluster(cpu_cluster):
+def test_load_cli_command_run_from_cluster(ondemand_cpu_cluster):
     # At this point the Run exists locally and on the cluster (hasn't yet been saved to RNS).
     # Load from the cluster
-    cli_run = cpu_cluster.get_run(CLI_RUN_NAME)
+    cli_run = ondemand_cpu_cluster.get_run(CLI_RUN_NAME)
     assert isinstance(cli_run, rh.Run)
 
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
 @pytest.mark.runstest
-def test_save_cli_run_to_rns(cpu_cluster):
+def test_save_cli_run_to_rns(ondemand_cpu_cluster):
     # Load the run from the cluster
-    cli_run = cpu_cluster.get_run(CLI_RUN_NAME)
+    cli_run = ondemand_cpu_cluster.get_run(CLI_RUN_NAME)
 
     # Save to RNS
     cli_run.save(name=CLI_RUN_NAME)
@@ -364,9 +366,9 @@ def test_save_cli_run_to_rns(cpu_cluster):
 @pytest.mark.clustertest
 @pytest.mark.rnstest
 @pytest.mark.runstest
-def test_read_cli_command_stdout_from_cluster(cpu_cluster):
+def test_read_cli_command_stdout_from_cluster(ondemand_cpu_cluster):
     # Read the stdout from the cluster
-    cli_run = cpu_cluster.get_run(CLI_RUN_NAME)
+    cli_run = ondemand_cpu_cluster.get_run(CLI_RUN_NAME)
     cli_stdout = cli_run.stdout()
     assert cli_stdout == "Python 3.10.6"
 
@@ -384,20 +386,20 @@ def test_delete_cli_run_from_local_filesystem():
 
 @pytest.mark.clustertest
 @pytest.mark.runstest
-def test_delete_cli_run_from_cluster(cpu_cluster):
+def test_delete_cli_run_from_cluster(ondemand_cpu_cluster):
     """Delete the config where it was copied to (in the ``~/.rh/logs/<run_name>`` folder of the cluster)"""
-    cli_run = cpu_cluster.get_run(CLI_RUN_NAME)
+    cli_run = ondemand_cpu_cluster.get_run(CLI_RUN_NAME)
     assert cli_run, f"Failed to load run {CLI_RUN_NAME} from cluster"
 
     # Update the Run's folder to point to the cluster instead of the local file system
-    cli_run.folder.system = cpu_cluster
+    cli_run.folder.system = ondemand_cpu_cluster
     cli_run.folder.path = rh.Run._base_cluster_folder_path(name=CLI_RUN_NAME)
     assert cli_run.folder.exists_in_system()
 
     cli_run.folder.rm()
     assert not cli_run.folder.exists_in_system()
 
-    cli_run = cpu_cluster.get_run(CLI_RUN_NAME)
+    cli_run = ondemand_cpu_cluster.get_run(CLI_RUN_NAME)
     assert cli_run is None, f"Failed to delete {cli_run} on cluster"
 
 
@@ -416,7 +418,7 @@ def test_delete_cli_run_from_rns():
 @pytest.mark.clustertest
 @pytest.mark.rnstest
 @pytest.mark.runstest
-def test_create_local_ctx_manager_run(summer_func, cpu_cluster):
+def test_create_local_ctx_manager_run(summer_func, ondemand_cpu_cluster):
     from runhouse.rh_config import rns_client
 
     ctx_mgr_func = "my_ctx_mgr_func"
@@ -432,7 +434,7 @@ def test_create_local_ctx_manager_run(summer_func, cpu_cluster):
         run_res = current_run.result()
         print(f"Run result: {run_res}")
 
-        cluster_config = rh.load(name=cpu_cluster.name, instantiate=False)
+        cluster_config = rh.load(name=ondemand_cpu_cluster.name, instantiate=False)
         cluster = rh.Cluster.from_config(config=cluster_config, dryrun=True)
         print(f"Cluster loaded: {cluster.name}")
 
@@ -445,10 +447,10 @@ def test_create_local_ctx_manager_run(summer_func, cpu_cluster):
     # Artifacts include the rns resolved name (ex: "/jlewitt1/rh-cpu")
     assert r.downstream_artifacts == [
         rns_client.resolve_rns_path(ctx_mgr_func),
-        rns_client.resolve_rns_path(cpu_cluster.name),
+        rns_client.resolve_rns_path(ondemand_cpu_cluster.name),
     ]
     assert r.upstream_artifacts == [
-        rns_client.resolve_rns_path(cpu_cluster.name),
+        rns_client.resolve_rns_path(ondemand_cpu_cluster.name),
     ]
 
 

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -4,6 +4,8 @@ import pytest
 
 import runhouse as rh
 
+from .conftest import parametrize_cpu_clusters
+
 
 @pytest.mark.rnstest
 def test_get_all_secrets_from_vault():
@@ -144,10 +146,11 @@ def test_add_github_secrets():
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_sending_secrets_to_cluster(cpu_cluster):
+@parametrize_cpu_clusters
+def test_sending_secrets_to_cluster(cluster):
     enabled_providers: list = rh.Secrets.enabled_providers()
 
-    cpu_cluster.sync_secrets(providers=enabled_providers)
+    cluster.sync_secrets(providers=enabled_providers)
 
     # Confirm the secrets now exist on the cluster
     for provider_cls in enabled_providers:
@@ -156,7 +159,7 @@ def test_sending_secrets_to_cluster(cpu_cluster):
             f"from runhouse.rns.secrets.{provider_name}_secrets import {str(provider_cls)}",
             f"print({str(provider_cls)}.has_secrets_file())",
         ]
-        status_codes: list = cpu_cluster.run_python(commands)
+        status_codes: list = cluster.run_python(commands)
         if "False" in status_codes[0][1]:
             assert False, f"No credentials file found on cluster for {provider_name}"
 

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -4,7 +4,7 @@ import pytest
 
 import runhouse as rh
 
-from .conftest import parametrize_cpu_clusters
+from .conftest import cpu_clusters
 
 
 @pytest.mark.rnstest
@@ -146,7 +146,7 @@ def test_add_github_secrets():
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_sending_secrets_to_cluster(cluster):
     enabled_providers: list = rh.Secrets.enabled_providers()
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -9,6 +9,8 @@ import runhouse as rh
 
 from runhouse import Folder
 
+from .conftest import parametrize_cpu_clusters
+
 NUM_PARTITIONS = 10
 
 
@@ -556,10 +558,11 @@ def test_shuffling_pyarrow_data_from_s3(arrow_table, table_s3_bucket):
 # -------------------------------------------------
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_create_and_reload_pandas_data_from_cluster(pandas_table, cpu_cluster):
+@parametrize_cpu_clusters
+def test_create_and_reload_pandas_data_from_cluster(pandas_table, cluster):
     # Make sure the destination folder for the data exists on the cluster
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/pandas-data"
-    cpu_cluster.run([f"mkdir -p {data_path_on_cluster}"])
+    cluster.run([f"mkdir -p {data_path_on_cluster}"])
 
     name = "@/my_test_pandas_table"
     my_table = (
@@ -567,7 +570,7 @@ def test_create_and_reload_pandas_data_from_cluster(pandas_table, cpu_cluster):
             data=pandas_table,
             name=name,
             path=data_path_on_cluster,
-            system=cpu_cluster,
+            system=cluster,
         )
         .write()
         .save()
@@ -594,9 +597,10 @@ def test_create_and_reload_pandas_data_from_cluster(pandas_table, cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_create_and_reload_ray_data_from_cluster(ray_table, cpu_cluster):
+@parametrize_cpu_clusters
+def test_create_and_reload_ray_data_from_cluster(ray_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/ray-data"
-    cpu_cluster.run([f"mkdir -p {data_path_on_cluster}"])
+    cluster.run([f"mkdir -p {data_path_on_cluster}"])
 
     name = "@/my_test_ray_cluster_table"
 
@@ -605,7 +609,7 @@ def test_create_and_reload_ray_data_from_cluster(ray_table, cpu_cluster):
             data=ray_table,
             name=name,
             path=data_path_on_cluster,
-            system=cpu_cluster,
+            system=cluster,
         )
         .write()
         .save()
@@ -633,9 +637,10 @@ def test_create_and_reload_ray_data_from_cluster(ray_table, cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cpu_cluster):
+@parametrize_cpu_clusters
+def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/pyarrow-data"
-    cpu_cluster.run([f"mkdir -p {data_path_on_cluster}"])
+    cluster.run([f"mkdir -p {data_path_on_cluster}"])
 
     name = "@/my_test_pyarrow_cluster_table"
 
@@ -644,7 +649,7 @@ def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cpu_cluster):
             data=arrow_table,
             name=name,
             path=data_path_on_cluster,
-            system=cpu_cluster,
+            system=cluster,
         )
         .write()
         .save()
@@ -669,11 +674,10 @@ def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_create_and_reload_huggingface_data_from_cluster(
-    huggingface_table, cpu_cluster
-):
+@parametrize_cpu_clusters
+def test_create_and_reload_huggingface_data_from_cluster(huggingface_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/hf-data"
-    cpu_cluster.run([f"mkdir -p {data_path_on_cluster}"])
+    cluster.run([f"mkdir -p {data_path_on_cluster}"])
 
     name = "@/my_test_hf_cluster_table"
 
@@ -682,7 +686,7 @@ def test_create_and_reload_huggingface_data_from_cluster(
             data=huggingface_table,
             name=name,
             path=data_path_on_cluster,
-            system=cpu_cluster,
+            system=cluster,
         )
         .write()
         .save()
@@ -709,9 +713,10 @@ def test_create_and_reload_huggingface_data_from_cluster(
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_create_and_reload_dask_data_from_cluster(dask_table, cpu_cluster):
+@parametrize_cpu_clusters
+def test_create_and_reload_dask_data_from_cluster(dask_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/dask-data"
-    cpu_cluster.run([f"mkdir -p {data_path_on_cluster}"])
+    cluster.run([f"mkdir -p {data_path_on_cluster}"])
 
     name = "@/my_test_dask_cluster_table"
 
@@ -720,7 +725,7 @@ def test_create_and_reload_dask_data_from_cluster(dask_table, cpu_cluster):
             data=dask_table,
             name=name,
             path=data_path_on_cluster,
-            system=cpu_cluster,
+            system=cluster,
         )
         .write()
         .save()
@@ -746,7 +751,8 @@ def test_create_and_reload_dask_data_from_cluster(dask_table, cpu_cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-def test_to_cluster_attr(pandas_table, cpu_cluster, tmp_path):
+@parametrize_cpu_clusters
+def test_to_cluster_attr(pandas_table, cluster, tmp_path):
     local_path = tmp_path / "table_tests/local_test_table"
     name = "~/my_local_test_table"
 
@@ -761,7 +767,7 @@ def test_to_cluster_attr(pandas_table, cpu_cluster, tmp_path):
         .save()
     )
 
-    cluster_table = my_table.to(system=cpu_cluster)
+    cluster_table = my_table.to(system=cluster)
 
     assert isinstance(cluster_table.system, rh.Cluster)
     assert cluster_table._folder._fs_str == "ssh"

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -9,7 +9,7 @@ import runhouse as rh
 
 from runhouse import Folder
 
-from .conftest import parametrize_cpu_clusters
+from .conftest import cpu_clusters
 
 NUM_PARTITIONS = 10
 
@@ -558,7 +558,7 @@ def test_shuffling_pyarrow_data_from_s3(arrow_table, table_s3_bucket):
 # -------------------------------------------------
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_create_and_reload_pandas_data_from_cluster(pandas_table, cluster):
     # Make sure the destination folder for the data exists on the cluster
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/pandas-data"
@@ -597,7 +597,7 @@ def test_create_and_reload_pandas_data_from_cluster(pandas_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_create_and_reload_ray_data_from_cluster(ray_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/ray-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -637,7 +637,7 @@ def test_create_and_reload_ray_data_from_cluster(ray_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/pyarrow-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -674,7 +674,7 @@ def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_create_and_reload_huggingface_data_from_cluster(huggingface_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/hf-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -713,7 +713,7 @@ def test_create_and_reload_huggingface_data_from_cluster(huggingface_table, clus
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_create_and_reload_dask_data_from_cluster(dask_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/dask-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -751,7 +751,7 @@ def test_create_and_reload_dask_data_from_cluster(dask_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@parametrize_cpu_clusters
+@cpu_clusters
 def test_to_cluster_attr(pandas_table, cluster, tmp_path):
     local_path = tmp_path / "table_tests/local_test_table"
     name = "~/my_local_test_table"


### PR DESCRIPTION
Add support for BYO clusters with passwords. These clusters
* use paramiko for running SSH commands
* use fsspec for file transfers between local <-> cluster and cluster <-> cluster

Note: to run tests without password cluster, add `-k "not [password_cluster]"` to pytest command (ex/ `pytest test_function.py -v -m clustertest -k "not [password_cluster]"`)

Note: running `python -c` through cli or `cluster.run_python` is finicky due to bsah cli quoting. 