### PR TITLE
Remove deprecated pytest decorator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -557,9 +557,20 @@ def sm_source_dir(sm_entry_point, pytorch_training_script):
 
 @pytest.fixture(scope="session")
 def cluster(request):
-    """Parametrize over multiple fixtures - useful for running the same test on multiple hardware types."""
-    # Example: @pytest.mark.parametrize("cluster", [v100_gpu_cluster, k80_gpu_cluster], indirect=True)"""
     return request.getfixturevalue(request.param.__name__)
+
+
+@pytest.fixture(
+    params=[
+        "ondemand_cpu_cluster",
+        "v100_gpu_cluster",
+        "k80_gpu_cluster",
+        "a10g_gpu_cluster",
+    ],
+    ids=["cpu", "v100", "k80", "a10g"],
+)
+def ondemand_cluster(request):
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -726,22 +726,6 @@ def password_cluster():
     return cluster
 
 
-cpu_clusters = pytest.mark.parametrize(
-    "cluster",
-    [
-        "ondemand_cpu_cluster",
-        "ondemand_https_cluster_with_auth",
-        "password_cluster",
-        "byo_cpu",
-    ],
-    indirect=True,
-)
-
-sagemaker_clusters = pytest.mark.parametrize(
-    "cluster", ["sm_cluster", "other_sm_cluster"], indirect=True
-)
-
-
 # ----------------- Envs -----------------
 
 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -9,7 +9,6 @@ import runhouse as rh
 from runhouse import Cluster
 from runhouse.globals import configs
 
-from .conftest import cpu_clusters
 
 TEMP_LOCAL_FOLDER = Path(__file__).parents[1] / "rh-blobs"
 
@@ -70,7 +69,6 @@ def test_reload_file_with_path(blob):
 
 @pytest.mark.clustertest
 @pytest.mark.parametrize("file", ["local_file", "cluster_file"], indirect=True)
-@cpu_clusters
 def test_file_to_blob(file, cluster):
     local_blob = file.to("here")
     assert local_blob.system is None

--- a/tests/test_clusters/test_cluster.py
+++ b/tests/test_clusters/test_cluster.py
@@ -9,7 +9,7 @@ from runhouse.resources.hardware import OnDemandCluster
 from runhouse.resources.hardware.utils import ServerConnectionType
 from runhouse.rns.utils.api import resolve_absolute_path
 
-from ..conftest import cpu_clusters, summer
+from ..conftest import summer
 
 
 def is_on_cluster(cluster):
@@ -56,7 +56,6 @@ def test_read_shared_cluster(ondemand_cpu_cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_install(cluster):
     cluster.install_packages(
         [
@@ -69,7 +68,6 @@ def test_install(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_basic_run(cluster):
     # Create temp file where fn's will be stored
     test_cmd = "echo hi"
@@ -78,7 +76,6 @@ def test_basic_run(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_restart_server(cluster):
     cluster.up_if_not()
     codes = cluster.restart_server(resync_rh=False)
@@ -86,7 +83,6 @@ def test_restart_server(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_on_same_cluster(cluster):
     hw_copy = copy.copy(cluster)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -11,8 +11,6 @@ import yaml
 from runhouse.resources.folders.folder import Folder
 from runhouse.resources.packages import Package
 
-from .conftest import cpu_clusters
-
 pip_reqs = ["torch", "numpy"]
 
 # -------- BASE ENV TESTS ----------- #
@@ -47,7 +45,6 @@ def test_create_env():
 
 @pytest.mark.clustertest
 @pytest.mark.parametrize("env_name", ["base", "test_env"])
-@cpu_clusters
 def test_to_cluster(cluster, env_name):
     test_env = rh.env(name=env_name, reqs=["transformers"])
 
@@ -60,7 +57,6 @@ def test_to_cluster(cluster, env_name):
 
 @pytest.mark.awstest
 @pytest.mark.clustertest
-@cpu_clusters
 def test_to_fs_to_cluster(cluster, s3_package):
     cluster.install_packages(["s3fs"])
 
@@ -85,7 +81,6 @@ def test_to_fs_to_cluster(cluster, s3_package):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_function_to_env(cluster):
     test_env = rh.env(name="test-env", reqs=["parameterized"]).save()
 
@@ -114,7 +109,6 @@ def _get_env_var_value(env_var):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_function_env_vars(cluster):
     test_env_var = "TEST_ENV_VAR"
     test_value = "value"
@@ -127,7 +121,6 @@ def test_function_env_vars(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_function_env_vars_file(cluster):
     env_file = ".env"
     contents = ["# comment", "", "ENV_VAR1=value", "# comment with =", "ENV_VAR2 =val2"]
@@ -146,7 +139,6 @@ def test_function_env_vars_file(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_env_vars_to_cluster(cluster):
     env_vars = {"TEST_ENV_VAR": "value"}
     env = rh.env(name="base", reqs=["parameterized"], env_vars=env_vars)
@@ -154,7 +146,6 @@ def test_env_vars_to_cluster(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_env_vars_conda_env(cluster):
     test_env_var = "TEST_ENV_VAR_CONDA"
     test_value = "conda"
@@ -168,7 +159,6 @@ def test_env_vars_conda_env(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_env_git_reqs(cluster):
     git_package = rh.GitPackage(
         git_url="https://github.com/huggingface/diffusers.git",
@@ -183,7 +173,6 @@ def test_env_git_reqs(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_working_dir(cluster, tmp_path):
     working_dir = tmp_path / "test_working_dir"
     working_dir.mkdir(exist_ok=True)
@@ -243,7 +232,6 @@ def test_conda_env_from_name_rns():
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_env_path_to_system(cluster, tmp_path):
     env_name = "from_path"
     python_version = "3.9.16"
@@ -261,7 +249,6 @@ def test_conda_env_path_to_system(cluster, tmp_path):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_env_local_to_system(cluster):
     env_name = "local-env"
     python_version = "3.9.16"
@@ -272,7 +259,6 @@ def test_conda_env_local_to_system(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_env_dict_to_system(cluster):
     conda_env = _get_conda_env(python_version="3.9.16")
     test_env = rh.env(name="test_env", conda_env=conda_env)
@@ -285,7 +271,6 @@ def test_conda_env_dict_to_system(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_function_to_conda_env(cluster):
     conda_env = _get_conda_env(python_version="3.9.16")
     test_env = rh.env(name="test_env", conda_env=conda_env)
@@ -298,7 +283,6 @@ def test_function_to_conda_env(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_additional_reqs(cluster):
     new_conda_env = _get_conda_env(name="test-add-reqs")
     new_conda_env = rh.env(name="conda_env", reqs=["scipy"], conda_env=new_conda_env)
@@ -309,7 +293,6 @@ def test_conda_additional_reqs(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_git_reqs(cluster):
     conda_env = _get_conda_env(name="test-add-reqs")
     git_package = rh.GitPackage(
@@ -325,7 +308,6 @@ def test_conda_git_reqs(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_env_to_fs_to_cluster(cluster, s3_package):
     conda_env = _get_conda_env(name="s3-env")
     conda_env_s3 = rh.env(reqs=["s3fs", "scipy", s3_package], conda_env=conda_env).to(
@@ -365,7 +347,6 @@ def np_summer(a, b):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_call_fn(cluster):
     conda_dict = _get_conda_env(name="c")
     conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])
@@ -376,7 +357,6 @@ def test_conda_call_fn(cluster):
 
 @unittest.skip("Map does not work properly following Module refactor.")
 @pytest.mark.clustertest
-@cpu_clusters
 def test_conda_map_fn(cluster):
     conda_dict = _get_conda_env(name="test-map-fn")
     conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -8,7 +8,6 @@ import runhouse as rh
 from ray import cloudpickle as pickle
 from runhouse.globals import configs
 
-from .conftest import cpu_clusters
 
 DATA_STORE_BUCKET = "runhouse-folder"
 DATA_STORE_PATH = f"/{DATA_STORE_BUCKET}/folder-tests"
@@ -22,7 +21,6 @@ def fs_str_rh_fn(folder):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_from_cluster(cluster):
     rh.folder(path="./").to(cluster, path="my_new_tests_folder")
     tests_folder = rh.folder(system=cluster, path="my_new_tests_folder")
@@ -61,7 +59,6 @@ def test_create_and_delete_folder_from_s3():
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_folder_attr_on_cluster(local_folder, cluster):
     cluster_folder = local_folder.to(cluster)
     fs_str_cluster = rh.function(fn=fs_str_rh_fn).to(cluster)
@@ -72,7 +69,6 @@ def test_folder_attr_on_cluster(local_folder, cluster):
 @pytest.mark.gcptest
 @pytest.mark.awstest
 @pytest.mark.clustertest
-@cpu_clusters
 def test_cluster_tos(cluster, tmp_path):
     tests_folder = rh.folder(path=str(Path.cwd()))
 
@@ -105,7 +101,6 @@ def test_cluster_tos(cluster, tmp_path):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_local_and_cluster(cluster, local_folder, tmp_path):
     # Local to cluster
     cluster_folder = local_folder.to(system=cluster)
@@ -150,7 +145,6 @@ def test_local_and_gcs(local_folder, tmp_path):
 
 @pytest.mark.awstest
 @pytest.mark.clustertest
-@cpu_clusters
 def test_cluster_and_s3(cluster, cluster_folder):
     # Cluster to S3
     s3_folder = cluster_folder.to(system="s3")
@@ -167,7 +161,6 @@ def test_cluster_and_s3(cluster, cluster_folder):
 
 @unittest.skip("requires GCS setup")
 @pytest.mark.clustertest
-@cpu_clusters
 def test_cluster_and_gcs(cluster, cluster_folder):
     # Make sure we have gsutil and gcloud on the cluster - needed for copying the package + authenticating
     cluster.install_packages(["gsutil"])
@@ -267,7 +260,6 @@ def test_s3_folder_uploads_and_downloads(local_folder, tmp_path):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_cluster_and_cluster(byo_cpu, cluster, local_folder):
     # Upload sky secrets to cluster - required when syncing over the folder from c1 to c2
     byo_cpu.sync_secrets(providers=["sky"])

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,8 +6,6 @@ import pytest
 
 import runhouse as rh
 
-from .conftest import cpu_clusters
-
 extra_index_url = "--extra-index-url https://pypi.python.org/simple/"
 cuda_116_url = "--index-url https://download.pytorch.org/whl/cu116"
 
@@ -80,7 +78,6 @@ def test_load_shared_git_package():
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_local_package_function(cluster):
     function = rh.function(fn=summer).to(cluster, env=["./"])
 
@@ -91,7 +88,6 @@ def test_local_package_function(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_local_package_to_cluster(cluster):
     package = rh.Package.from_string("./").to(cluster)
 
@@ -100,7 +96,6 @@ def test_local_package_to_cluster(cluster):
 
 
 @pytest.mark.clustertest
-@cpu_clusters
 def test_mount_local_package_to_cluster(cluster):
     mount_path = "package_mount"
     package = rh.Package.from_string("./").to(cluster, path=mount_path, mount=True)
@@ -112,7 +107,6 @@ def test_mount_local_package_to_cluster(cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.awstest
-@cpu_clusters
 def test_package_file_system_to_cluster(cluster, s3_package):
     assert s3_package.install_target.system == "s3"
     assert s3_package.install_target.exists_in_system()
@@ -277,11 +271,6 @@ def test_torch_install_command_generator():
 
 
 @pytest.mark.gputest
-@pytest.mark.parametrize(
-    "cluster",
-    ["ondemand_cpu_cluster", "v100_gpu_cluster", "k80_gpu_cluster", "a10g_gpu_cluster"],
-    indirect=True,
-)
 def test_getting_cuda_version_on_clusters(request, cluster):
     """Gets the cuda version on the cluster and asserts it is the expected version"""
     return_codes: list = cluster.run_python(
@@ -304,11 +293,6 @@ def test_getting_cuda_version_on_clusters(request, cluster):
 
 
 @pytest.mark.gputest
-@pytest.mark.parametrize(
-    "cluster",
-    ["ondemand_cpu_cluster", "v100_gpu_cluster", "k80_gpu_cluster", "a10g_gpu_cluster"],
-    indirect=True,
-)
 def test_install_cmd_for_torch_on_cluster(request, cluster):
     """Checks that the install command for torch runs properly on the cluster.
     Confirms that we can properly install the package (and send a torch tensor to cuda to validate it"""

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -4,8 +4,6 @@ import pytest
 
 import runhouse as rh
 
-from .conftest import cpu_clusters
-
 
 @pytest.mark.rnstest
 def test_get_all_secrets_from_vault():
@@ -146,7 +144,6 @@ def test_add_github_secrets():
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@cpu_clusters
 def test_sending_secrets_to_cluster(cluster):
     # only send a few to the cluster
     providers: list = rh.Secrets.enabled_providers()[:3]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -9,8 +9,6 @@ import runhouse as rh
 
 from runhouse import Folder
 
-from .conftest import cpu_clusters
-
 NUM_PARTITIONS = 10
 
 
@@ -558,7 +556,6 @@ def test_shuffling_pyarrow_data_from_s3(arrow_table, table_s3_bucket):
 # -------------------------------------------------
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@cpu_clusters
 def test_create_and_reload_pandas_data_from_cluster(pandas_table, cluster):
     # Make sure the destination folder for the data exists on the cluster
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/pandas-data"
@@ -597,7 +594,6 @@ def test_create_and_reload_pandas_data_from_cluster(pandas_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@cpu_clusters
 def test_create_and_reload_ray_data_from_cluster(ray_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/ray-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -637,7 +633,6 @@ def test_create_and_reload_ray_data_from_cluster(ray_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@cpu_clusters
 def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/pyarrow-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -674,7 +669,6 @@ def test_create_and_reload_pyarrow_data_from_cluster(arrow_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@cpu_clusters
 def test_create_and_reload_huggingface_data_from_cluster(huggingface_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/hf-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -713,7 +707,6 @@ def test_create_and_reload_huggingface_data_from_cluster(huggingface_table, clus
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@cpu_clusters
 def test_create_and_reload_dask_data_from_cluster(dask_table, cluster):
     data_path_on_cluster = f"{Folder.DEFAULT_CACHE_FOLDER}/dask-data"
     cluster.run([f"mkdir -p {data_path_on_cluster}"])
@@ -751,7 +744,6 @@ def test_create_and_reload_dask_data_from_cluster(dask_table, cluster):
 
 @pytest.mark.clustertest
 @pytest.mark.rnstest
-@cpu_clusters
 def test_to_cluster_attr(pandas_table, cluster, tmp_path):
     local_path = tmp_path / "table_tests/local_test_table"
     name = "~/my_local_test_table"


### PR DESCRIPTION
Use `default_fixtures` based on the provided test level instead of the `cpu_clusters` decorator