### PR TITLE
Bugfixes (Sagemaker, Function, Env)

### DIFF
--- a/runhouse/resources/function.py
+++ b/runhouse/resources/function.py
@@ -29,7 +29,6 @@ class Function(Module):
         env: Optional[Env] = None,
         dryrun: bool = False,
         access: Optional[str] = None,
-        resources: Optional[dict] = None,
         **kwargs,  # We have this here to ignore extra arguments when calling from from_config
     ):
         """
@@ -41,7 +40,6 @@ class Function(Module):
         """
         self.fn_pointers = fn_pointers
         self.access = access or self.DEFAULT_ACCESS
-        self.resources = resources or {}
         super().__init__(name=name, dryrun=dryrun, system=system, env=env, **kwargs)
 
     # ----------------- Constructor helper methods -----------------
@@ -250,14 +248,9 @@ class Function(Module):
         config.update(
             {
                 "fn_pointers": self.fn_pointers,
-                "resources": self.resources,
             }
         )
         return config
-
-    def _save_sub_resources(self):
-        if isinstance(self.system, Cluster):
-            self.system.save()
 
     def send_secrets(self, providers: Optional[List[str]] = None):
         """Send secrets to the system.
@@ -387,7 +380,6 @@ def function(
     name: Optional[str] = None,
     system: Optional[Union[str, Cluster]] = None,
     env: Optional[Union[List[str], Env, str]] = None,
-    resources: Optional[dict] = None,
     dryrun: bool = False,
     load_secrets: bool = False,
     serialize_notebook_fn: bool = False,
@@ -405,8 +397,6 @@ def function(
             This can be either the string name of a Cluster object, or a Cluster object.
         env (Optional[List[str] or Env or str]): List of requirements to install on the remote cluster, or path to the
             requirements.txt file, or Env object or string name of an Env object.
-        resources (Optional[dict]): Optional number (int) of resources needed to run the Function on the Cluster.
-            Keys must be ``num_cpus`` and ``num_gpus``.
         dryrun (bool): Whether to create the Function if it doesn't exist, or load the Function object as a dryrun.
             (Default: ``False``)
         load_secrets (bool): Whether or not to send secrets; only applicable if `dryrun` is set to ``False``.
@@ -432,7 +422,7 @@ def function(
         >>> # Load function from above
         >>> reloaded_function = rh.function(name="my_func")
     """
-    if name and not any([fn, system, env, resources]):
+    if name and not any([fn, system, env]):
         # Try reloading existing function
         return Function.from_name(name, dryrun)
 
@@ -496,7 +486,6 @@ def function(
 
     new_function = Function(
         fn_pointers=fn_pointers,
-        resources=resources,
         access=Function.DEFAULT_ACCESS,
         name=name,
         dryrun=dryrun,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -129,7 +129,11 @@ class Module(Resource):
             self._resource_string_for_subconfig(self.system) if self.system else None
         )
         config["env"] = (
-            self._resource_string_for_subconfig(self.env) if self.env else None
+            None
+            if not self.env
+            else self.env.config_for_rns
+            if self.env.name == Env.DEFAULT_NAME
+            else self._resource_string_for_subconfig(self.env)
         )
         if self._cls_pointers:
             # For some reason sometimes this is coming back as a string, so we force it into a tuple
@@ -768,7 +772,7 @@ class Module(Resource):
     def _save_sub_resources(self):
         if isinstance(self.system, Resource):
             self.system.save()
-        if isinstance(self.env, Resource):
+        if isinstance(self.env, Resource) and self.env.name != Env.DEFAULT_NAME:
             self.env.save()
 
     def rename(self, name: str):

--- a/runhouse/resources/resource.py
+++ b/runhouse/resources/resource.py
@@ -212,6 +212,8 @@ class Resource:
                     config[key]
                 ):
                     return None
+            else:
+                return None
         return config
 
     @classmethod


### PR DESCRIPTION
Some sagemaker bugs:
- not creating session with profile
- not taking up the cluster if no address found in check_server
- Don't fail if role or profile are not found to create session when on the cluster

Remove "resources" from function, which is obsolete.

Don't let env save if it has name Env.DEFAULT_NAME. This clearly needs more work (e.g. not setting the default name directly, but rather implicitly) but for now is ok.

Fix alt_options so if an option is specified which is not in the config, it counts as a miss.

One thing we still need is to run `/opt/conda/bin/conda init` somewhere in the setup flow. Not sure where that should be (I don't think it should be in the script, because conda may not be present inside the user's docker image). Thoughts @jlewitt1 ?