### PR TITLE
Fix file .to bugs

### DIFF
--- a/runhouse/resources/blobs/blob.py
+++ b/runhouse/resources/blobs/blob.py
@@ -67,9 +67,9 @@ class Blob(Module):
             path or self.default_path(self.rns_address, system)
         )  # Make sure it's a string and not a Path
 
-        from runhouse.resources.blobs.file import File
+        from runhouse.resources.blobs.file import file
 
-        new_blob = File(path=path, system=system, data_config=data_config)
+        new_blob = file(path=path, system=system, data_config=data_config)
         new_blob.write(self.fetch())
         return new_blob
 

--- a/runhouse/resources/blobs/file.py
+++ b/runhouse/resources/blobs/file.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import pickle
 from pathlib import Path
@@ -130,13 +129,14 @@ class File(Blob):
             new_blob.data = data_backup
             return new_blob
 
-        new_file = copy.copy(self)
-        new_file.local._folder = folder(
-            path=str(Path(path).parent) if path is not None else path,
-            system=system,
-            data_config=data_config,
-        )
-        new_file.write(self.fetch(mode="r"), serialize=False)
+        new_file = file(path=path, system=system, data_config=data_config)
+        try:
+            new_file.write(
+                self.fetch(mode="r", deserialize=False), serialize=False, mode="w"
+            )
+        except UnicodeDecodeError:
+            new_file.write(self.fetch())
+
         return new_file
 
     def resolved_state(self, deserialize: bool = True, mode: str = "rb"):

--- a/runhouse/resources/blobs/file.py
+++ b/runhouse/resources/blobs/file.py
@@ -37,7 +37,6 @@ class File(Blob):
             data_config=data_config,
             dryrun=dryrun,
         )
-        self._cached_data = None
         super().__init__(name=name, dryrun=dryrun, system=system, env=env, **kwargs)
 
     @property
@@ -145,14 +144,10 @@ class File(Blob):
         Example:
             >>> data = file.fetch()
         """
-        self.local._cached_data = self._folder.get(self._filename, mode=mode)
+        data = self._folder.get(self._filename, mode=mode)
         if deserialize:
-            try:
-                deserialized_data = pickle.loads(self._cached_data)
-            except (pickle.UnpicklingError, TypeError):
-                deserialized_data = self._cached_data
-            self.local._cached_data = deserialized_data
-        return self._cached_data
+            return pickle.loads(data)
+        return data
 
     def _save_sub_resources(self):
         if isinstance(self.system, Cluster):

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -601,7 +601,7 @@ class Module(Resource):
 
         return LocalPropertyWrapper()
 
-    def fetch(self, item: str = None, stream_logs: bool = False):
+    def fetch(self, item: str = None, stream_logs: bool = False, **kwargs):
         """Helper method to allow for access to remote state, both public and private. Fetching functions
         is not advised. `system.get(module.name).resolved_state()` is roughly equivalent to `module.fetch()`.
 
@@ -638,8 +638,8 @@ class Module(Resource):
             return system.call(name, item, stream_logs=stream_logs)
         else:
             if not isinstance(system, Cluster) or not name:
-                return self.resolved_state()
-            return system.get(name, stream_logs=stream_logs).resolved_state()
+                return self.resolved_state(**kwargs)
+            return system.get(name, stream_logs=stream_logs).resolved_state(**kwargs)
 
     async def fetch_async(
         self, key: str, remote: bool = False, stream_logs: bool = False

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -89,7 +89,9 @@ def test_file_to_blob(file, cluster):
 @pytest.mark.awstest
 @pytest.mark.gcptest
 @pytest.mark.clustertest
-@pytest.mark.parametrize("blob", ["local_blob", "cluster_blob"], indirect=True)
+@pytest.mark.parametrize(
+    "blob", ["local_blob", "cluster_blob", "local_file"], indirect=True
+)
 @pytest.mark.parametrize(
     "folder",
     ["local_folder", "cluster_folder", "s3_folder", "gcs_folder"],


### PR DESCRIPTION
Fixes two bugs in the current `.to(cluster, dest_path)` function for File:
* we set the folder of the `dest_path` to have the path of the `dest_path`, rather than the parent of `dest_path`
* we send the folder to `cluster`, which includes all contents of the file's parent folder, rather than the file alone

The intended goal of `.to(cluster, dest_path)` is to write the contents of the local file to the `dest_path` file.

This can further be improved in the future by directly syncing over files without needing to hold the contents in Python memory.