### PR TITLE
Change default keypair keypath for Docker-based local tests.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,10 @@ do TDD and add edge cases one-off as needed. We also use imports within test mod
 test cases in multiple suites where appropriate (just importing the test case function is enough for PyTest to
 do this, so ignore warnings that the imports are unused).
 
+Runhouse uses Sky (which uses ssh) to communicate with the clusters it runs on (e.g. AWS EC2). Sky generates
+a keypair for you locally the first time you use it to communicate with a cluster, and for local container tests
+we take this key from `~/.ssh/sky-key` and copy it to the Docker containers such that Sky can communicate with them.
+
 To run a single test file with a given level, use a command like this:
 ```bash
 pytest -s -v --level "unit" tests/test_resources/test_resource.py

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ do this, so ignore warnings that the imports are unused).
 
 Runhouse uses Sky (which uses ssh) to communicate with the clusters it runs on (e.g. AWS EC2). Sky generates
 a keypair for you locally the first time you use it to communicate with a cluster, and for local container tests
-we take this key from `~/.ssh/sky-key` and copy it to the Docker containers such that Sky can communicate with them.
+we take this key from `~/.ssh/sky-key` and copy it to the Docker containers such that Sky can communicate with them. You can override the choice of keypair by adding the following line to your `~/.rh/config.yaml`: `default_keypair: <path to your private key>`.
 
 To run a single test file with a given level, use a command like this:
 ```bash

--- a/tests/test_resources/test_clusters/conftest.py
+++ b/tests/test_resources/test_clusters/conftest.py
@@ -11,6 +11,7 @@ from ...conftest import init_args
 
 SSH_USER = "rh-docker-user"
 BASE_LOCAL_SSH_PORT = 32320
+DEFAULT_KEYPAIR_KEYPATH = "~/.ssh/sky-key"
 
 
 @pytest.fixture(scope="session")
@@ -282,9 +283,7 @@ def local_logged_out_docker_cluster(request, detached=True):
     container_name = "rh-logged-out-slim"
     dir_name = "public-key-auth"
     keypath = str(
-        Path(
-            rh.configs.get("default_keypair", "~/.ssh/runhouse/docker/id_rsa")
-        ).expanduser()
+        Path(rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)).expanduser()
     )
     local_ssh_port = BASE_LOCAL_SSH_PORT + 1
 
@@ -336,9 +335,7 @@ def local_docker_cluster_public_key(request, detached=True):
     container_name = "rh-slim-keypair"
     dir_name = "public-key-auth"
     keypath = str(
-        Path(
-            rh.configs.get("default_keypair", "~/.ssh/runhouse/docker/id_rsa")
-        ).expanduser()
+        Path(rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)).expanduser()
     )
     local_ssh_port = BASE_LOCAL_SSH_PORT + 2
 
@@ -392,7 +389,7 @@ def local_test_account_cluster_public_key(request, test_account, detached=True):
         # Create the shared cluster using the test account
         keypath = str(
             Path(
-                rh.configs.get("default_keypair", "~/.ssh/runhouse/docker/id_rsa")
+                rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
             ).expanduser()
         )
         local_ssh_port = BASE_LOCAL_SSH_PORT + 3


### PR DESCRIPTION
As explained in `tests/README.md`, users generally have a sky-key set up and we can use that for communication with local Docker clusters.