### PR TITLE
Enable simultaneous cluster tests

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -53,9 +53,7 @@ class Cluster(Resource):
     SERVER_START_CMD = f"{sys.executable} -m runhouse.servers.http.http_server"
     SERVER_STOP_CMD = f'pkill -f "{SERVER_START_CMD}"'
     # 2>&1 redirects stderr to stdout
-    START_SCREEN_CMD = (
-        f"screen -dm bash -c \"{SERVER_START_CMD} |& tee -a '{SERVER_LOGFILE}' 2>&1\""
-    )
+    START_SCREEN_CMD = f"screen -dm bash -c \"{SERVER_START_CMD} 2>&1 | tee -a '{SERVER_LOGFILE}' 2>&1\""
     RAY_START_CMD = "ray start --head --port 6379"
     # RAY_BOOTSTRAP_FILE = "~/ray_bootstrap_config.yaml"
     # --autoscaling-config=~/ray_bootstrap_config.yaml

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -920,7 +920,7 @@ class Cluster(Resource):
                     return_cmd=True,
                     ssh_mode=SshMode.INTERACTIVE,
                 )
-                ssh = pexpect.spawn(ssh_command, encoding="utf-8")
+                ssh = pexpect.spawn(ssh_command, encoding="utf-8", timeout=None)
                 ssh.logfile_read = sys.stdout
                 # If CommandRunner uses the control path, the password may not be requested
                 next_line = ssh.expect(["assword:", pexpect.EOF])
@@ -939,7 +939,7 @@ class Cluster(Resource):
                 stream_logs=stream_logs,
                 return_cmd=True,
             )
-            ssh = pexpect.spawn(rsync_cmd, encoding="utf-8")
+            ssh = pexpect.spawn(rsync_cmd, encoding="utf-8", timeout=None)
             if stream_logs:
                 # FYI This will print a ton of of stuff to stdout
                 ssh.logfile_read = sys.stdout
@@ -1071,7 +1071,7 @@ class Cluster(Resource):
                     ssh_mode=SshMode.INTERACTIVE,
                     quiet_ssh=True,
                 )
-                ssh = pexpect.spawn(ssh_command, encoding="utf-8")
+                ssh = pexpect.spawn(ssh_command, encoding="utf-8", timeout=None)
                 if stream_logs:
                     ssh.logfile_read = sys.stdout
                 next_line = ssh.expect(["assword:", pexpect.EOF])

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -31,13 +31,15 @@ def cluster(
 
     Args:
         name (str): Name for the cluster, to re-use later on.
-        host (str or List[str], optional): Hostname, IP address, or list of IP addresses for the BYO cluster.
+        host (str or List[str], optional): Hostname (e.g. domain or name in .ssh/config), IP address, or list of IP
+            addresses for the cluster (the first of which is the head node).
         ssh_creds (dict, optional): Dictionary mapping SSH credentials.
             Example: ``ssh_creds={'ssh_user': '...', 'ssh_private_key':'<path_to_key>'}``
         server_port (bool, optional): Port to use for the server. If not provided will use 80 for a
             ``server_connection_type`` of ``none``, 443 for ``tls`` and ``32300`` for all other SSH connection types.
-        server_host (bool, optional): Host for the server. If connecting to the server with an SSH connection,
-            use `localhost`` or ``127.0.0.1``. If not provided, will use the IP address of the server.
+        server_host (bool, optional): Host from which the server listens for traffic (i.e. the --host argument
+            `runhouse start` run on the cluster). Defaults to "0.0.0.0" unless connecting to the server with an SSH
+            connection, in which case ``localhost`` is used.
         server_connection_type (ServerConnectionType or str, optional): Type of connection to use for the Runhouse
             API server. ``ssh`` will use start with server via an SSH tunnel. ``tls`` will start the server
             with HTTPS on port 443 using TLS certs without an SSH tunnel. ``none`` will start the server with HTTP
@@ -74,21 +76,18 @@ def cluster(
             "``ips`` argument has been deprecated. Please use ``host`` to refer to the cluster IPs or host instead."
         )
 
-    if server_connection_type:
-        if ssh_creds and server_connection_type != ServerConnectionType.SSH:
-            raise ValueError(
-                f"SSH creds provided but server connection type not set to {ServerConnectionType.SSH}"
-            )
-        if server_connection_type == ServerConnectionType.AWS_SSM:
-            raise ValueError(
-                f"Cluster does not support server connection type of {server_connection_type}"
-            )
-    else:
-        server_connection_type = (
-            ServerConnectionType.TLS
-            if ssl_certfile or ssl_keyfile
-            else ServerConnectionType.SSH
-        )
+    if "localhost" in host or ":" in host:
+        server_connection_type = server_connection_type or ServerConnectionType.NONE
+        if ":" in host:
+            # e.g. "localhost:23324" or <real_ip>:<custom port> (e.g. a port is already open to the server)
+            host, client_port = self.address.split(":")
+            kwargs["client_port"] = client_port
+
+    server_connection_type = server_connection_type or (
+        ServerConnectionType.TLS
+        if ssl_certfile or ssl_keyfile
+        else ServerConnectionType.SSH
+    )
 
     if server_port is None:
         if server_connection_type == ServerConnectionType.TLS:
@@ -122,7 +121,18 @@ def cluster(
         )
 
     if "instance_type" in kwargs.keys():
-        return ondemand_cluster(name=name, **kwargs)
+        return ondemand_cluster(
+            name=name,
+            ssh_creds=ssh_creds,
+            server_port=server_port,
+            server_host=server_host,
+            server_connection_type=server_connection_type,
+            ssl_keyfile=ssl_keyfile,
+            ssl_certfile=ssl_certfile,
+            den_auth=den_auth,
+            dryrun=dryrun,
+            **kwargs,
+        )
 
     if any(
         k in kwargs.keys()
@@ -138,7 +148,23 @@ def cluster(
             "The `cluster` factory is intended to be used for static clusters. "
             "If you would like to create a sagemaker cluster, please use `rh.sagemaker_cluster()` instead."
         )
-        return sagemaker_cluster(name=name, **kwargs)
+        return sagemaker_cluster(
+            name=name,
+            ssh_creds=ssh_creds,
+            server_port=server_port,
+            server_host=server_host,
+            server_connection_type=server_connection_type,
+            ssl_keyfile=ssl_keyfile,
+            ssl_certfile=ssl_certfile,
+            den_auth=den_auth,
+            dryrun=dryrun,
+            **kwargs,
+        )
+
+    if server_connection_type == ServerConnectionType.AWS_SSM:
+        raise ValueError(
+            f"Cluster does not support server connection type of {server_connection_type}"
+        )
 
     c = Cluster(
         ips=host,
@@ -151,6 +177,7 @@ def cluster(
         ssl_certfile=ssl_certfile,
         den_auth=den_auth,
         dryrun=dryrun,
+        **kwargs,
     )
 
     if den_auth:
@@ -202,8 +229,9 @@ def ondemand_cluster(
             that you are responsible for ensuring that the applications listening on these ports are secure.
         server_port (bool, optional): Port to use for the server. If not provided will use 80 for a
             ``server_connection_type`` of ``none``, 443 for ``tls`` and ``32300`` for all other SSH connection types.
-        server_host (bool, optional): Host for the server. If connecting to the server with an SSH connection,
-            use `localhost`` or ``127.0.0.1``. If not provided, will use the IP address of the server.
+        server_host (bool, optional): Host from which the server listens for traffic (i.e. the --host argument
+            `runhouse start` run on the cluster). Defaults to "0.0.0.0" unless connecting to the server with an SSH
+            connection, in which case ``localhost`` is used.
         server_connection_type (ServerConnectionType or str, optional): Type of connection to use for the Runhouse
             API server. ``ssh`` will use start with server via an SSH tunnel. ``tls`` will start the server
             with HTTPS on port 443 using TLS certs without an SSH tunnel. ``none`` will start the server with HTTP
@@ -237,7 +265,6 @@ def ondemand_cluster(
     """
     if server_connection_type in [
         ServerConnectionType.AWS_SSM,
-        ServerConnectionType.PARAMIKO,
     ]:
         raise ValueError(
             f"OnDemandCluster does not support server connection type {server_connection_type}"
@@ -359,6 +386,7 @@ def ondemand_cluster(
         den_auth=den_auth,
         name=name,
         dryrun=dryrun,
+        **kwargs,
     )
 
     if den_auth:
@@ -429,7 +457,8 @@ def sagemaker_cluster(
         server_port (bool, optional): Port to use for the server. If not provided will use 80 for a
             ``server_connection_type`` of ``none``, 443 for ``tls`` and ``32300`` for all other SSH connection types.
             *Note: For SageMaker will use ``32300`` since the connection will always be made via SSH.*
-        server_host (bool, optional): Host to use for the server.
+        server_host (bool, optional): Host from which the server listens for traffic (i.e. the --host argument
+            `runhouse start` run on the cluster).
             *Note: For SageMaker, since we connect to the Runhouse API server via an SSH tunnel, the only valid
             host is localhost.*
         server_connection_type (ServerConnectionType or str, optional): Type of connection to use for the Runhouse
@@ -534,6 +563,7 @@ def sagemaker_cluster(
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         dryrun=dryrun,
+        **kwargs,
     )
 
     if den_auth:

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -59,6 +59,7 @@ class OnDemandCluster(Cluster):
             ssl_certfile=ssl_certfile,
             den_auth=den_auth,
             dryrun=dryrun,
+            **kwargs,
         )
 
         self.instance_type = instance_type

--- a/runhouse/resources/hardware/sagemaker_cluster.py
+++ b/runhouse/resources/hardware/sagemaker_cluster.py
@@ -99,6 +99,7 @@ class SageMakerCluster(Cluster):
             ssl_keyfile=ssl_keyfile,
             den_auth=den_auth,
             dryrun=dryrun,
+            **kwargs,
         )
         self._connection_wait_time = connection_wait_time
         self._instance_type = instance_type
@@ -111,7 +112,7 @@ class SageMakerCluster(Cluster):
 
         # Keep track of the ports used for forwarding to the cluster
         self._local_port = self.DEFAULT_SERVER_PORT
-        self._ssh_port = self.DEFAULT_SSH_PORT
+        self._ssh_port = self.DEFAULT_SSH_PORT  # TODO reconcile with Cluster.ssh_port?
 
         # Note: Relevant only if an estimator is explicitly provided
         self._estimator_entry_point = kwargs.get("estimator_entry_point")

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -43,7 +43,6 @@ class ServerConnectionType(str, Enum):
     TLS = "tls"
     NONE = "none"
     AWS_SSM = "aws_ssm"
-    PARAMIKO = "paramiko"
 
 
 def _current_cluster(key="name"):

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -735,7 +735,11 @@ if __name__ == "__main__":
         help="Address to use for generating self-signed certs and enabling HTTPS. (e.g. public IP address)",
     )
 
-    cluster_config = _load_cluster_config()
+    cluster_config = (
+        _load_cluster_config()
+        if Path("~/.rh/cluster_config.yaml").expanduser().exists()
+        else {}
+    )
     parse_args = parser.parse_args()
 
     conda_name = parse_args.conda_env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ class TestLevels(str, enum.Enum):
     MAXIMAL = "maximal"
 
 
-DEFAULT_LEVEL = TestLevels.UNIT
+DEFAULT_LEVEL = TestLevels.LOCAL
 
 
 def pytest_addoption(parser):
@@ -206,7 +206,7 @@ from tests.test_resources.test_modules.test_tables.conftest import (
 default_fixtures = {}
 default_fixtures[TestLevels.UNIT] = {"cluster": [local_docker_cluster_public_key]}
 default_fixtures[TestLevels.LOCAL] = {
-    "cluster": [local_docker_cluster_passwd, local_docker_cluster_public_key]
+    "cluster": [local_docker_cluster_public_key, local_docker_cluster_passwd]
 }
 default_fixtures[TestLevels.MINIMAL] = {"cluster": [ondemand_cpu_cluster]}
 default_fixtures[TestLevels.THOROUGH] = {

--- a/tests/test_resources/test_clusters/conftest.py
+++ b/tests/test_resources/test_clusters/conftest.py
@@ -502,6 +502,6 @@ def local_docker_cluster_passwd(request, detached=True):
 
     # Stop the Docker container
     if not detached:
-        client.containers.get("rh-slim-server-password-auth").stop()
+        client.containers.get(container_name).stop()
         client.containers.prune()
         client.images.prune()

--- a/tests/test_resources/test_clusters/conftest.py
+++ b/tests/test_resources/test_clusters/conftest.py
@@ -10,6 +10,7 @@ import runhouse as rh
 from ...conftest import init_args
 
 SSH_USER = "rh-docker-user"
+BASE_LOCAL_SSH_PORT = 32320
 
 
 @pytest.fixture(scope="session")
@@ -147,6 +148,7 @@ def build_and_run_image(
     keypath=None,
     pwd_file=None,
     force_rebuild=False,
+    port_fwds=["22:22"],
 ):
 
     import subprocess
@@ -220,28 +222,14 @@ def build_and_run_image(
             run_shell_command(subprocess, build_cmd, cwd=str(rh_parent_path.parent))
 
         # Run the Docker image
-        run_cmd = [
-            "docker",
-            "run",
-            "--name",
-            container_name,
-            "-d",
-            "--rm",
-            "--shm-size=4gb",
-            "-p",
-            "32300:32300",
-            "-p",
-            "6379:6379",
-            "-p",
-            "52365:52365",
-            "-p",
-            "443:443",
-            "-p",
-            "80:80",
-            "-p",
-            "22:22",
-            f"runhouse:{image_name}",
-        ]
+        port_fwds = (
+            "".join([f"-p {port_fwd} " for port_fwd in port_fwds]).strip().split(" ")
+        )
+        run_cmd = (
+            ["docker", "run", "--name", container_name, "-d", "--rm", "--shm-size=4gb"]
+            + port_fwds
+            + [f"runhouse:{image_name}"]
+        )
         print(shlex.join(run_cmd))
         res = popen_shell_command(subprocess, run_cmd, cwd=str(rh_parent_path.parent))
         stdout, stderr = res.communicate()
@@ -291,13 +279,14 @@ def popen_shell_command(subprocess, command: list[str], cwd: str = None):
 @pytest.fixture(scope="session")
 def local_logged_out_docker_cluster(request, detached=True):
     image_name = "keypair"
-    container_name = "rh-slim-server-public-key-auth"
+    container_name = "rh-logged-out-slim"
     dir_name = "public-key-auth"
     keypath = str(
         Path(
             rh.configs.get("default_keypair", "~/.ssh/runhouse/docker/id_rsa")
         ).expanduser()
     )
+    local_ssh_port = BASE_LOCAL_SSH_PORT + 1
 
     client, rh_parent_path = build_and_run_image(
         image_name=image_name,
@@ -306,13 +295,16 @@ def local_logged_out_docker_cluster(request, detached=True):
         detached=detached,
         keypath=keypath,
         force_rebuild=request.config.getoption("--force-rebuild"),
+        port_fwds=[f"{local_ssh_port}:22"],
     )
 
     # Runhouse commands can now be run locally
     args = dict(
-        name="local-docker-slim-public-key-auth",
+        name="local_logged_out_docker_cluster",
         host="localhost",
         server_host="0.0.0.0",
+        ssh_port=local_ssh_port,
+        server_connection_type="ssh",
         ssh_creds={
             "ssh_user": SSH_USER,
             "ssh_private_key": keypath,
@@ -341,13 +333,14 @@ def local_logged_out_docker_cluster(request, detached=True):
 @pytest.fixture(scope="session")
 def local_docker_cluster_public_key(request, detached=True):
     image_name = "keypair"
-    container_name = "rh-slim-server-public-key-auth"
+    container_name = "rh-slim-keypair"
     dir_name = "public-key-auth"
     keypath = str(
         Path(
             rh.configs.get("default_keypair", "~/.ssh/runhouse/docker/id_rsa")
         ).expanduser()
     )
+    local_ssh_port = BASE_LOCAL_SSH_PORT + 2
 
     client, rh_parent_path = build_and_run_image(
         image_name=image_name,
@@ -356,13 +349,16 @@ def local_docker_cluster_public_key(request, detached=True):
         detached=detached,
         keypath=keypath,
         force_rebuild=request.config.getoption("--force-rebuild"),
+        port_fwds=[f"{local_ssh_port}:22"],
     )
 
     # Runhouse commands can now be run locally
     args = dict(
-        name="local-docker-slim-public-key-auth",
+        name="local-docker-slim-keypair",
         host="localhost",
         server_host="0.0.0.0",
+        ssh_port=local_ssh_port,
+        server_connection_type="ssh",
         ssh_creds={
             "ssh_user": SSH_USER,
             "ssh_private_key": keypath,
@@ -399,21 +395,25 @@ def local_test_account_cluster_public_key(request, test_account, detached=True):
                 rh.configs.get("default_keypair", "~/.ssh/runhouse/docker/id_rsa")
             ).expanduser()
         )
+        local_ssh_port = BASE_LOCAL_SSH_PORT + 3
 
         client, rh_parent_path = build_and_run_image(
             image_name="keypair",
-            container_name="rh-slim-server-public-key-auth",
+            container_name="rh-slim-test-acct",
             detached=True,
             dir_name="public-key-auth",
             keypath=keypath,
             force_rebuild=pytestconfig.getoption("--force-rebuild"),
+            port_fwds=[f"{local_ssh_port}:22"],
         )
 
         args = dict(
-            name="local-docker-slim-public-key-auth",
+            name="local-docker-slim-test-acct",
             host="localhost",
             den_auth=True,
             server_host="0.0.0.0",
+            ssh_port=local_ssh_port,
+            server_connection_type="ssh",
             ssh_creds={
                 "ssh_user": SSH_USER,
                 "ssh_private_key": keypath,
@@ -460,9 +460,10 @@ def shared_cluster(test_account, local_test_account_cluster_public_key):
 @pytest.fixture(scope="session")
 def local_docker_cluster_passwd(request, detached=True):
     image_name = "pwd"
-    container_name = "rh-slim-server-password-auth"
+    container_name = "rh-slim-password"
     dir_name = "password-file-auth"
     pwd_file = "docker_user_passwd"
+    local_ssh_port = BASE_LOCAL_SSH_PORT + 4
 
     client, rh_parent_path = build_and_run_image(
         image_name=image_name,
@@ -471,14 +472,17 @@ def local_docker_cluster_passwd(request, detached=True):
         detached=detached,
         pwd_file=pwd_file,
         force_rebuild=request.config.getoption("--force-rebuild"),
+        port_fwds=[f"{local_ssh_port}:22"],
     )
 
     # Runhouse commands can now be run locally
     pwd = (rh_parent_path.parent / pwd_file).read_text().strip()
     args = dict(
-        name="local-docker-slim-password-file-auth",
+        name="local-docker-slim-password",
         host="localhost",
         server_host="0.0.0.0",
+        ssh_port=local_ssh_port,
+        server_connection_type="ssh",
         ssh_creds={"ssh_user": SSH_USER, "password": pwd},
     )
     c = rh.cluster(**args)

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -27,16 +27,15 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     UNIT = {"cluster": [local_docker_cluster_public_key]}
     LOCAL = {
         "cluster": [
-            named_cluster,
             local_docker_cluster_public_key,
             local_docker_cluster_passwd,
             local_logged_out_docker_cluster,
             local_test_account_cluster_public_key,
         ]
     }
-    REMOTE = {"cluster": [static_cpu_cluster]}
-    FULL = {"cluster": [named_cluster, password_cluster]}
-    ALL = {"cluster": [named_cluster, password_cluster]}
+    MINIMAL = {"cluster": [static_cpu_cluster]}
+    THOROUGH = {"cluster": [named_cluster, password_cluster]}
+    MAXIMAL = {"cluster": [named_cluster, password_cluster]}
 
     def test_cluster_factory_and_properties(self, cluster):
         assert isinstance(cluster, rh.Cluster)


### PR DESCRIPTION
- Enable simultaneous docker cluster tests
- Introduce ssh_port and client_port in Cluster to avoid collisions on localhost:22
- Docker clusters now connect over ssh tunnels if connection_type="ssh" instead of opening ports and sidestepping ssh (more realistic)
- Fix passthrough bugs in cluster factories
- Remove PARAMIKO connection type, obsolete 

Module tests pass with LOCAL