### PR TITLE
Fix json docs build command to include subfolders

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,7 +13,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 json:
-	@$(SPHINXBUILD) -M json "$(SOURCEDIR)" "$(BUILDDIR)" json -t json
+	@$(SPHINXBUILD) -M json "$(SOURCEDIR)" "$(BUILDDIR)" -b json -t json
 
 .PHONY: help Makefile
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ markdown_anchor_sections = True
 
 if tags.has("json"):
     html_link_suffix = ""
-    json_baseurl = "docs/json/"
+    json_baseurl = "docs/"
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Previous command was skipping all the subfolders `/api` etc