### PR TITLE
draft(docker-env): adds support to test with containerized http server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+
+FROM python:3.9
+
+WORKDIR /app
+
+# COPY requirements.txt .
+
+COPY . .
+
+RUN pip install -e .
+
+EXPOSE 50052
+
+# CMD ["python", "-m", "runhouse.servers.http.http_server"]
+CMD ["runhouse", "start"]

--- a/dockerize.py
+++ b/dockerize.py
@@ -1,0 +1,40 @@
+# def local_docker_cluster():
+#     port = 6379
+#     # Check if container is already running
+#     import docker
+#     import runhouse as rh
+#     import os
+#     client = docker.from_env()
+#     if "rh_cluster" not in [c.name for c in client.containers.list(filters={"status": "running"})]:
+#         client.images.pull("berkeleyskypilot/skypilot:latest")
+#         print("got here")
+#         from pathlib import Path
+#         import pkgutil
+#         print("got here now ")
+#         runhouse_path = Path(pkgutil.get_loader("runhouse").path).parent.parent
+#         if "rh_cluster" in [c.name for c in client.containers.list(all=True)]:
+#             client.containers.get("rh_cluster").remove()
+#             print("in here")
+#         client.containers.run("berkeleyskypilot/skypilot:latest",
+#                               command="tail -f /dev/null",
+#                               name="rh_cluster",
+#                               detach=True,
+#                               shm_size="2.15gb",
+#                               auto_remove=True,
+#                               ports={port: port},
+#                               volumes={os.path.expanduser("~/.sky"): {"bind": "/root/.sky", "mode": "rw"},
+#                                        runhouse_path: {"bind": "/root/runhouse", "mode": "rw"}
+#                                        }
+#                               )
+#     c = rh.cluster(name="local-docker", host=f"localhost:{port}", ssh_creds={"ssh_user": "root", "ssh_proxy_command": "docker exec -it rh_cluster /bin/bash"})
+#     c.up_if_not()
+#     c.install_packages(["pytest"])
+#     return c
+
+# local_docker_cluster()
+
+import runhouse as rh
+port = 50052
+c = rh.cluster(name="local-docker", host=f"localhost:{port}", ssh_creds={"ssh_user": "root", "ssh_proxy_command": "docker exec -it ro-http-server-container /bin/bash"})
+c.up_if_not()
+print(c.is_up())


### PR DESCRIPTION
Task objective: Create a testing ground where we can create a Runhouse cluster composed of a docker container; wherein this container runs Runhouse's http server. 

Goal: Run a test that sends a function to this Runhouse cluster and calls the function. 

Current state: 
@dongreenberg has provided the initial pytest script he wrote to get this working. He mentioned the HTTP server would not startup even after running `runhouse restart` 

I wrote a Dockerfile to containerize the HTTP server and it starts up the HTTP server. However, looking at `docker logs` the following error surfaces: 

Dockerfile commands: 
Build image: `docker build -t ro-http-server-image .`
Run container: `docker run -d -p 50052:50052 --name ro-http-server-container ro-http-server-image`

See all containers: `docker ps -a`
Remove stopped containers: `docker container prune` 

```
Executing `/usr/local/bin/python -m runhouse.servers.http.http_server`
ERROR | 2023-09-18 18:53:34.805814 | Failed to collect cluster stats: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.UNAVAILABLE
        details = "failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:6379: Failed to connect to remote host: Connection refused"
        debug_error_string = "UNKNOWN:failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:6379: Failed to connect to remote host: Connection refused {grpc_status:14, created_time:"2023-09-18T18:53:34.805264188+00:00"}"
>
INFO:     Started server process [29]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:50052 (Press CTRL+C to quit)
```

Furthermore, in dockerize.py I run the following script to see if an rh cluster that uses this container can be launched: 
```
import runhouse as rh
port = 50052
c = rh.cluster(name="local-docker", host=f"localhost:{port}", ssh_creds={"ssh_user": "root", "ssh_proxy_command": "docker exec -it ro-http-server-container /bin/bash"})
c.up_if_not()
print(c.is_up())
```

An important question brought up in standup was whether the `ssh_proxy_command` specified above actually works as a parameter in `rh_cluster` as so. Worth exploring what rh_cluster's docker support looks like. (If you just run `docker exec -it ro-http-server-container /bin/bash` it works fine and you can get inside the container) 

Running the script above does not yield the expected logs (ie. starting up the Ray runtime etc etc.). However, `c.is_up()` prints `True.`

That is the current state of this task. Please feel free to pick up from here. I will also be continually working on this. 



