### PR TITLE
Fixing test account context manager to correctly update account in global cache.

### DIFF
--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -4,7 +4,9 @@ import os
 import pkgutil
 import shutil
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
+
+import dotenv
 
 import requests
 
@@ -191,6 +193,37 @@ class RNSClient:
                 del payload[k]
         payload["data"] = data
         return payload
+
+    def load_account_from_env(self) -> Dict[str, str]:
+        dotenv.load_dotenv()
+
+        test_token = os.getenv("TEST_TOKEN")
+        test_username = os.getenv("TEST_USERNAME")
+        if not (test_token and test_username):
+            return None
+
+        # Hack to avoid actually writing down these values, in case the user stops mid-test and we don't reach the
+        # finally block
+        self._configs.defaults_cache["token"] = test_token
+        self._configs.defaults_cache["username"] = test_username
+        self._configs.defaults_cache["default_folder"] = f"/{test_username}"
+
+        # The client caches the folder that is used as the current folder variable, we clear this so it loads the new
+        # folder when we switch accounts
+        self._current_folder = None
+
+        return {
+            "token": self._configs.defaults_cache["token"],
+            "username": self._configs.defaults_cache["username"],
+            "default_folder": self._configs.defaults_cache["default_folder"],
+        }
+
+    def load_account_from_file(self) -> None:
+        # Setting this to None causes it to be loaded from file upon next access
+        self._configs.defaults_cache = None
+
+        # Same as above, for this to correctly load the account/folder from the new cache, it needs to be unset
+        self._current_folder = None
 
     # Run Stack
     # ---------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,9 @@
 import contextlib
 import enum
-import os
-
-import dotenv
 
 import pytest
 
-import runhouse as rh
+from runhouse.globals import rns_client
 
 
 class TestLevels(str, enum.Enum):
@@ -82,39 +79,14 @@ def test_account():
     """Used for the purposes of testing resource sharing among different accounts.
     When inside the context manager, use the test account credentials before reverting back to the original
     account when exiting."""
-    dotenv.load_dotenv()
-
-    test_token = os.getenv("TEST_TOKEN")
-    test_username = os.getenv("TEST_USERNAME")
-    if not test_token or not test_username:
-        pytest.skip("`TEST_TOKEN` or `TEST_USERNAME` not set, skipping test.")
-
-    current_token = rh.configs.get("token")
-    current_username = rh.configs.get("username")
 
     try:
-        # Assume the role of the test account when inside the context manager
-        test_account_token = test_token
-        test_account_username = test_username
-        test_account_folder = f"/{test_account_username}"
-
-        # Hack to avoid actually writing down these values, in case the user stops mid-test and we don't reach the
-        # finally block
-        rh.configs.defaults_cache["token"] = test_account_token
-        rh.configs.defaults_cache["username"] = test_account_username
-        rh.configs.defaults_cache["default_folder"] = test_account_folder
-
-        yield {
-            "test_token": test_account_token,
-            "test_username": test_account_username,
-            "test_folder": test_account_folder,
-        }
-
+        account = rns_client.load_account_from_env()
+        if account is None:
+            pytest.skip("`TEST_TOKEN` or `TEST_USERNAME` not set, skipping test.")
+        
     finally:
-        # Reset configs back to original account
-        rh.configs.defaults_cache["token"] = current_token
-        rh.configs.defaults_cache["username"] = current_username
-        rh.configs.defaults_cache["default_folder"] = f"/{current_username}"
+        rns_client.load_account_from_file()
 
 
 # ----------------- Clusters -----------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,8 @@ def test_account():
         account = rns_client.load_account_from_env()
         if account is None:
             pytest.skip("`TEST_TOKEN` or `TEST_USERNAME` not set, skipping test.")
-        
+        yield account
+
     finally:
         rns_client.load_account_from_file()
 

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -7,7 +7,7 @@ from .conftest import (
     local_docker_cluster_passwd,
     local_docker_cluster_public_key,
     local_logged_out_docker_cluster,
-    local_test_account_cluster_public_key,
+    # local_test_account_cluster_public_key,
     named_cluster,
     password_cluster,
     static_cpu_cluster,
@@ -30,7 +30,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
             local_docker_cluster_public_key,
             local_docker_cluster_passwd,
             local_logged_out_docker_cluster,
-            local_test_account_cluster_public_key,
+            # local_test_account_cluster_public_key,
         ]
     }
     MINIMAL = {"cluster": [static_cpu_cluster]}

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -7,7 +7,6 @@ from .conftest import (
     local_docker_cluster_passwd,
     local_docker_cluster_public_key,
     local_logged_out_docker_cluster,
-    # local_test_account_cluster_public_key,
     named_cluster,
     password_cluster,
     static_cpu_cluster,
@@ -30,7 +29,6 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
             local_docker_cluster_public_key,
             local_docker_cluster_passwd,
             local_logged_out_docker_cluster,
-            # local_test_account_cluster_public_key,
         ]
     }
     MINIMAL = {"cluster": [static_cpu_cluster]}


### PR DESCRIPTION
There was a bug in the `test_account` context manager / fixture that led to the config not being properly updated globally. This led to Resources being created with the wrong account in test usages.