### PR TITLE
Cleaning up local Docker cluster fixtures.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,9 +97,9 @@ from tests.test_resources.test_clusters.conftest import (
     byo_cpu,  # noqa: F401
     cluster,  # noqa: F401
     local_docker_cluster_passwd,  # noqa: F401
-    local_docker_cluster_public_key,  # noqa: F401
+    local_docker_cluster_public_key_logged_in,  # noqa: F401
+    local_docker_cluster_public_key_logged_out,  # noqa: F401
     local_docker_cluster_telemetry_public_key,  # noqa: F401
-    local_logged_out_docker_cluster,  # noqa: F401
     local_test_account_cluster_public_key,  # noqa: F401
     named_cluster,  # noqa: F401
     password_cluster,  # noqa: F401
@@ -190,15 +190,26 @@ from tests.test_resources.test_modules.test_tables.conftest import (
 ########## DEFAULT LEVELS ##########
 
 default_fixtures = {}
-default_fixtures[TestLevels.UNIT] = {"cluster": [local_docker_cluster_public_key]}
+default_fixtures[TestLevels.UNIT] = {
+    "cluster": [
+        local_docker_cluster_public_key_logged_in,
+        local_docker_cluster_public_key_logged_out,
+    ]
+}
 default_fixtures[TestLevels.LOCAL] = {
-    "cluster": [local_docker_cluster_public_key, local_docker_cluster_passwd]
+    "cluster": [
+        local_docker_cluster_public_key_logged_in,
+        local_docker_cluster_public_key_logged_out,
+        local_docker_cluster_passwd,
+    ]
 }
 default_fixtures[TestLevels.MINIMAL] = {"cluster": [ondemand_cpu_cluster]}
 default_fixtures[TestLevels.THOROUGH] = {
     "cluster": [
         local_docker_cluster_passwd,
-        local_docker_cluster_public_key,
+        local_docker_cluster_public_key_logged_in,
+        local_docker_cluster_public_key_logged_out,
+        local_docker_cluster_telemetry_public_key,
         ondemand_cpu_cluster,
         ondemand_https_cluster_with_auth,
         password_cluster,
@@ -208,7 +219,9 @@ default_fixtures[TestLevels.THOROUGH] = {
 default_fixtures[TestLevels.MAXIMAL] = {
     "cluster": [
         local_docker_cluster_passwd,
-        local_docker_cluster_public_key,
+        local_docker_cluster_public_key_logged_in,
+        local_docker_cluster_public_key_logged_out,
+        local_docker_cluster_telemetry_public_key,
         ondemand_cpu_cluster,
         ondemand_https_cluster_with_auth,
         password_cluster,

--- a/tests/test_resources/conftest.py
+++ b/tests/test_resources/conftest.py
@@ -11,7 +11,7 @@ RESOURCE_NAME = "my_resource"
 ######## Fixtures ########
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def resource(request):
     return request.getfixturevalue(request.param.__name__)
 


### PR DESCRIPTION
**To Test (all passing)**: 
```
pytest -v tests/test_resources/test_clusters/test_cluster.py --level local
```

After the addition of the telemetry cluster, we have a lot of local Docker clusters running. When running the cluster tests with the addition of @DenisYay 's telemetry test, my Docker VM begins to OOM because there are too many containers running on it at once.

In an effort to get rid of this problem, I introduce two function scoped fixtures, `local_docker_cluster_public_key_logged_out` and `local_docker_cluster_public_key_logged_in`, that are _actually_ the same container under the hood and simply log the user in and out. I introduce some basic tests for these that ensure that we are correctly "logged in". These additional simple tests are really useful and would have uncovered the test_account bugs I discovered and fixed earlier.

Some notes:
1. Right now, these fixtures require a `restart_server()` and a switch in the `~/.rh/config.yaml`. However, as we work on making user switching less hacky and dependent on in memory caches / config.yaml, this will no longer be required and we'll be able to run a remote command to switch the user.
2. For self explanatory reasons, `local_docker_cluster_public_key_logged_out` and `local_docker_cluster_public_key_logged_in` can never be used in the same test.
3. The `local_test_account_cluster_public_key` cluster, which is used in the next PR in the stack, cannot actually be parameterized, even though it is a simple log-in/log-out of this cluster. This is because it is used in the generic `test_sharing` resource test, where one of the repetitive use fixtures will be used alongside it. If these were both the same container under the hood, there would be thrash.
4. In a future PR (with input from @DenisYay), we can hopefully consolidate the telemetry fixture/cluster into a common container where we can modify the telemetry parameter remotely.
5. I change the `def resource(request)` and `def cluster(request)` parameterized fixtures to be function scoped (Let me know if there are any problems with this @jlewitt1 @dongreenberg) In general, I think we are abusing `session` scoping in our fixtures. This is restrictive because as soon as we use session scoped fixtures, we can't depend on function scoped ones. We should reserve session wide fixtures for really expensive operations only, otherwise things are fine to run function scoped.