### PR TITLE
Support running shell commands in env

### DIFF
--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -151,11 +151,19 @@ class Env(Resource):
             if self._run_cmd:
                 cmd = f"{self._run_cmd} {cmd}"
             logging.info(f"Running: {cmd}")
-            ret_code = subprocess.call(
-                shlex.split(cmd),
-                # cwd=self.working_dir,  # Should we do this?
-                shell=False,
-            )
+            use_shell = any(shell_feat in cmd for shell_feat in [">", "|", "&&", "||"])
+            if use_shell:
+                # Example: "echo '<TOKEN>' > ~/.rh/config.yaml"
+                ret_code = subprocess.call(
+                    cmd,
+                    shell=True,
+                )
+            else:
+                ret_code = subprocess.call(
+                    shlex.split(cmd),
+                    # cwd=self.working_dir,  # Should we do this?
+                    shell=False,
+                )
             ret_codes.append(ret_code)
         return ret_codes
 


### PR DESCRIPTION
Example: 

```
rh.env(
        reqs=["pytest"],
        working_dir=None,
        setup_cmds=[
            f'mkdir -p ~/.rh; echo "token: {rh.configs.get("token")}" > ~/.rh/config.yaml'
        ],
        name="base_env")```