### PR TITLE
Use Pexpect for password clusters instead of paramiko and fsspec

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -27,6 +27,7 @@ from runhouse.resources.hardware.utils import (
     _current_cluster,
     ServerConnectionType,
     SkySSHRunner,
+    SshMode,
 )
 from runhouse.resources.resource import Resource
 
@@ -916,7 +917,10 @@ class Cluster(Resource):
 
             if up:
                 ssh_command = runner.run(
-                    ["mkdir", "-p", dest], stream_logs=False, return_cmd=True
+                    ["mkdir", "-p", dest],
+                    stream_logs=False,
+                    return_cmd=True,
+                    ssh_mode=SshMode.INTERACTIVE,
                 )
                 ssh = pexpect.spawn(ssh_command, encoding="utf-8")
                 ssh.logfile_read = sys.stdout
@@ -928,6 +932,7 @@ class Cluster(Resource):
                 ssh.close()
             else:
                 Path(dest).expanduser().parent.mkdir(parents=True, exist_ok=True)
+
             rsync_cmd = runner.rsync(
                 source,
                 dest,
@@ -1063,6 +1068,7 @@ class Cluster(Resource):
                     stream_logs=stream_logs,
                     port_forward=port_forward,
                     return_cmd=True,
+                    ssh_mode=SshMode.INTERACTIVE,
                 )
                 ssh = pexpect.spawn(ssh_command, encoding="utf-8")
                 if stream_logs:

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -212,9 +212,7 @@ class SkySSHRunner(SSHCommandRunner):
             "--login",
             "-c",
             # Need this `-i` option to make sure `source ~/.bashrc` work.
-            # RH MODIFIED, disable for pexpect
-            # "-i"
-            # "" if ssh_mode == SshMode.NON_INTERACTIVE else "-i",
+            "-i",
         ]
 
         command += [

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -166,6 +166,7 @@ class SkySSHRunner(SSHCommandRunner):
         ssh_mode: SshMode = SshMode.NON_INTERACTIVE,
         separate_stderr: bool = False,
         return_cmd: bool = False,  # RH MODIFIED
+        quiet_ssh: bool = False,  # RH MODIFIED
         **kwargs,
     ) -> Union[int, Tuple[int, str, str]]:
         """Uses 'ssh' to run 'cmd' on a node with ip.
@@ -186,6 +187,7 @@ class SkySSHRunner(SSHCommandRunner):
                 See SSHMode for more details.
             separate_stderr: Whether to separate stderr from stdout.
             return_cmd: If True, return the command string instead of running it.
+            quiet_ssh: If True, do not print the OpenSSH outputs (i.e. add "-q" option to ssh).
 
 
         Returns:
@@ -203,6 +205,10 @@ class SkySSHRunner(SSHCommandRunner):
             return proc.returncode, "", ""
         if isinstance(cmd, list):
             cmd = " ".join(cmd)
+
+        # RH MODIFIED: Add quiet_ssh option
+        if quiet_ssh:
+            base_ssh_command.append("-q")
 
         log_dir = os.path.expanduser(os.path.dirname(log_path))
         os.makedirs(log_dir, exist_ok=True)

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 import shlex
 import subprocess
 import time
@@ -7,13 +8,20 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
-import sky.utils.command_runner as cr
-
 import yaml
 from sky.skylet import log_lib
 from sky.utils import subprocess_utils
 
-from sky.utils.command_runner import ssh_options_list, SSHCommandRunner, SshMode
+from sky.utils.command_runner import (
+    common_utils,
+    GIT_EXCLUDE,
+    RSYNC_DISPLAY_OPTION,
+    RSYNC_EXCLUDE_OPTION,
+    RSYNC_FILTER_OPTION,
+    ssh_options_list,
+    SSHCommandRunner,
+    SshMode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -88,19 +96,26 @@ class SkySSHRunner(SSHCommandRunner):
         ip,
         ssh_user=None,
         ssh_private_key=None,
-        ssh_control_name=None,
-        ssh_proxy_command=None,
+        ssh_control_name: Optional[str] = "__default__",
+        ssh_proxy_command: Optional[str] = None,
+        port: int = 22,
+        docker_user: Optional[str] = None,
+        disable_control_master: Optional[bool] = False,
     ):
         super().__init__(
-            ip, ssh_user, ssh_private_key, ssh_control_name, ssh_proxy_command
+            ip,
+            ssh_user,
+            ssh_private_key,
+            ssh_control_name,
+            ssh_proxy_command,
+            port,
+            docker_user,
+            disable_control_master,
         )
         self._tunnel_procs = []
 
     def _ssh_base_command(
-        self,
-        *,
-        ssh_mode: SshMode,
-        port_forward: Union[None, List[int], List[Tuple[int, int]]],
+        self, *, ssh_mode: SshMode, port_forward: Optional[List[int]]
     ) -> List[str]:
         ssh = ["ssh"]
         if ssh_mode == SshMode.NON_INTERACTIVE:
@@ -111,6 +126,7 @@ class SkySSHRunner(SSHCommandRunner):
             # Force pseudo-terminal allocation for interactive/login mode.
             ssh += ["-tt"]
         if port_forward is not None:
+            # RH MODIFIED: Accept port int (to forward same port) or pair of ports
             for fwd in port_forward:
                 if isinstance(fwd, int):
                     local, remote = fwd, fwd
@@ -118,13 +134,20 @@ class SkySSHRunner(SSHCommandRunner):
                     local, remote = fwd
                 logger.info(f"Forwarding port {local} to port {remote} on localhost.")
                 ssh += ["-L", f"{remote}:localhost:{local}"]
+        if self._docker_ssh_proxy_command is not None:
+            docker_ssh_proxy_command = self._docker_ssh_proxy_command(ssh)
+        else:
+            docker_ssh_proxy_command = None
         return (
             ssh
             + ssh_options_list(
                 self.ssh_private_key,
                 self.ssh_control_name,
-                port=None,
                 ssh_proxy_command=self._ssh_proxy_command,
+                docker_ssh_proxy_command=docker_ssh_proxy_command,
+                # TODO change to None like before?
+                port=self.port,
+                disable_control_master=self.disable_control_master,
             )
             + [f"{self.ssh_user}@{self.ip}"]
         )
@@ -142,10 +165,34 @@ class SkySSHRunner(SSHCommandRunner):
         stream_logs: bool = True,
         ssh_mode: SshMode = SshMode.NON_INTERACTIVE,
         separate_stderr: bool = False,
+        return_cmd: bool = False,  # RH MODIFIED
         **kwargs,
     ) -> Union[int, Tuple[int, str, str]]:
-        """This is identical to the SkyPilot command runner, other than logging the full command to be run
-        before running it."""
+        """Uses 'ssh' to run 'cmd' on a node with ip.
+
+        Args:
+            ip: The IP address of the node.
+            cmd: The command to run.
+            port_forward: A list of ports to forward from the localhost to the
+            remote host.
+
+            Advanced options:
+
+            require_outputs: Whether to return the stdout/stderr of the command.
+            log_path: Redirect stdout/stderr to the log_path.
+            stream_logs: Stream logs to the stdout/stderr.
+            check: Check the success of the command.
+            ssh_mode: The mode to use for ssh.
+                See SSHMode for more details.
+            separate_stderr: Whether to separate stderr from stdout.
+            return_cmd: If True, return the command string instead of running it.
+
+
+        Returns:
+            returncode
+            or
+            A tuple of (returncode, stdout, stderr).
+        """
         base_ssh_command = self._ssh_base_command(
             ssh_mode=ssh_mode, port_forward=port_forward
         )
@@ -165,7 +212,9 @@ class SkySSHRunner(SSHCommandRunner):
             "--login",
             "-c",
             # Need this `-i` option to make sure `source ~/.bashrc` work.
-            "-i",
+            # RH MODIFIED, disable for pexpect
+            # "-i"
+            # "" if ssh_mode == SshMode.NON_INTERACTIVE else "-i",
         ]
 
         command += [
@@ -203,8 +252,11 @@ class SkySSHRunner(SSHCommandRunner):
                 command += [f"> {log_path}"]
             executable = "/bin/bash"
 
-        # This log should be the only difference between our command
+        # RH MODIFIED: Return command instead of running it
         logging.info(f"Running command: {' '.join(command)}")
+        if return_cmd:
+            return " ".join(command)
+
         return log_lib.run_with_log(
             " ".join(command),
             log_path,
@@ -238,22 +290,110 @@ class SkySSHRunner(SSHCommandRunner):
         *,
         up: bool,
         # Advanced options.
-        filter_options: Optional[str] = None,
+        filter_options: Optional[str] = None,  # RH MODIFIED
         log_path: str = os.devnull,
         stream_logs: bool = True,
         max_retry: int = 1,
+        return_cmd: bool = False,
     ) -> None:
-        # temp update rsync filters to exclude docs, when syncing over runhouse folder
-        org_rsync_filter = cr.RSYNC_FILTER_OPTION
-        if filter_options:
-            cr.RSYNC_FILTER_OPTION += f" --filter='{filter_options}'"
-        super().rsync(
-            source,
-            target,
-            up=up,
-            log_path=log_path,
-            stream_logs=stream_logs,
-            max_retry=max_retry,
+        """Uses 'rsync' to sync 'source' to 'target'.
+
+        Args:
+            source: The source path.
+            target: The target path.
+            up: The direction of the sync, True for local to cluster, False
+              for cluster to local.
+            filter_options: The filter options for rsync.
+            log_path: Redirect stdout/stderr to the log_path.
+            stream_logs: Stream logs to the stdout/stderr.
+            max_retry: The maximum number of retries for the rsync command.
+              This value should be non-negative.
+            return_cmd: If True, return the command string instead of running it.
+
+        Raises:
+            exceptions.CommandError: rsync command failed.
+        """
+        # Build command.
+        # TODO(zhwu): This will print a per-file progress bar (with -P),
+        # shooting a lot of messages to the output. --info=progress2 is used
+        # to get a total progress bar, but it requires rsync>=3.1.0 and Mac
+        # OS has a default rsync==2.6.9 (16 years old).
+        rsync_command = ["rsync", RSYNC_DISPLAY_OPTION]
+
+        # RH MODIFIED: add --filter option
+        addtl_filter_options = f" --filter='{filter_options}'" if filter_options else ""
+        rsync_command.append(RSYNC_FILTER_OPTION + addtl_filter_options)
+
+        if up:
+            # The source is a local path, so we need to resolve it.
+            # --exclude-from
+            resolved_source = pathlib.Path(source).expanduser().resolve()
+            if (resolved_source / GIT_EXCLUDE).exists():
+                # Ensure file exists; otherwise, rsync will error out.
+                rsync_command.append(
+                    RSYNC_EXCLUDE_OPTION.format(str(resolved_source / GIT_EXCLUDE))
+                )
+
+        if self._docker_ssh_proxy_command is not None:
+            docker_ssh_proxy_command = self._docker_ssh_proxy_command(["ssh"])
+        else:
+            docker_ssh_proxy_command = None
+        ssh_options = " ".join(
+            ssh_options_list(
+                self.ssh_private_key,
+                self.ssh_control_name,
+                ssh_proxy_command=self._ssh_proxy_command,
+                docker_ssh_proxy_command=docker_ssh_proxy_command,
+                port=self.port,
+                disable_control_master=self.disable_control_master,
+            )
         )
-        if filter_options:
-            cr.RSYNC_FILTER_OPTION = org_rsync_filter
+        rsync_command.append(f'-e "ssh {ssh_options}"')
+        # To support spaces in the path, we need to quote source and target.
+        # rsync doesn't support '~' in a quoted local path, but it is ok to
+        # have '~' in a quoted remote path.
+        if up:
+            full_source_str = str(resolved_source)
+            if resolved_source.is_dir():
+                full_source_str = os.path.join(full_source_str, "")
+            rsync_command.extend(
+                [
+                    f"{full_source_str!r}",
+                    f"{self.ssh_user}@{self.ip}:{target!r}",
+                ]
+            )
+        else:
+            rsync_command.extend(
+                [
+                    f"{self.ssh_user}@{self.ip}:{source!r}",
+                    f"{os.path.expanduser(target)!r}",
+                ]
+            )
+        command = " ".join(rsync_command)
+
+        # RH MODIFIED: return command instead of running it
+        if return_cmd:
+            return command
+
+        backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=5)
+        while max_retry >= 0:
+            returncode, _, stderr = log_lib.run_with_log(
+                command,
+                log_path=log_path,
+                stream_logs=stream_logs,
+                shell=True,
+                require_outputs=True,
+            )
+            if returncode == 0:
+                break
+            max_retry -= 1
+            time.sleep(backoff.current_backoff())
+
+        direction = "up" if up else "down"
+        error_msg = (
+            f"Failed to rsync {direction}: {source} -> {target}. "
+            "Ensure that the network is stable, then retry."
+        )
+        subprocess_utils.handle_returncode(
+            returncode, command, error_msg, stderr=stderr, stream_logs=stream_logs
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,26 +21,6 @@ from runhouse.globals import configs
 SSH_USER = "rh-docker-user"
 
 
-DEFAULT_LEVEL = TestLevels.UNIT
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--level",
-        action="store",
-        default=DEFAULT_LEVEL,
-        help="Fixture set to spin up: unit, local, minimal, thorough, or maximal",
-    )
-
-
-def pytest_generate_tests(metafunc):
-    level = metafunc.config.getoption("level")
-    level_fixtures = getattr(metafunc.module, level.upper(), default_fixtures[level])
-    for fixture_name, fixture_list in level_fixtures.items():
-        if fixture_name in metafunc.fixturenames:
-            metafunc.parametrize(fixture_name, fixture_list, indirect=True)
-
-
 class TestLevels(str, enum.Enum):
     UNIT = "unit"
     LOCAL = "local"
@@ -49,7 +29,7 @@ class TestLevels(str, enum.Enum):
     MAXIMAL = "maximal"
 
 
-DEFAULT_LEVEL = TestLevels.UNIT
+DEFAULT_LEVEL = TestLevels.MINIMAL
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ class TestLevels(str, enum.Enum):
     MAXIMAL = "maximal"
 
 
-DEFAULT_LEVEL = TestLevels.MINIMAL
+DEFAULT_LEVEL = TestLevels.UNIT
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,26 @@ from runhouse.globals import configs
 SSH_USER = "rh-docker-user"
 
 
+DEFAULT_LEVEL = TestLevels.UNIT
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--level",
+        action="store",
+        default=DEFAULT_LEVEL,
+        help="Fixture set to spin up: unit, local, minimal, thorough, or maximal",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    level = metafunc.config.getoption("level")
+    level_fixtures = getattr(metafunc.module, level.upper(), default_fixtures[level])
+    for fixture_name, fixture_list in level_fixtures.items():
+        if fixture_name in metafunc.fixturenames:
+            metafunc.parametrize(fixture_name, fixture_list, indirect=True)
+
+
 class TestLevels(str, enum.Enum):
     UNIT = "unit"
     LOCAL = "local"
@@ -47,6 +67,9 @@ def pytest_generate_tests(metafunc):
     for fixture_name, fixture_list in level_fixtures.items():
         if fixture_name in metafunc.fixturenames:
             metafunc.parametrize(fixture_name, fixture_list, indirect=True)
+
+
+############## FIXTURES ##############
 
 
 # https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ import dotenv
 import numpy as np
 import pandas as pd
 import pytest
-import enum
 
 import runhouse as rh
 from runhouse.globals import configs
@@ -58,31 +57,25 @@ class TestLevels(enum.Enum):
     MAXIMAL = "maximal"
 
 
+DEFAULT_LEVEL = TestLevels.UNIT.value
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--level",
         action="store",
-        default=TestLevels.UNIT.value,
+        default=DEFAULT_LEVEL,
         help="Fixture set to spin up: unit, local, minimal, thorough, or maximal",
     )
 
 
 def pytest_generate_tests(metafunc):
-    # suite_cls = metafunc.cls or metafunc.config.cache.get("suite")
-    # if not suite_cls:
-    #     suite = metafunc.config.getoption("suite")
-    #     if suite:
-    #         suite_cls_name = "Test" + suite.capitalize()
-    #         suite_cls = globals()[suite_cls_name]
-    #         metafunc.config.cache.set("suite", suite_cls)
     level = metafunc.config.getoption("level")
     level_fixtures = getattr(metafunc.module, level.upper(), {})
     for fixture_name, fixture_list in level_fixtures.items():
-        metafunc.parametrize(fixture_name, fixture_list, indirect=True)
+        if fixture_name in metafunc.fixturenames:
+            metafunc.parametrize(fixture_name, fixture_list, indirect=True)
 
-@pytest.fixture(scope="session")
-def cluster(request):
-    return request.getfixturevalue(request.param.__name__)
 
 ############## FIXTURES ##############
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,9 +49,6 @@ def pytest_generate_tests(metafunc):
             metafunc.parametrize(fixture_name, fixture_list, indirect=True)
 
 
-############## FIXTURES ##############
-
-
 # https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files
 
 ############## HELPERS ##############

--- a/tests/test_clusters/test_pwd_cluster.py
+++ b/tests/test_clusters/test_pwd_cluster.py
@@ -1,0 +1,33 @@
+import logging
+import unittest
+
+from tests.conftest import local_docker_cluster_passwd, password_cluster
+
+from tests.test_module import (
+    test_call_module_method,  # noqa: F401
+    test_module_from_factory,  # noqa: F401
+    test_module_from_subclass,  # noqa: F401
+    test_module_from_subclass_async,  # noqa: F401
+)
+from tests.test_obj_store import (
+    test_cancel_run,  # noqa: F401
+    test_get_from_cluster,  # noqa: F401
+    test_multiprocessing_streaming,  # noqa: F401
+    test_pinning_and_arg_replacement,  # noqa: F401
+    test_pinning_in_memory,  # noqa: F401
+    test_put_and_get_on_cluster,  # noqa: F401
+    test_put_resource,  # noqa: F401
+    test_stateful_generator,  # noqa: F401
+    test_stream_logs,  # noqa: F401
+    test_tqdm_streaming,  # noqa: F401
+)
+
+logger = logging.getLogger(__name__)
+
+UNIT = {"cluster": [local_docker_cluster_passwd]}
+LOCAL = {"cluster": [local_docker_cluster_passwd]}
+MINIMAL = {"cluster": [password_cluster, local_docker_cluster_passwd]}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_obj_store.py
+++ b/tests/test_obj_store.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import time
 import unittest
@@ -8,7 +7,6 @@ import numpy as np
 import pytest
 
 import runhouse as rh
-from runhouse import Package
 
 from tests.conftest import (
     byo_cpu,
@@ -103,33 +101,6 @@ def test_put_and_get_on_cluster(cluster):
     with pytest.raises(KeyError) as e:
         cluster.get("nonexistent_key", default=KeyError)
     assert "key nonexistent_key not found" in str(e.value)
-
-
-@pytest.mark.clustertest
-@pytest.mark.parametrize("env", [None, "base", "pytorch"])
-def test_call_module_method(cluster, env):
-    cluster.put("numpy_pkg", Package.from_string("numpy"), env=env)
-
-    # Test for method
-    res = cluster.call("numpy_pkg", "_detect_cuda_version_or_cpu")
-    assert res == "cpu"
-
-    # Test for property
-    res = cluster.call("numpy_pkg", "config_for_rns")
-    numpy_config = Package.from_string("numpy").config_for_rns
-    assert res
-    assert isinstance(res, dict)
-    assert res == numpy_config
-
-    # Test iterator
-    cluster.put("config_dict", list(numpy_config.keys()), env=env)
-    res = cluster.call("config_dict", "__iter__")
-    # Checks that all the keys in numpy_config were returned
-    inspect.isgenerator(res)
-    for key in res:
-        assert key
-        numpy_config.pop(key)
-    assert not numpy_config
 
 
 class slow_numpy_array:

--- a/tests/test_obj_store.py
+++ b/tests/test_obj_store.py
@@ -190,7 +190,6 @@ def test_put_resource(cluster, test_env):
     test_env.name = "~/test_env"
     cluster.put_resource(test_env)
     assert cluster.get("test_env").config_for_rns == test_env.config_for_rns
-
     assert (
         cluster.call("test_env", "config_for_rns", stream_logs=True)
         == test_env.config_for_rns


### PR DESCRIPTION
Uses pexepct to direct passwords to the console for clusters which require them, eliminating fsspec and paramiko from the connection flow, and also giving us a printable string to debug password cluster connection issues with. Everything now flows through the SkyPilot SSHCommandRunner, which I've also updated our fork of.

Also adds an attempt at a simple password test suite. Tests pass for docker and cpu password clusters.

...I have no idea what's going on with the commits. Help.