### PR TITLE
Sphinx JSON builder with global TOC

### DIFF
--- a/docs/_ext/json_globaltoc.py
+++ b/docs/_ext/json_globaltoc.py
@@ -1,22 +1,21 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from sphinx.application import Sphinx
-from sphinxcontrib.serializinghtml import JSONHTMLBuilder
 from sphinx.environment.adapters.toctree import TocTree
+from sphinxcontrib.serializinghtml import JSONHTMLBuilder
 
-__version__ = '0.0.1'
+__version__ = "0.0.1"
+
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_builder(SphinxGlobalTOCJSONHTMLBuilder, override=True)
 
-    return {
-        'version': __version__,
-        'parallel_read_safe': True
-    }
+    return {"version": __version__, "parallel_read_safe": True}
+
 
 class SphinxGlobalTOCJSONHTMLBuilder(JSONHTMLBuilder):
 
-    name: str = 'json'
+    name: str = "json"
 
     def get_doc_context(self, docname: str, body: str, metatags: str) -> Dict[str, Any]:
         """
@@ -37,9 +36,10 @@ class SphinxGlobalTOCJSONHTMLBuilder(JSONHTMLBuilder):
         # Get the entire doctree.  It is the 3rd argument (``collapse``) that
         # does this.  If you set that to ``True`` you will only get the submenu
         # HTML included if you are on a page that is within that submenu.
-        self_toctree = TocTree(self.env).get_toctree_for("index", self, False, titles_only=True, includehidden=False, maxdepth=2)
+        self_toctree = TocTree(self.env).get_toctree_for(
+            "index", self, False, titles_only=True, includehidden=False, maxdepth=2
+        )
         # self_toctree = global_toctree_for_doc(self.env, "index", self, collapse=False, titles_only=True)
         toctree = self.render_partial(self_toctree)["fragment"]
-        doc['globaltoc'] = toctree
+        doc["globaltoc"] = toctree
         return doc
-

--- a/docs/_ext/json_globaltoc.py
+++ b/docs/_ext/json_globaltoc.py
@@ -27,10 +27,8 @@ class SphinxGlobalTOCJSONHTMLBuilder(JSONHTMLBuilder):
         Note:
 
             We're rendering the **full global toc** for the entire documentation
-            set into every page.  We do this so that you can just look at the
-            ``master_doc`` and extract its ``globaltoc`` key to get the sitemap
-            for the entire set.  Otherwise you'd have to walk through every page
-            in the set and merge their individual HTML blobs into a whole.
+            set into every page. We do this to easily render the toc on each
+            page and allow for a unique toc for each branch and repo version.
         """
         doc = super().get_doc_context(docname, body, metatags)
         # Get the entire doctree.  It is the 3rd argument (``collapse``) that
@@ -39,7 +37,6 @@ class SphinxGlobalTOCJSONHTMLBuilder(JSONHTMLBuilder):
         self_toctree = TocTree(self.env).get_toctree_for(
             "index", self, False, titles_only=True, includehidden=False, maxdepth=2
         )
-        # self_toctree = global_toctree_for_doc(self.env, "index", self, collapse=False, titles_only=True)
         toctree = self.render_partial(self_toctree)["fragment"]
         doc["globaltoc"] = toctree
         return doc

--- a/docs/_ext/json_globaltoc.py
+++ b/docs/_ext/json_globaltoc.py
@@ -1,0 +1,45 @@
+from typing import Dict, Any
+
+from sphinx.application import Sphinx
+from sphinxcontrib.serializinghtml import JSONHTMLBuilder
+from sphinx.environment.adapters.toctree import TocTree
+
+__version__ = '0.0.1'
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_builder(SphinxGlobalTOCJSONHTMLBuilder, override=True)
+
+    return {
+        'version': __version__,
+        'parallel_read_safe': True
+    }
+
+class SphinxGlobalTOCJSONHTMLBuilder(JSONHTMLBuilder):
+
+    name: str = 'json'
+
+    def get_doc_context(self, docname: str, body: str, metatags: str) -> Dict[str, Any]:
+        """
+        Extends :py:class:`sphinxcontrib.serializinghtml.JSONHTMLBuilder`.
+
+        Add a ``globaltoc`` key to our document that contains the HTML for the
+        global table of contents.
+
+        Note:
+
+            We're rendering the **full global toc** for the entire documentation
+            set into every page.  We do this so that you can just look at the
+            ``master_doc`` and extract its ``globaltoc`` key to get the sitemap
+            for the entire set.  Otherwise you'd have to walk through every page
+            in the set and merge their individual HTML blobs into a whole.
+        """
+        doc = super().get_doc_context(docname, body, metatags)
+        # Get the entire doctree.  It is the 3rd argument (``collapse``) that
+        # does this.  If you set that to ``True`` you will only get the submenu
+        # HTML included if you are on a page that is within that submenu.
+        self_toctree = TocTree(self.env).get_toctree_for("index", self, False, titles_only=True, includehidden=False, maxdepth=2)
+        # self_toctree = global_toctree_for_doc(self.env, "index", self, collapse=False, titles_only=True)
+        toctree = self.render_partial(self_toctree)["fragment"]
+        doc['globaltoc'] = toctree
+        return doc
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "myst_parser",
     "sphinx_thebe",
     "sphinx_copybutton",
+    "_ext.json_globaltoc",
 ]
 
 autodoc_typehints_format = "short"

--- a/docs/tutorials/examples/distributed.rst
+++ b/docs/tutorials/examples/distributed.rst
@@ -32,6 +32,7 @@ Install dependencies
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-03-20 17:56:13,023 | No auth token provided, so not using RNS API to save and load configs
     INFO | 2023-03-20 17:56:14,334 | NumExpr defaulting to 2 threads.
@@ -121,6 +122,7 @@ hardware.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-03-20 21:01:46,942 | Setting up Function on cluster.
     INFO | 2023-03-20 21:01:46,951 | Installing packages on cluster rh-v100: ['GitPackage: https://github.com/huggingface/accelerate.git@v0.15.0', 'pip:./accelerate', 'transformers', 'datasets', 'evaluate', 'tqdm', 'scipy', 'scikit-learn', 'tensorboard', 'torch --upgrade --extra-index-url https://download.pytorch.org/whl/cu117']
@@ -156,6 +158,7 @@ then send the function to run on our GPU as well
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-03-20 19:56:15,257 | Writing out function function to /content/launch_training_fn.py as functions serialized in notebooks are brittle. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).
     INFO | 2023-03-20 19:56:15,262 | Setting up Function on cluster.
@@ -184,6 +187,7 @@ hardware!
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-03-20 20:11:45,415 | Running launch_training via gRPC
     INFO | 2023-03-20 20:11:45,718 | Time to send message: 0.3 seconds

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -200,7 +200,11 @@ class HTTPClient:
             elif output_type == OutputType.CONFIG:
                 # If this was a `.remote` call, we don't need to recreate the system and connection, which can be
                 # slow, we can just set it explicitly.
-                if system and "system" in result and system.rns_address == result["system"]:
+                if (
+                    system
+                    and "system" in result
+                    and system.rns_address == result["system"]
+                ):
                     result["system"] = system
                 non_generator_result = Resource.from_config(result, dryrun=True)
             elif output_type == OutputType.RESULT:


### PR DESCRIPTION
- Adds a custom extension to sphinx to append a global TOC to JSON output
- Updates the distributed example to use `:class: code-output` for clarifying output code blocks
- Replaces image blobs with URLs in large `inference.rst` file