### PR TITLE
Typo breaking JSON docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 markdown_http_base = "/docs/guide"
 markdown_anchor_sections = True
 
-if tags.has('json') :
+if tags.has("json"):
     html_link_suffix = ""
     json_baseurl = "docs/json/"
 
@@ -68,7 +68,7 @@ if tags.has('json') :
 # a list of builtin themes.
 #
 # html_theme = "sphinx_rtd_theme"
-if not tags.has('json') :
+if not tags.has("json"):
     html_theme = "sphinx_book_theme"
 
 html_title = "Runhouse"

--- a/docs/debugging_logging.rst
+++ b/docs/debugging_logging.rst
@@ -41,7 +41,7 @@ being printed out, and can debug normally inside the ``screen``.
     server.
 
 For debugging remote functions, which are launched using ``ray``, we can utilize Ray's debugger. Add a
-```breakpoint()`` call inside the function where you want to start the debugging session, then ssh into the
+``breakpoint()`` call inside the function where you want to start the debugging session, then ssh into the
 cluster with ``ssh cluster-name``, and call ``ray debug`` to view select the breakpoint to enter. You can run
 normal ``pdb`` commands within the debugging session, and can refer to
 `Ray Debugger <https://docs.ray.io/en/latest/ray-observability/ray-debugging.html>`_ for more information.


### PR DESCRIPTION
Fixes a link typo that was breaking the JSON docs building - was ignoring subfolders `/python` `/tutorials` etc.