### PR TITLE
Updating docs links and code output syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/runhouse_.svg?style=social&label=@runhouse_)](https://twitter.com/runhouse_)
 
 [![Website](https://img.shields.io/badge/run.house-green)](https://www.run.house)
-[![Docs](https://img.shields.io/badge/docs-blue)](https://runhouse-docs.readthedocs-hosted.com/en/latest/index.html)
+[![Docs](https://img.shields.io/badge/docs-blue)](https://www.run.house/docs)
 [![Den](https://img.shields.io/badge/runhouse_den-purple)](https://www.run.house/login)
 
 
@@ -113,7 +113,7 @@ Notebooks, scripts, pipeline nodes, etc. are all fair game.
 
 ## 🐣 Getting Started
 
-Please see the [Getting Started guide](https://runhouse-docs.readthedocs-hosted.com/en/latest/tutorials/quick_start.html).
+Please see the [Getting Started guide](https://www.run.house/docs/tutorials/quick_start).
 
 tldr;
 ```commandline
@@ -181,7 +181,7 @@ Please reach out (first name at run.house) to contribute or share feedback!
 
 ## 👨‍🏫 Learn More
 
-[**Docs**](https://runhouse-docs.readthedocs-hosted.com/en/latest/index.html):
+[**Docs**](https://www.run.house/docs):
 Detailed API references, basic API examples and walkthroughs, end-to-end tutorials, and high-level architecture overview.
 
 [**Funhouse Repo**](https://github.com/run-house/funhouse): Standalone Runhouse apps to try out fun ML ideas,

--- a/docs/notebooks/basics/accessibility.ipynb
+++ b/docs/notebooks/basics/accessibility.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "The Secrets API provides a simple interface for storing and retrieving secrets to a allow a more seamless experience when accessing resources across environments. It provides a simple interface for storing and retrieving secrets from a variety of providers (e.g. AWS, Azure, GCP, Hugging Face, Github, etc.) as well as SSH Keys and custom secrets, and stores them in Hashicorp Vault (and never on Runhouse servers).\n",
     "\n",
-    "The [API](https://runhouse-docs.readthedocs-hosted.com/en/main/api/python/secrets.html) handles secrets interactions between\n",
+    "The [API](https://www.run.house/docs/api/python/secrets) handles secrets interactions between\n",
     "\n",
     "* config files\n",
     "* environment variables\n",

--- a/docs/notebooks/basics/compute.ipynb
+++ b/docs/notebooks/basics/compute.ipynb
@@ -889,7 +889,7 @@
     "id": "NJL0TXCnKvWr"
    },
    "source": [
-    "Function logs are also automatically output onto a log file on cluster it is run on. You can refer to [Runhouse Logging Docs](https://runhouse-docs.readthedocs-hosted.com/en/latest/debugging_logging.html) for more information on accessing these logs."
+    "Function logs are also automatically output onto a log file on cluster it is run on. You can refer to [Runhouse Logging Docs](https://www.run.house/docs/debugging_logging) for more information on accessing these logs."
    ]
   },
   {
@@ -1446,7 +1446,7 @@
     "id": "agWXh0XoYnUw"
    },
    "source": [
-    "Now that you understand the basics, feel free to play around with more complicated scenarios! You can also check out our additional API and example usage tutorials on our [docs site](https://runhouse-docs.readthedocs-hosted.com/en/latest/index.html)."
+    "Now that you understand the basics, feel free to play around with more complicated scenarios! You can also check out our additional API and example usage tutorials on our [docs site](https://www.run.house/docs)."
    ]
   },
   {

--- a/docs/notebooks/basics/data.ipynb
+++ b/docs/notebooks/basics/data.ipynb
@@ -683,7 +683,7 @@
     "id": "-UaQpzxo9FA1"
    },
    "source": [
-    "Now that you understand the basics, feel free to play around with more complicated scenarios! You can also check out our additional API and example usage tutorials on our [docs site](https://runhouse-docs.readthedocs-hosted.com/en/latest/index.html)."
+    "Now that you understand the basics, feel free to play around with more complicated scenarios! You can also check out our additional API and example usage tutorials on our [docs site](https://www.run.house/docs)."
    ]
   },
   {

--- a/docs/notebooks/examples/distributed.ipynb
+++ b/docs/notebooks/examples/distributed.ipynb
@@ -80,7 +80,7 @@
         "### On-Demand Cluster (AWS, Azure, GCP, or LambdaLabs)\n",
         "\n",
         "For instructions on setting up cloud access for on-demand clusters, please refer to\n",
-        "[Hardware Setup](https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup)."
+        "[Cluster Setup](https://www.run.house/docs/tutorials/quick_start#cluster-setup)."
       ]
     },
     {

--- a/docs/notebooks/examples/training.ipynb
+++ b/docs/notebooks/examples/training.ipynb
@@ -85,7 +85,7 @@
       "source": [
         "## Hardware Setup\n",
         "\n",
-        "If you're not already familiar with setting up a Runhouse cluster, please first refer to [Cluster Setup](https://runhouse-docs.readthedocs-hosted.com/en/latest/tutorials/quick_start.html#cluster-setup) for a more introductory and in-depth walkthrough."
+        "If you're not already familiar with setting up a Runhouse cluster, please first refer to [Cluster Setup](https://www.run.house/docs/tutorials/quick_start#cluster-setup) for a more introductory and in-depth walkthrough."
       ]
     },
     {
@@ -228,7 +228,7 @@
         "\n",
         "Note that all the code inside the function runs on our gpu cluster, which means there's no need to install anything locally either.\n",
         "\n",
-        "For a more in-depth walkthrough of Runhouse's function and env APIs, please refer to the [Compute API Tutorial](https://runhouse-docs.readthedocs-hosted.com/en/latest/tutorials/api/compute.html)."
+        "For a more in-depth walkthrough of Runhouse's function and env APIs, please refer to the [Compute API Tutorial](https://www.run.house/docs/tutorials/api/compute)."
       ]
     },
     {

--- a/docs/tutorials/api/accessibility.rst
+++ b/docs/tutorials/api/accessibility.rst
@@ -40,7 +40,7 @@ Hugging Face, Github, etc.) as well as SSH Keys and custom secrets, and
 stores them in Hashicorp Vault (and never on Runhouse servers).
 
 The
-`API <https://runhouse-docs.readthedocs-hosted.com/en/main/api/python/secrets.html>`__
+`API <https://www.run.house/docs/api/python/secrets>`__
 handles secrets interactions between
 
 * config files
@@ -73,6 +73,7 @@ new secrets from your environment.
 
 
 .. parsed-literal::
+    :class: code-output
 
     [<runhouse.rns.secrets.aws_secrets.AWSSecrets at 0x106743b20>,
      <runhouse.rns.secrets.azure_secrets.AzureSecrets at 0x1067439d0>,
@@ -95,6 +96,7 @@ new secrets from your environment.
 
 
 .. parsed-literal::
+    :class: code-output
 
     WARNING | 2023-06-21 08:03:55,081 | Received secrets ['azure'] which Runhouse did not auto-detect as configured. For cloud providers, you may want to run `sky check` to double check that they're enabled and to see instructions on how to enable them.
     INFO | 2023-06-21 08:03:55,084 | Getting secrets from Vault.
@@ -183,6 +185,7 @@ lives in the current folder.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-21 22:15:57,611 | Saving config for ~/aws_cluster to: /Users/caroline/Documents/runhouse/runhouse/rh/aws_cluster/config.json
 
@@ -190,6 +193,7 @@ lives in the current folder.
 
 
 .. parsed-literal::
+    :class: code-output
 
     <runhouse.rns.hardware.on_demand_cluster.OnDemandCluster at 0x1661c7040>
 
@@ -201,6 +205,7 @@ lives in the current folder.
 
 
 .. parsed-literal::
+    :class: code-output
 
     {
         "name": "~/aws_cluster",
@@ -227,6 +232,7 @@ the resource factory method, passing in only the name.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-21 22:20:03,710 | Loading config from local file /Users/caroline/Documents/runhouse/runhouse/rh/aws_cluster/config.json
 
@@ -234,6 +240,7 @@ the resource factory method, passing in only the name.
 
 
 .. parsed-literal::
+    :class: code-output
 
     <runhouse.rns.hardware.on_demand_cluster.OnDemandCluster at 0x1231023d0>
 
@@ -245,6 +252,7 @@ the resource factory method, passing in only the name.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-21 22:20:20,156 | Loading config from local file /Users/caroline/Documents/runhouse/runhouse/rh/aws_cluster/config.json
 
@@ -252,6 +260,7 @@ the resource factory method, passing in only the name.
 
 
 .. parsed-literal::
+    :class: code-output
 
     <runhouse.rns.hardware.on_demand_cluster.OnDemandCluster at 0x12324b400>
 
@@ -283,6 +292,7 @@ The following resource, whose name ``my_blob`` does not begin with
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-21 22:38:05,351 | Creating new s3 folder if it does not already exist in path: /runhouse-blob/d57201aa760b4893800c7e3782117b3b/carolineechen
     INFO | 2023-06-21 22:38:05,368 | Found credentials in shared credentials file: ~/.aws/credentials
@@ -294,6 +304,7 @@ The following resource, whose name ``my_blob`` does not begin with
 
 
 .. parsed-literal::
+    :class: code-output
 
     <runhouse.rns.blob.Blob at 0x16703ee80>
 
@@ -312,6 +323,7 @@ into!
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-21 22:38:10,598 | Attempting to load config for /carolineechen/my_blob from RNS.
     INFO | 2023-06-21 22:38:10,936 | Creating new s3 folder if it does not already exist in path: /runhouse-blob/d57201aa760b4893800c7e3782117b3b/carolineechen
@@ -321,6 +333,7 @@ into!
 
 
 .. parsed-literal::
+    :class: code-output
 
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
@@ -341,6 +354,7 @@ to notify them.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-21 22:38:14,252 | Attempting to load config for /carolineechen/my_blob from RNS.
 
@@ -348,5 +362,6 @@ to notify them.
 
 
 .. parsed-literal::
+    :class: code-output
 
     ({}, {'teammate1@email.com': 'write'})

--- a/docs/tutorials/api/compute.rst
+++ b/docs/tutorials/api/compute.rst
@@ -506,7 +506,7 @@ To stream logs to local during the remote function call, pass in
 
 Function logs are also automatically output onto a log file on cluster
 it is run on. You can refer to `Runhouse Logging
-Docs <https://runhouse-docs.readthedocs-hosted.com/en/latest/debugging_logging.html>`__
+Docs <https://www.run.house/docs/debugging_logging>`__
 for more information on accessing these logs.
 
 Modules
@@ -577,21 +577,25 @@ scripts, the class can be defined in the same file as the script.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-09-05 19:57:10.034443 | Calling PIDModule.getpid
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method getpid on module PIDModule
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-09-05 19:57:10.308916 | Time to call PIDModule.getpid: 0.27 seconds
 
 
 .. parsed-literal::
+    :class: code-output
 
     21806
 
@@ -663,6 +667,7 @@ automatically set up (packages are installed) on the cluster.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 04:44:06.955053 | Copying package from file:///Users/caroline/Documents/runhouse/runhouse to: cpu-cluster
     INFO | 2023-08-29 04:44:08.250678 | Copying package from file:///Users/caroline/Documents/runhouse/runhouse to: cpu-cluster
@@ -670,17 +675,20 @@ automatically set up (packages are installed) on the cluster.
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method _set_env_vars on module env_20230829_044402
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 04:44:10.028261 | Time to call env_20230829_044402._set_env_vars: 0.29 seconds
     INFO | 2023-08-29 04:44:10.029212 | Calling env_20230829_044402.install
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method install on module env_20230829_044402
     Installing package: Package: numpy
@@ -704,6 +712,7 @@ automatically set up (packages are installed) on the cluster.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 04:44:19.111342 | Time to call env_20230829_044402.install: 9.08 seconds
 
@@ -748,18 +757,21 @@ As with the base env, we can set up a conda env on the cluster with:
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 04:48:21.600485 | Copying package from file:///Users/caroline/Documents/runhouse/runhouse to: cpu-cluster
     INFO | 2023-08-29 04:48:23.132095 | Calling new_env.install
 
 
 .. parsed-literal::
+    :class: code-output
 
     new_env servlet: Calling method install on module new_env
     Env already installed, skipping
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 04:48:24.358608 | Time to call new_env.install: 1.23 seconds
 
@@ -777,16 +789,19 @@ the cluster:
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 05:14:08.725396 | Running command on cpu-cluster: conda run -n new_env python3 -c "import numpy; print(numpy.__version__)"
 
 
 .. parsed-literal::
+    :class: code-output
 
     1.25.2
 
 
 .. parsed-literal::
+    :class: code-output
 
     [(0, '1.25.2\n\n', '')]
 
@@ -828,6 +843,7 @@ but can be outside the function if being used in a Python script.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 05:20:27.959315 | Writing out function function to /Users/caroline/Documents/runhouse/runhouse/docs/notebooks/basics/add_lists_fn.py. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).
     INFO | 2023-08-29 05:20:27.962973 | Setting up Function on cluster.
@@ -836,6 +852,7 @@ but can be outside the function if being used in a Python script.
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method install on module env_20230829_052021
     Installing package: Package: numpy
@@ -849,6 +866,7 @@ but can be outside the function if being used in a Python script.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 05:20:32.575986 | Time to call env_20230829_052021.install: 3.17 seconds
     INFO | 2023-08-29 05:20:32.774676 | Function setup complete.
@@ -856,11 +874,13 @@ but can be outside the function if being used in a Python script.
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method call on module add_lists
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 05:20:33.086075 | Time to call add_lists.call: 0.29 seconds
 
@@ -868,6 +888,7 @@ but can be outside the function if being used in a Python script.
 
 
 .. parsed-literal::
+    :class: code-output
 
     array([3, 5, 7])
 
@@ -876,7 +897,7 @@ but can be outside the function if being used in a Python script.
 Now that you understand the basics, feel free to play around with more
 complicated scenarios! You can also check out our additional API and
 example usage tutorials on our `docs
-site <https://runhouse-docs.readthedocs-hosted.com/en/latest/index.html>`__.
+site <https://www.run.house/docs>`__.
 
 Cluster Termination
 -------------------

--- a/docs/tutorials/api/data.rst
+++ b/docs/tutorials/api/data.rst
@@ -81,12 +81,14 @@ use ``.to()`` to send the folder to a remote cluster.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 19:45:52.597164 | Copying folder from file:///Users/caroline/Documents/runhouse/runhouse/docs/notebooks/basics/sample_folder to: cpu-cluster, with path: sample_folder
     INFO | 2023-08-29 19:45:54.633598 | Running command on cpu-cluster: ls sample_folder
 
 
 .. parsed-literal::
+    :class: code-output
 
     0.txt
     1.txt
@@ -98,6 +100,7 @@ use ``.to()`` to send the folder to a remote cluster.
 
 
 .. parsed-literal::
+    :class: code-output
 
     [(0, '0.txt\n1.txt\n2.txt\n3.txt\n4.txt\n', '')]
 
@@ -112,6 +115,7 @@ You can also send the folder to file storage, such as S3, GS, and Azure.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 19:47:47.618511 | Copying folder from file:///Users/caroline/Documents/runhouse/runhouse/docs/notebooks/basics/sample_folder to: s3, with path: /runhouse-folder/a6f195296945409da432b2981f984ae7
     INFO | 2023-08-29 19:47:47.721743 | Found credentials in shared credentials file: ~/.aws/credentials
@@ -121,6 +125,7 @@ You can also send the folder to file storage, such as S3, GS, and Azure.
 
 
 .. parsed-literal::
+    :class: code-output
 
     ['0.txt', '1.txt', '2.txt', '3.txt', '4.txt']
 
@@ -165,6 +170,7 @@ bucket using Runhouse.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 19:55:29.834000 | Found credentials in shared credentials file: ~/.aws/credentials
 
@@ -176,6 +182,7 @@ bucket using Runhouse.
 
 
 .. parsed-literal::
+    :class: code-output
 
      id grade
       1     a
@@ -196,12 +203,14 @@ To sync over and save the table to a remote cluster, or to local
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 19:59:39.456856 | Copying folder from s3://runhouse-table/sample_table to: cpu-cluster, with path: ~/.cache/runhouse/82d19ef56425409fb92e5d4dfcd389e2
     INFO | 2023-08-29 19:59:39.458405 | Running command on cpu-cluster: aws --version >/dev/null 2>&1 || pip3 install awscli && aws s3 sync --no-follow-symlinks s3://runhouse-table/sample_table ~/.cache/runhouse/82d19ef56425409fb92e5d4dfcd389e2
 
 
 .. parsed-literal::
+    :class: code-output
 
     download: s3://runhouse-table/sample_table/d68a64f755014c049b6e97b120db5d0f.parquet to .cache/runhouse/82d19ef56425409fb92e5d4dfcd389e2/d68a64f755014c049b6e97b120db5d0f.parquet
     download: s3://runhouse-table/sample_table/ebf7bbc1b22e4172b162b723b4b234f2.parquet to .cache/runhouse/82d19ef56425409fb92e5d4dfcd389e2/ebf7bbc1b22e4172b162b723b4b234f2.parquet
@@ -217,6 +226,7 @@ To sync over and save the table to a remote cluster, or to local
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 19:59:49.336813 | Copying folder from s3://runhouse-table/sample_table to: file, with path: /Users/caroline/Documents/runhouse/runhouse/docs/notebooks/basics/sample_table
 
@@ -241,6 +251,7 @@ necessarily in an iterable format.
 
 
 .. parsed-literal::
+    :class: code-output
 
        id grade
     0   1     a
@@ -280,6 +291,7 @@ can be written down or synced to systems.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 20:57:10.570715 | Creating new file folder if it does not already exist in path: /Users/caroline/Documents/runhouse/runhouse
 
@@ -315,6 +327,7 @@ To get the contents from a blob, use ``.fetch()``:
 
 
 .. parsed-literal::
+    :class: code-output
 
     '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]'
 
@@ -323,7 +336,7 @@ To get the contents from a blob, use ``.fetch()``:
 Now that you understand the basics, feel free to play around with more
 complicated scenarios! You can also check out our additional API and
 example usage tutorials on our `docs
-site <https://runhouse-docs.readthedocs-hosted.com/en/latest/index.html>`__.
+site <https://www.run.house/docs>`__.
 
 Cluster Termination
 -------------------

--- a/docs/tutorials/examples/distributed.rst
+++ b/docs/tutorials/examples/distributed.rst
@@ -45,8 +45,8 @@ On-Demand Cluster (AWS, Azure, GCP, or LambdaLabs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For instructions on setting up cloud access for on-demand clusters,
-please refer to `Hardware
-Setup <https://runhouse-docs.readthedocs-hosted.com/en/stable/rh_primitives/cluster.html#hardware-setup>`__.
+please refer to `Cluster
+Setup <https://www.run.house/docs/tutorials/quick_start#cluster-setup>`__.
 
 .. code:: python
 

--- a/docs/tutorials/examples/inference.rst
+++ b/docs/tutorials/examples/inference.rst
@@ -41,6 +41,7 @@ Install Runhouse
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-02-07 15:37:56,202 | Loaded Runhouse config from /root/.rh/config.yaml
     INFO | 2023-02-07 15:37:56,965 | NumExpr defaulting to 2 threads.
@@ -77,6 +78,7 @@ Install Runhouse
 
 
 .. parsed-literal::
+    :class: code-output
 
     Token: ··········
     Upload your local config to Runhouse? [y/N]: y
@@ -171,6 +173,7 @@ while the model actually runs on an A100/A10G in the cloud.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-02-07 16:10:42,374 | Running sd_generate via gRPC
     INFO | 2023-02-07 16:11:27,874 | Time to send message: 45.5 seconds
@@ -543,6 +546,7 @@ only be observed in future runs.
 
 
 .. parsed-literal::
+    :class: code-output
 
     WARNING | 2023-02-07 16:29:32,700 | /usr/local/lib/python3.8/dist-packages/ipyplot/_utils.py:95: FutureWarning: The input object of type 'Image' is an array-like implementing one of the corresponding protocols (`__array__`, `__array_interface__` or `__array_struct__`); but not a sequence (or 0-D). In the future, this object will be coerced as if it was first converted using `np.array(obj)`. To retain the old behaviour, you have to either modify the type 'Image', or assign to an empty array created with `np.empty(correct_shape, dtype=object)`.
       return np.asarray(seq, dtype=type(seq[0]))
@@ -884,6 +888,7 @@ then pipe the outputs into our Stable Diffusion service.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-02-07 16:15:17,183 | Writing out function to /content/send_fn.py as functions serialized in notebooks are brittle. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).
     WARNING | 2023-02-07 16:15:17,186 | You should name Functions that are created in notebooks to avoid naming collisions between the modules that are created to hold their functions (i.e. "send_fn.py" errors.
@@ -906,6 +911,7 @@ then pipe the outputs into our Stable Diffusion service.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-02-07 16:15:19,115 | Running causal_lm_generate via gRPC
     INFO | 2023-02-07 16:19:04,544 | Time to send message: 225.42 seconds
@@ -925,6 +931,7 @@ then pipe the outputs into our Stable Diffusion service.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-02-07 16:25:41,344 | Running sd_generate_pinned via gRPC
     INFO | 2023-02-07 16:26:20,268 | Time to send message: 38.92 seconds

--- a/docs/tutorials/examples/training.rst
+++ b/docs/tutorials/examples/training.rst
@@ -37,6 +37,7 @@ Install Runhouse
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-08 18:12:34,980 | No auth token provided, so not using RNS API to save and load configs
     INFO | 2023-06-08 18:12:36,499 | NumExpr defaulting to 2 threads.
@@ -47,7 +48,7 @@ Hardware Setup
 
 If you’re not already familiar with setting up a Runhouse cluster,
 please first refer to `Cluster
-Setup <https://runhouse-docs.readthedocs-hosted.com/en/latest/tutorials/quick_start.html#cluster-setup>`__
+Setup <https://www.run.house/docs/tutorials/quick_start#cluster-setup>`__
 for a more introductory and in-depth walkthrough.
 
 .. code:: python
@@ -73,12 +74,14 @@ for a more introductory and in-depth walkthrough.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-08 18:30:56,926 | Attempting to load config for /carolineechen/rh-a10x from RNS.
 
 
 
 .. parsed-literal::
+    :class: code-output
 
     Output()
 
@@ -102,7 +105,7 @@ which means there’s no need to install anything locally either.
 
 For a more in-depth walkthrough of Runhouse’s function and env APIs,
 please refer to the `Compute API
-Tutorial <https://runhouse-docs.readthedocs-hosted.com/en/latest/tutorials/api/compute.html>`__.
+Tutorial <https://www.run.house/docs/tutorials/api/compute>`__.
 
 .. code:: python
 
@@ -134,6 +137,7 @@ Tutorial <https://runhouse-docs.readthedocs-hosted.com/en/latest/tutorials/api/c
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-08 18:43:59,993 | Writing out function function to /content/load_and_preprocess_fn.py. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).
     INFO | 2023-06-08 18:44:00,000 | Setting up Function on cluster.
@@ -164,6 +168,7 @@ Data API Tutorial for more information on that.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-08 18:52:55,092 | Running load_and_preprocess via HTTP
     INFO | 2023-06-08 18:52:55,191 | Time to call remote function: 0.1 seconds
@@ -233,6 +238,7 @@ Training from locally defined functions
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-08 18:53:03,726 | Writing out function function to /content/train_fn.py. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).
     INFO | 2023-06-08 18:53:03,730 | Setting up Function on cluster.
@@ -248,6 +254,7 @@ To run the function, call it as you would any Python function. Pass in the datas
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-08 18:53:21,114 | Running train via HTTP
     INFO | 2023-06-08 18:56:10,362 | Time to call remote function: 169.25 seconds
@@ -498,6 +505,7 @@ repo <https://github.com/huggingface/accelerate>`__.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-06-08 19:57:11,991 | Installing packages on cluster rh-a10x: ['GitPackage: https://github.com/huggingface/accelerate.git@v0.18.0']
 
@@ -542,6 +550,7 @@ inactivity.
 
 
 .. parsed-literal::
+    :class: code-output
 
     Terminating 1 cluster: rh-a10x. Proceed? [Y/n]: y
     [2K[1;36mTerminating 1 cluster[0m [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [35m  0%[0m [36m-:--:--[0m

--- a/docs/tutorials/quick_start.rst
+++ b/docs/tutorials/quick_start.rst
@@ -244,6 +244,7 @@ CPUs available.
 
 
 .. parsed-literal::
+    :class: code-output
 
     'Num cpus: 10'
 
@@ -295,6 +296,7 @@ instead of local.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 03:03:52.826786 | Writing out function function to /Users/caroline/Documents/runhouse/runhouse/docs/notebooks/basics/num_cpus_fn.py. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).
     /Users/caroline/Documents/runhouse/runhouse/runhouse/rns/function.py:106: UserWarning: ``reqs`` and ``setup_cmds`` arguments has been deprecated. Please use ``env`` instead.
@@ -309,6 +311,7 @@ instead of local.
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method install on module env_20230829_030349
     Installing package: Package: runhouse
@@ -319,6 +322,7 @@ instead of local.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 03:03:58.230209 | Time to call env_20230829_030349.install: 1.75 seconds
     INFO | 2023-08-29 03:03:58.462054 | Function setup complete.
@@ -330,16 +334,19 @@ instead of local.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 03:04:01.105011 | Calling num_cpus_cluster.call
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method call on module num_cpus_cluster
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 03:04:01.384439 | Time to call num_cpus_cluster.call: 0.28 seconds
 
@@ -347,6 +354,7 @@ instead of local.
 
 
 .. parsed-literal::
+    :class: code-output
 
     'Num cpus: 8'
 
@@ -365,6 +373,7 @@ environment, or share it with your collaborators.
 
 
 .. parsed-literal::
+    :class: code-output
 
     <runhouse.rns.function.Function at 0x104634ee0>
 
@@ -388,6 +397,7 @@ as long as you are logged in to your Runhouse account.
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 03:04:24.820884 | Checking server cpu-cluster
     INFO | 2023-08-29 03:04:25.850301 | Server cpu-cluster is up.
@@ -395,11 +405,13 @@ as long as you are logged in to your Runhouse account.
 
 
 .. parsed-literal::
+    :class: code-output
 
     base servlet: Calling method call on module num_cpus_cluster
 
 
 .. parsed-literal::
+    :class: code-output
 
     INFO | 2023-08-29 03:04:26.127098 | Time to call num_cpus_cluster.call: 0.27 seconds
 
@@ -407,6 +419,7 @@ as long as you are logged in to your Runhouse account.
 
 
 .. parsed-literal::
+    :class: code-output
 
     'Num cpus: 8'
 


### PR DESCRIPTION
- Changes `run-house.readthedocs` links to `run.house/docs`
- Adds `code-output` class to parsed literals