### PR TITLE
Auth Cluster Cache

### DIFF
--- a/runhouse/servers/http/auth.py
+++ b/runhouse/servers/http/auth.py
@@ -1,12 +1,13 @@
+import hashlib
 import json
 import logging
 from typing import Union
 
+import ray
 import requests
 
 from runhouse.globals import rns_client
 from runhouse.rns.utils.api import load_resp_content, ResourceAccess
-from runhouse.servers.http.http_utils import hash_token
 
 logger = logging.getLogger(__name__)
 
@@ -15,21 +16,15 @@ class AuthCache:
     CACHE = {}
 
     @classmethod
-    def get_user_resources(cls, token: str) -> dict:
+    def get_user_resources(cls, token_hash: str) -> dict:
         """Get resources associated with a particular user's token"""
-        return cls.CACHE.get(hash_token(token), {})
+        return cls.CACHE.get(token_hash, {})
 
     @classmethod
     def lookup_access_level(
-        cls, token: str, resource_uri: str, retry=True
+        cls, token_hash: str, resource_uri: str
     ) -> Union[str, None]:
-        resources: dict = cls.get_user_resources(token)
-        if not resources and retry:
-            cls.add_user(token)
-
-            # Try again after refreshing the cache
-            return cls.lookup_access_level(token, resource_uri, retry=False)
-
+        resources: dict = cls.get_user_resources(token_hash)
         return resources.get(resource_uri)
 
     @classmethod
@@ -60,22 +55,30 @@ def verify_cluster_access(
     func_call: bool,
 ) -> bool:
     """Verify the user has access to the cluster. If user has write access to the cluster, will have access
-    to all other resources on the cluster. For calling functions must have read or write access to the cluster."""
+    to all other resources on the cluster. For calling functions must have read or write access to the cluster.
+    Access is managed by the object store, with a Ray actor (AuthCache) which maps a user's hashed token to
+    the list of resources they have access to."""
     from runhouse.globals import obj_store
 
-    # Check if user's token has already been validated and saved to cache on the cluster
-    cached_resources: dict = obj_store.get_user_resources(token)
+    token_hash = hash_token(token)
 
-    if not cached_resources:
-        # Refresh the cache with the resources user has access to
-        obj_store.add_user(token)
-        cached_resources: dict = obj_store.get_user_resources(token)
+    # Check if user's token has already been validated and saved to cache on the cluster
+    cached_resources: dict = obj_store.user_resources(token_hash)
 
     # e.g. {"/jlewitt1/bert-preproc": "read"}
     cluster_access_type = cached_resources.get(cluster_uri)
     if cluster_access_type == ResourceAccess.WRITE.value:
         # If user has write access to the cluster will have access to all functions on the cluster
         return True
+
+    # Refresh cache for the user
+    # Note: for adding user we need to pass in the token since it requires querying Den
+    auth_cache_actor = ray.get_actor("auth_cache", namespace="runhouse")
+    ray.get(auth_cache_actor.add_user.remote(token))
+
+    # Re-check if user has access to the cluster
+    cached_resources: dict = obj_store.user_resources(token_hash)
+    cluster_access_type = cached_resources.get(cluster_uri)
 
     # For running functions must have read or write access to the cluster
     if func_call and cluster_access_type not in [
@@ -85,3 +88,8 @@ def verify_cluster_access(
         return False
 
     return True
+
+
+def hash_token(token: str) -> str:
+    """Hash the user's token to avoid storing them in plain text on the cluster."""
+    return hashlib.sha256(token.encode()).hexdigest()

--- a/runhouse/servers/http/auth.py
+++ b/runhouse/servers/http/auth.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import logging
 from typing import Union
@@ -6,31 +5,27 @@ from typing import Union
 import requests
 
 from runhouse.globals import rns_client
-from runhouse.rns.utils.api import load_resp_content
+from runhouse.rns.utils.api import load_resp_content, ResourceAccess
+from runhouse.servers.http.http_utils import hash_token
 
 logger = logging.getLogger(__name__)
 
 
 class AuthCache:
-    AUTH_CACHE = {}
+    CACHE = {}
 
     @classmethod
     def get_user_resources(cls, token: str) -> dict:
         """Get resources associated with a particular user's token"""
-        return cls.AUTH_CACHE.get(cls.hash_token(token), {})
-
-    @classmethod
-    def update_user_resources(cls, token: str, resources: dict):
-        """Update server cache with a user's resources and access type"""
-        cls.AUTH_CACHE[cls.hash_token(token)] = resources
+        return cls.CACHE.get(hash_token(token), {})
 
     @classmethod
     def lookup_access_level(
         cls, token: str, resource_uri: str, retry=True
     ) -> Union[str, None]:
-        resources: dict = cls.get_user_resources(cls.hash_token(token))
+        resources: dict = cls.get_user_resources(token)
         if not resources and retry:
-            cls.refresh_cache(token)
+            cls.add_user(token)
 
             # Try again after refreshing the cache
             return cls.lookup_access_level(token, resource_uri, retry=False)
@@ -38,24 +33,55 @@ class AuthCache:
         return resources.get(resource_uri)
 
     @classmethod
-    def refresh_cache(cls, token):
-        """Refresh the server cache with the latest resources and access levels"""
+    def add_user(cls, token):
+        """Refresh the server cache with the latest resources and access levels for a particular user"""
         resp = requests.get(
             f"{rns_client.api_server_url}/resource",
             headers={"Authorization": f"Bearer {token}"},
         )
         if resp.status_code != 200:
-            raise Exception(f"Failed to refresh cache: {load_resp_content(resp)}")
+            raise Exception(
+                f"Failed to load resources for user: {load_resp_content(resp)}"
+            )
 
         resp_data = json.loads(resp.content)
         all_resources: dict = {
             resource["name"]: resource["access_type"] for resource in resp_data["data"]
         }
 
-        cls.update_user_resources(cls.hash_token(token), all_resources)
-        logger.info(f"Updated cache for user with {len(all_resources)} resources")
+        # Update server cache with a user's resources and access type
+        cls.CACHE[hash_token(token)] = all_resources
+        logger.info(f"Updated cache for user with {len(all_resources)} resources:")
 
-    @staticmethod
-    def hash_token(token: str) -> str:
-        """Hash the user's token to avoid storing them in plain text on the cluster."""
-        return hashlib.sha256(token.encode()).hexdigest()
+
+def verify_cluster_access(
+    cluster_uri: str,
+    token: str,
+    func_call: bool,
+) -> bool:
+    """Verify the user has access to the cluster. If user has write access to the cluster, will have access
+    to all other resources on the cluster. For calling functions must have read or write access to the cluster."""
+    from runhouse.globals import obj_store
+
+    # Check if user's token has already been validated and saved to cache on the cluster
+    cached_resources: dict = obj_store.get_user_resources(token)
+
+    if not cached_resources:
+        # Refresh the cache with the resources user has access to
+        obj_store.add_user(token)
+        cached_resources: dict = obj_store.get_user_resources(token)
+
+    # e.g. {"/jlewitt1/bert-preproc": "read"}
+    cluster_access_type = cached_resources.get(cluster_uri)
+    if cluster_access_type == ResourceAccess.WRITE.value:
+        # If user has write access to the cluster will have access to all functions on the cluster
+        return True
+
+    # For running functions must have read or write access to the cluster
+    if func_call and cluster_access_type not in [
+        ResourceAccess.READ,
+        ResourceAccess.WRITE,
+    ]:
+        return False
+
+    return True

--- a/runhouse/servers/http/auth.py
+++ b/runhouse/servers/http/auth.py
@@ -1,22 +1,59 @@
 import hashlib
+import json
 import logging
+from typing import Union
+
+import requests
+
+from runhouse.globals import rns_client
+from runhouse.rns.utils.api import load_resp_content
 
 logger = logging.getLogger(__name__)
 
 
-class ServerCache:
-    # TODO: Turn this into a Ray actor to handle token and resource auth
+class AuthCache:
     AUTH_CACHE = {}
 
     @classmethod
-    def get_resources(cls, token: str) -> dict:
+    def get_user_resources(cls, token: str) -> dict:
         """Get resources associated with a particular user's token"""
         return cls.AUTH_CACHE.get(cls.hash_token(token), {})
 
     @classmethod
-    def put_resources(cls, token: str, resources: dict):
+    def update_user_resources(cls, token: str, resources: dict):
         """Update server cache with a user's resources and access type"""
         cls.AUTH_CACHE[cls.hash_token(token)] = resources
+
+    @classmethod
+    def lookup_access_level(
+        cls, token: str, resource_uri: str, retry=True
+    ) -> Union[str, None]:
+        resources: dict = cls.get_user_resources(cls.hash_token(token))
+        if not resources and retry:
+            cls.refresh_cache(token)
+
+            # Try again after refreshing the cache
+            return cls.lookup_access_level(token, resource_uri, retry=False)
+
+        return resources.get(resource_uri)
+
+    @classmethod
+    def refresh_cache(cls, token):
+        """Refresh the server cache with the latest resources and access levels"""
+        resp = requests.get(
+            f"{rns_client.api_server_url}/resource",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        if resp.status_code != 200:
+            raise Exception(f"Failed to refresh cache: {load_resp_content(resp)}")
+
+        resp_data = json.loads(resp.content)
+        all_resources: dict = {
+            resource["name"]: resource["access_type"] for resource in resp_data["data"]
+        }
+
+        cls.update_user_resources(cls.hash_token(token), all_resources)
+        logger.info(f"Updated cache for user with {len(all_resources)} resources")
 
     @staticmethod
     def hash_token(token: str) -> str:

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -20,7 +20,7 @@ from runhouse.globals import configs, env_servlets, rns_client
 from runhouse.resources.hardware.utils import _load_cluster_config
 from runhouse.rns.utils.api import resolve_absolute_path
 from runhouse.rns.utils.names import _generate_default_name
-from runhouse.servers.http.auth import verify_cluster_access
+from runhouse.servers.http.auth import hash_token, verify_cluster_access
 from runhouse.servers.http.certs import TLSCertConfig
 from runhouse.servers.http.http_utils import (
     b64_unpickle,
@@ -355,7 +355,7 @@ class HTTPServer:
                 # Unless we're returning a fast response, we discard this obj_ref
                 obj_ref = HTTPServer.call_in_env_servlet(
                     "call_module_method",
-                    [module, method, message, token],
+                    [module, method, message, hash_token(token)],
                     env=env,
                     create=True,
                     block=False,
@@ -578,7 +578,7 @@ class HTTPServer:
         token = get_token_from_request(request)
         resp = HTTPServer.call_in_env_servlet(
             "call",
-            [module, method, args, kwargs, serialization, token],
+            [module, method, args, kwargs, serialization, hash_token(token)],
             create=True,
             lookup_env_for_name=module,
         )

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -1,5 +1,4 @@
 import codecs
-import hashlib
 import logging
 import re
 import sys
@@ -58,11 +57,6 @@ def b64_unpickle(b64_pickled):
 def get_token_from_request(request):
     auth_headers = request.headers.get("Authorization", "")
     return auth_headers.split("Bearer ")[-1] if auth_headers else None
-
-
-def hash_token(token: str) -> str:
-    """Hash the user's token to avoid storing them in plain text on the cluster."""
-    return hashlib.sha256(token.encode()).hexdigest()
 
 
 def load_current_cluster():

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -54,6 +54,11 @@ def b64_unpickle(b64_pickled):
     return pickle.loads(codecs.decode(b64_pickled.encode(), "base64"))
 
 
+def get_token_from_request(request):
+    auth_headers = request.headers.get("Authorization", "")
+    return auth_headers.split("Bearer ")[-1] if auth_headers else None
+
+
 def handle_response(response_data, output_type, err_str):
     if output_type in [OutputType.RESULT, OutputType.RESULT_STREAM]:
         return b64_unpickle(response_data["data"])

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -1,4 +1,5 @@
 import codecs
+import hashlib
 import logging
 import re
 import sys
@@ -57,6 +58,18 @@ def b64_unpickle(b64_pickled):
 def get_token_from_request(request):
     auth_headers = request.headers.get("Authorization", "")
     return auth_headers.split("Bearer ")[-1] if auth_headers else None
+
+
+def hash_token(token: str) -> str:
+    """Hash the user's token to avoid storing them in plain text on the cluster."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def load_current_cluster():
+    from runhouse.resources.hardware import _current_cluster, _get_cluster_from
+
+    current_cluster = _get_cluster_from(_current_cluster("config"))
+    return current_cluster.rns_address if current_cluster else None
 
 
 def handle_response(response_data, output_type, err_str):


### PR DESCRIPTION
**Move the den auth / resource validation out of the HTTP server and into the object store**

Make `AuthCache` into an actor on the cluster which holds a basic cache. 

The `AuthCache` class itself is the actor: when a new request comes in with a token, pass in to the actor's `add_user` method which loads down resources it has access to and stores it in the cache.

When functions are called on the cluster, validate token (if den auth is enabled) and first check cache to validate the user's access. 

------

Continue using a validator decorator (`validate_cluster_access`) to validate the user's access to the cluster if den auth is enabled before continuing with API logic. If the user has write access to the cluster will be given access to all resources on the cluster by default. 

For function calls must have read or write access to the resource. 