### PR TITLE
Use python3 cmd to start http_server + logging when cmd not found

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -144,7 +144,7 @@ def start(
             raise typer.exit(1)
     except FileNotFoundError:
         console.print("python3 command was not found. Make sure you have python3 installed.")
-        raise type.exit(1)
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -124,7 +124,7 @@ def start(
     restart_ray: bool = typer.Option(False, help="Restart the Ray runtime"),
     screen: bool = typer.Option(False, help="Start the server in a screen"),
 ):
-    http_server_cmd = "python -m runhouse.servers.http.http_server"
+    http_server_cmd = "python3 -m runhouse.servers.http.http_server"
     kill_proc_cmd = ["pkill", "-f", f"{http_server_cmd}"]
     subprocess.run(kill_proc_cmd)
 
@@ -135,7 +135,16 @@ def start(
     start_server_cmd = (
         f'screen -dm bash -c "{http_server_cmd}"' if screen else http_server_cmd
     )
-    subprocess.run(shlex.split(start_server_cmd))
+    try:
+        result = subprocess.run(shlex.split(start_server_cmd), capture_output=True, text=True)
+        if result.returncode != 0:
+            console.print(
+                f"Error while executing `{start_server_cmd}`: {result.stderr}"
+            )
+            raise typer.exit(1)
+    except FileNotFoundError:
+        console.print("python3 command was not found. Make sure you have python3 installed.")
+        raise type.exit(1)
 
 
 @app.command()

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -141,7 +141,7 @@ def start(
             console.print(
                 f"Error while executing `{start_server_cmd}`: {result.stderr}"
             )
-            raise typer.exit(1)
+            raise typer.Exit(1)
     except FileNotFoundError:
         console.print("python3 command was not found. Make sure you have python3 installed.")
         raise typer.Exit(1)

--- a/runhouse/rns/hardware/cluster.py
+++ b/runhouse/rns/hardware/cluster.py
@@ -465,7 +465,7 @@ class Cluster(Resource):
         if resync_rh:
             self._sync_runhouse_to_cluster(_install_url=_rh_install_url)
         logfile = f"cluster_server_{self.name}.log"
-        http_server_cmd = "python -m runhouse.servers.http.http_server"
+        http_server_cmd = "runhouse start"
         kill_proc_cmd = f'pkill -f "{http_server_cmd}"'
         # 2>&1 redirects stderr to stdout
         screen_cmd = (


### PR DESCRIPTION
This PR replaces usage of python with python3 in command `python -m runhouse.servers.http.http_server`
Also adds logging around subprocess executing this command to log relevant error if execution is unsuccessul.
