### PR TITLE
feat(k8s): adds kubernetes support to Runhouse

### DIFF
--- a/runhouse/__init__.py
+++ b/runhouse/__init__.py
@@ -10,6 +10,8 @@ from runhouse.resources.hardware import (
     OnDemandCluster,
     sagemaker_cluster,
     SageMakerCluster,
+    kubernetes_cluster,
+    KubernetesCluster
 )
 
 # WARNING: Any built-in module that is imported here must be capitalized followed by all lowercase, or we will

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -103,7 +103,27 @@ def _start_server(restart, restart_ray, screen, create_logfile=True):
 
     try:
         # We do these one by one so it's more obvious where the error is if there is one
-        for cmd in cmds:
+        for i, cmd in enumerate(cmds):
+
+            last_cmd = i == len(cmds)-1
+
+            # need to clean up this execution logic 
+            if last_cmd:
+                try:
+                    # consider cleaning up this command to parameterize it more
+                    new_str = "nohup /opt/conda/bin/python -m runhouse.servers.http.http_server >> /home/sky/.rh/server.log 2>&1 &"
+                    console.print(f"Executing `{new_str}`")
+                    output = subprocess.run(new_str, shell=True, check=True)
+                    if output.returncode != 0:
+                        reg_output = subprocess.run(shlex.split(cmd), text=True)
+                        if reg_output.returncode != 0:
+                            console.print(f"Error while executing `{cmd}`")
+                            raise typer.Exit(1)
+                        return 
+                    return
+                except subprocess.CalledProcessError as e:
+                    print(f"Error: {e}")    
+
             console.print(f"Executing `{cmd}`")
             result = subprocess.run(shlex.split(cmd), text=True)
             # We don't want to raise an error if the server kill fails, as it may simply not be running

--- a/runhouse/resources/function.py
+++ b/runhouse/resources/function.py
@@ -129,12 +129,16 @@ class Function(Module):
 
         logging.info("Setting up Function on cluster.")
         # To up cluster in case it's not yet up
+
         new_function.system.check_server()
         new_function.name = new_function.name or self.fn_pointers[2]
         # TODO
         # env.name = env.name or (new_function.name + "_env")
-        new_env = env.to(new_function.system, force_install=force_install)
-        new_function.env = new_env
+
+        # temporarily commented out the below to enable k8s support 
+
+        # new_env = env.to(new_function.system, force_install=force_install)
+        # new_function.env = new_env
 
         new_function.dryrun = True
         system.put_resource(new_function, dryrun=True)

--- a/runhouse/resources/hardware/__init__.py
+++ b/runhouse/resources/hardware/__init__.py
@@ -1,5 +1,6 @@
 from .cluster import Cluster
-from .cluster_factory import cluster, ondemand_cluster, sagemaker_cluster
+from .cluster_factory import cluster, ondemand_cluster, sagemaker_cluster, kubernetes_cluster
 from .on_demand_cluster import OnDemandCluster
 from .sagemaker_cluster import SageMakerCluster
+from .kubernetes_cluster import KubernetesCluster
 from .utils import _current_cluster, _get_cluster_from, RESERVED_SYSTEM_NAMES

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -98,6 +98,10 @@ class Cluster(Resource):
             from .sagemaker_cluster import SageMakerCluster
 
             return SageMakerCluster(**config, dryrun=dryrun)
+        elif resource_subtype == "KubernetesCluster":
+            from .kubernetes_cluster import KubernetesCluster
+
+            return KubernetesCluster(**config, dryrun=dryrun)
         else:
             raise ValueError(f"Unknown cluster type {resource_subtype}")
 

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -6,6 +6,7 @@ from runhouse.resources.hardware.utils import RESERVED_SYSTEM_NAMES
 from .cluster import Cluster
 from .on_demand_cluster import OnDemandCluster
 from .sagemaker_cluster import SageMakerCluster
+from .kubernetes_cluster import KubernetesCluster
 
 
 # Cluster factory method
@@ -15,7 +16,7 @@ def cluster(
     ssh_creds: Optional[dict] = None,
     dryrun: bool = False,
     **kwargs,
-) -> Union[Cluster, OnDemandCluster, SageMakerCluster]:
+) -> Union[Cluster, OnDemandCluster, SageMakerCluster, KubernetesCluster]:
     """
     Builds an instance of :class:`Cluster`.
 
@@ -141,6 +142,72 @@ def ondemand_cluster(
         )
 
     return OnDemandCluster(
+        instance_type=instance_type,
+        provider=provider,
+        num_instances=num_instances,
+        autostop_mins=autostop_mins,
+        use_spot=use_spot,
+        image_id=image_id,
+        region=region,
+        name=name,
+        dryrun=dryrun,
+    )
+
+# KubernetesCluster factory method
+def kubernetes_cluster(
+    name: str,
+    instance_type: Optional[str] = None,
+    num_instances: Optional[int] = None,
+    provider: Optional[str] = None,
+    autostop_mins: Optional[int] = None,
+    use_spot: bool = False,
+    image_id: Optional[str] = None,
+    region: Optional[str] = None,
+    dryrun: bool = False,
+) -> KubernetesCluster:
+    """
+    Builds an instance of :class:`KubernetesCluster`.
+
+    Args:
+        name (str): Name for the cluster, to re-use later on.
+        instance_type (int, optional): Type of cloud instance to use for the cluster. This could
+            be a Runhouse built-in type, or your choice of instance type.
+        num_instances (int, optional): Number of instances to use for the cluster.
+        provider (str, optional): Cloud provider to use for the cluster.
+        autostop_mins (int, optional): Number of minutes to keep the cluster up after inactivity,
+            or ``-1`` to keep cluster up indefinitely.
+        use_spot (bool, optional): Whether or not to use spot instance.
+        image_id (str, optional): Custom image ID for the cluster.
+        region (str, optional): The region to use for the cluster.
+        dryrun (bool): Whether to create the Cluster if it doesn't exist, or load a Cluster object as a dryrun.
+            (Default: ``False``)
+
+    Returns:
+        KubernetesCluster: The resulting cluster.
+
+    Example:
+        >>> import runhouse as rh
+        >>> # Kubernetes SkyPilot Cluster (KubernetesCluster)
+        >>> cluster = rh.kubernetes_cluster(
+        >>>            name="cpu-cluster-test",
+        >>>            instance_type="CPU:1",
+        >>>            provider="kubernetes",      
+        >>>        )
+
+        >>> # Load cluster from above
+        >>> reloaded_cluster = rh.kubernetes_cluster(name="rh-4-a100s")
+    """
+    if name and not any([instance_type, num_instances, provider, image_id, region]):
+        # If only the name is provided and dryrun is set to True
+        return Cluster.from_name(name, dryrun)
+
+    if name in RESERVED_SYSTEM_NAMES:
+        raise ValueError(
+            f"Cluster name {name} is a reserved name. Please use a different name which is not one of "
+            f"{RESERVED_SYSTEM_NAMES}."
+        )
+
+    return KubernetesCluster(
         instance_type=instance_type,
         provider=provider,
         num_instances=num_instances,

--- a/runhouse/resources/hardware/kubernetes_cluster.py
+++ b/runhouse/resources/hardware/kubernetes_cluster.py
@@ -1,0 +1,127 @@
+import sky
+from pathlib import Path
+import subprocess
+import logging
+import time
+
+from runhouse.resources.hardware.on_demand_cluster import OnDemandCluster
+
+logger = logging.getLogger(__name__)
+
+class KubernetesCluster(OnDemandCluster):
+
+    def up(self):
+        """Up the cluster.
+
+        Example:
+            >>> rh.kubernetes_cluster(
+            >>>     name="cpu-cluster-test",
+            >>>     instance_type="CPU:1",
+            >>>     provider="kubernetes",      
+            >>> )
+        """
+        if self.on_this_cluster():
+            return self
+
+        if self.provider in ["kubernetes"]:
+            task = sky.Task(
+                num_nodes=self.num_instances
+                if self.instance_type and ":" not in self.instance_type
+                else None,
+                # docker_image=image,  # Zongheng: this is experimental, don't use it
+                # envs=None,
+            )
+            cloud_provider = (
+                sky.clouds.CLOUD_REGISTRY.from_str(self.provider)
+                if self.provider != "cheapest"
+                else None
+            )
+            task.set_resources(
+                sky.Resources(
+                    cloud=cloud_provider,
+                    instance_type=self.instance_type
+                    if self.instance_type
+                    and ":" not in self.instance_type
+                    and "CPU" not in self.instance_type
+                    else None,
+                    accelerators=self.instance_type
+                    if self.instance_type
+                    and ":" in self.instance_type
+                    and "CPU" not in self.instance_type
+                    else None,
+                    cpus=self.instance_type.rsplit(":", 1)[1]
+                    if self.instance_type
+                    and ":" in self.instance_type
+                    and "CPU" in self.instance_type
+                    else None,
+                    region=self.region,
+                    image_id=self.image_id,
+                    use_spot=self.use_spot,
+                )
+            )
+            if Path("~/.rh").expanduser().exists():
+                task.set_file_mounts(
+                    {
+                        "~/.rh": "~/.rh",
+                    }
+                )
+            # If we choose to reduce collisions of cluster names:
+            # cluster_name = self.rns_address.strip('~/').replace("/", "-")
+            sky.launch(
+                task,
+                cluster_name=self.name,
+                idle_minutes_to_autostop=self.autostop_mins,
+                down=True,
+            )
+        else:
+            raise ValueError(f"Cluster provider {self.provider} not supported.")
+
+        self._update_from_sky_status()
+        
+        self.restart_server(restart_ray=True)
+
+        return self
+
+    def restart_server(
+        self,
+        _rh_install_url: str = None,
+        resync_rh: bool = True,
+        restart_ray: bool = True,
+        env_activate_cmd: str = None,
+    ):
+        """Restart the RPC server.
+
+        Args:
+            resync_rh (bool): Whether to resync runhouse. (Default: ``True``)
+            restart_ray (bool): Whether to restart Ray. (Default: ``True``)
+            env_activate_cmd (str, optional): Command to activate the environment on the server. (Default: ``None``)
+        Example:
+            >>> rh.kubernetes_cluster("rh-cpu").restart_server()
+        """
+        logger.info(f"Restarting HTTP server on {self.name}.")
+
+        if resync_rh:
+
+            # sync_rh_cmd = "kubectl cp ../runhouse/ default/cpu-cluster-42-dc19-ray-head:runhouse"
+
+            # consider modifying this so that the kubernetes namespace is parameterized 
+            # also consider extracting the kubernetes pod name 
+            sync_rh_cmd = f"kubectl cp ../runhouse/ default/{self.name}-dc19-ray-head:runhouse"
+
+            cmd = f"{sync_rh_cmd}"
+            try:
+                subprocess.run(cmd, shell=True, check=True)
+            except subprocess.CalledProcessError as e:
+                print(f"Error: {e}")
+
+        install_rh_cmd = "pip install ./runhouse"
+
+        cmd_1 = self.CLI_RESTART_CMD + (" --no-restart-ray" if not restart_ray else "")
+        cmd_1 = f"{install_rh_cmd} && {cmd_1}"
+
+        status_codes = self.run(commands=[cmd_1])
+        if not status_codes[0][0] == 0:
+            raise ValueError(f"Failed to restart server {self.name}.")
+        # As of 2023-15-May still seems we need this.
+        time.sleep(5)
+        return status_codes

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -65,9 +65,10 @@ class SkySSHRunner(SSHCommandRunner):
         ssh_private_key=None,
         ssh_control_name=None,
         ssh_proxy_command=None,
+        disable_control_master: Optional[bool] = False
     ):
         super().__init__(
-            ip, ssh_user, ssh_private_key, ssh_control_name, ssh_proxy_command
+            ip, ssh_user, ssh_private_key, ssh_control_name, ssh_proxy_command, disable_control_master
         )
         self._tunnel_procs = []
 


### PR DESCRIPTION
Adds Kubernetes support to Runhouse. 
Utilizes Skypilot API. 

Example usage: 
```
cluster = rh.cluster(
              name="cpu-cluster-39",
              instance_type="CPU:1",
              provider="kubernetes",      
          )
```

Function setup and function calls work with this new support. Further testing and explorations will be done soon. 