### PR TITLE
Support an optional `host` parameter for the start and restart commands.

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -91,9 +91,7 @@ def load_cluster(cluster_name: str):
         c._update_from_sky_status(dryrun=True)
 
 
-def _start_server(
-    restart, restart_ray, screen, create_logfile=True, custom_server_host=None
-):
+def _start_server(restart, restart_ray, screen, create_logfile=True, host=None):
     from runhouse.resources.hardware.cluster import Cluster
 
     cmds = Cluster._start_server_cmds(
@@ -101,7 +99,7 @@ def _start_server(
         restart_ray=restart_ray,
         screen=screen,
         create_logfile=create_logfile,
-        custom_server_host=custom_server_host,
+        host=host,
     )
 
     try:
@@ -124,9 +122,9 @@ def _start_server(
 def start(
     restart_ray: bool = typer.Option(False, help="Restart the Ray runtime"),
     screen: bool = typer.Option(False, help="Start the server in a screen"),
-    custom_server_host: Optional[str] = typer.Option(
+    host: Optional[str] = typer.Option(
         None,
-        help="Custom server host address e.g. 0.0.0.0. Default is `None` and the server would start on 127.0.0.1.",
+        help="Custom server host address e.g. 0.0.0.0. Default is `None` and the server would start on 127.0.0.1",
     ),
 ):
     """Start the HTTP server on the cluster."""
@@ -135,7 +133,7 @@ def start(
         restart_ray=restart_ray,
         screen=screen,
         create_logfile=True,
-        custom_server_host=custom_server_host,
+        host=host,
     )
 
 
@@ -151,9 +149,9 @@ def restart(
         False,
         help="Resync the Runhouse package. Only relevant when restarting remotely.",
     ),
-    custom_server_host: Optional[str] = typer.Option(
+    host: Optional[str] = typer.Option(
         None,
-        help="Custom server host e.g. 0.0.0.0. Default is `None` and the server would start on 127.0.0.1.",
+        help="Custom server host address e.g. 0.0.0.0. Default is `None` and the server would start on 127.0.0.1",
     ),
 ):
     """Restart the HTTP server on the cluster."""
@@ -167,7 +165,7 @@ def restart(
         restart_ray=restart_ray,
         screen=screen,
         create_logfile=True,
-        custom_server_host=custom_server_host,
+        host=host,
     )
 
 

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -91,7 +91,9 @@ def load_cluster(cluster_name: str):
         c._update_from_sky_status(dryrun=True)
 
 
-def _start_server(restart, restart_ray, screen, create_logfile=True):
+def _start_server(
+    restart, restart_ray, screen, create_logfile=True, custom_server_host=None
+):
     from runhouse.resources.hardware.cluster import Cluster
 
     cmds = Cluster._start_server_cmds(
@@ -99,6 +101,7 @@ def _start_server(restart, restart_ray, screen, create_logfile=True):
         restart_ray=restart_ray,
         screen=screen,
         create_logfile=create_logfile,
+        custom_server_host=custom_server_host,
     )
 
     try:
@@ -121,10 +124,18 @@ def _start_server(restart, restart_ray, screen, create_logfile=True):
 def start(
     restart_ray: bool = typer.Option(False, help="Restart the Ray runtime"),
     screen: bool = typer.Option(False, help="Start the server in a screen"),
+    custom_server_host: Optional[str] = typer.Option(
+        None,
+        help="Custom server host address e.g. 0.0.0.0. Default is `None` and the server would start on 127.0.0.1.",
+    ),
 ):
     """Start the HTTP server on the cluster."""
     _start_server(
-        restart=False, restart_ray=restart_ray, screen=screen, create_logfile=True
+        restart=False,
+        restart_ray=restart_ray,
+        screen=screen,
+        create_logfile=True,
+        custom_server_host=custom_server_host,
     )
 
 
@@ -140,6 +151,10 @@ def restart(
         False,
         help="Resync the Runhouse package. Only relevant when restarting remotely.",
     ),
+    custom_server_host: Optional[str] = typer.Option(
+        None,
+        help="Custom server host e.g. 0.0.0.0. Default is `None` and the server would start on 127.0.0.1.",
+    ),
 ):
     """Restart the HTTP server on the cluster."""
     if name:
@@ -152,6 +167,7 @@ def restart(
         restart_ray=restart_ray,
         screen=screen,
         create_logfile=True,
+        custom_server_host=custom_server_host,
     )
 
 

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -466,9 +466,7 @@ class Cluster(Resource):
         return ssh_tunnel, local_port
 
     @classmethod
-    def _start_server_cmds(
-        cls, restart, restart_ray, screen, create_logfile, custom_server_host
-    ):
+    def _start_server_cmds(cls, restart, restart_ray, screen, create_logfile, host):
         cmds = []
         if restart:
             cmds.append(cls.SERVER_STOP_CMD)
@@ -483,8 +481,8 @@ class Cluster(Resource):
             cmds.append(cls.START_SCREEN_CMD)
         else:
             server_start_cmd = cls.SERVER_START_CMD
-            if custom_server_host is not None:
-                server_start_cmd += f" --host {custom_server_host}"
+            if host is not None:
+                server_start_cmd += f" --host {host}"
             logger.info(
                 f"Starting HTTP server using the following command: {server_start_cmd}."
             )

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -466,7 +466,9 @@ class Cluster(Resource):
         return ssh_tunnel, local_port
 
     @classmethod
-    def _start_server_cmds(cls, restart, restart_ray, screen, create_logfile):
+    def _start_server_cmds(
+        cls, restart, restart_ray, screen, create_logfile, custom_server_host
+    ):
         cmds = []
         if restart:
             cmds.append(cls.SERVER_STOP_CMD)
@@ -480,7 +482,13 @@ class Cluster(Resource):
                 Path(cls.SERVER_LOGFILE).touch()
             cmds.append(cls.START_SCREEN_CMD)
         else:
-            cmds.append(cls.SERVER_START_CMD)
+            server_start_cmd = cls.SERVER_START_CMD
+            if custom_server_host is not None:
+                server_start_cmd += f" --host {custom_server_host}"
+            logger.info(
+                f"Starting HTTP server using the following command: {server_start_cmd}."
+            )
+            cmds.append(server_start_cmd)
         return cmds
 
     def restart_server(

--- a/runhouse/rns/defaults.py
+++ b/runhouse/rns/defaults.py
@@ -26,7 +26,7 @@ class Defaults:
         "default_autostop": -1,
         "use_spot": False,
         "use_local_configs": True,
-        "disable_data_collection": False,
+        "disable_data_collection": True,
         "use_rns": False,
         "api_server_url": "https://api.run.house",
         "dashboard_url": "https://run.house",

--- a/runhouse/rns/defaults.py
+++ b/runhouse/rns/defaults.py
@@ -26,7 +26,7 @@ class Defaults:
         "default_autostop": -1,
         "use_spot": False,
         "use_local_configs": True,
-        "disable_data_collection": True,
+        "disable_data_collection": False,
         "use_rns": False,
         "api_server_url": "https://api.run.house",
         "dashboard_url": "https://run.house",

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -20,6 +20,7 @@ from runhouse.rns.utils.names import _generate_default_name
 from runhouse.servers.servlet import EnvServlet
 from ..http.http_utils import (
     b64_unpickle,
+    DEFAULT_SERVER_HOST,
     DEFAULT_SERVER_PORT,
     Message,
     OutputType,
@@ -584,6 +585,9 @@ class HTTPServer:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--host", type=str, default=DEFAULT_SERVER_HOST, help="Host to run server on"
+    )
+    parser.add_argument(
         "--port", type=int, default=DEFAULT_SERVER_PORT, help="Port to run server on"
     )
     parser.add_argument(
@@ -596,6 +600,7 @@ if __name__ == "__main__":
         help="Enable local span collection",
     )
     parse_args = parser.parse_args()
+    host = parse_args.host
     port = parse_args.port
     conda_name = parse_args.conda_env
     should_enable_local_span_collection = parse_args.enable_local_span_collection
@@ -606,4 +611,4 @@ if __name__ == "__main__":
         conda_env=conda_name,
         enable_local_span_collection=should_enable_local_span_collection,
     )
-    uvicorn.run(app, host="127.0.0.1", port=port)
+    uvicorn.run(app, host=host, port=port)

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -10,6 +10,7 @@ from ray import cloudpickle as pickle
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SERVER_HOST = "127.0.0.1"
 DEFAULT_SERVER_PORT = 50052
 
 


### PR DESCRIPTION
Example usages:
runhouse start --custom_server_host 0.0.0.0
runhouse restart --custom_server_host 0.0.0.0
python -m runhouse.servers.http.http_server --host 0.0.0.0