### PR TITLE
Handle case where `nvidia-smi` is not installed

### DIFF
--- a/runhouse/rns/packages/package.py
+++ b/runhouse/rns/packages/package.py
@@ -226,7 +226,7 @@ class Package(Resource):
         try:
             subprocess.check_call(["nvidia-smi"])
             return cuda_version
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return "cpu"
 
     @staticmethod


### PR DESCRIPTION
There is an edge case in [`check_call`](https://docs.python.org/3/library/subprocess.html#subprocess.check_call) where, if the process was not able to be started, the underlying exception is propagated. In my case, `nvidia-smi` is not installed, so my `rh.function()` call crashed with a `FileNotFoundError`.

The relevant portion of the docs (emphasis mine):

> Run command with arguments. Wait for command to complete. If the return code was zero then return, otherwise raise [CalledProcessError](https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError). The [CalledProcessError](https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError) object will have the return code in the [returncode](https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError.returncode) attribute. **If [check_call()](https://docs.python.org/3/library/subprocess.html#subprocess.check_call) was unable to start the process it will propagate the exception that was raised.**