### PR TITLE
Add generic resource sharing test utilizing test account cluster fixture.

### DIFF
--- a/tests/test_resources/test_clusters/conftest.py
+++ b/tests/test_resources/test_clusters/conftest.py
@@ -411,24 +411,30 @@ def local_docker_cluster_telemetry_public_key(request, detached=True):
         client.images.prune()
 
 
-@pytest.fixture(scope="session")
-def local_test_account_cluster_public_key(request, test_account):
-    container_name = "rh-slim-test-acct"
-    detached = request.config.getoption("--detached")
-    den_auth = "den_auth" in request.keywords
+@pytest.fixture(scope="function")
+def local_test_account_cluster_public_key(request, test_account, detached=True):
+    """
+    This fixture is not parameterized for every test; it is a separate cluster started with a test account
+    (username: kitchen_tester) in order to test sharing resources with other users.
+    """
+    with test_account as test_account_dict:
+        image_name = "keypair"
+        container_name = "rh-slim-test-acct"
+        dir_name = "public-key-auth"
+        detached = request.config.getoption("--detached")
+        den_auth = "den_auth" in request.keywords
+        keypath = str(
+            Path(
+                rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
+            ).expanduser()
+        )
+        local_ssh_port = BASE_LOCAL_SSH_PORT + 4
 
-    keypath = str(
-        Path(rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)).expanduser()
-    )
-    local_ssh_port = BASE_LOCAL_SSH_PORT + 3
-
-    with test_account:
-        # Create the shared cluster using the test account
         client, rh_parent_path = build_and_run_image(
-            image_name="keypair",
+            image_name=image_name,
             container_name=container_name,
-            detached=True,
-            dir_name="public-key-auth",
+            detached=detached,
+            dir_name=dir_name,
             keypath=keypath,
             force_rebuild=request.config.getoption("--force-rebuild"),
             port_fwds=[f"{local_ssh_port}:22"],
@@ -446,30 +452,28 @@ def local_test_account_cluster_public_key(request, test_account):
                 "ssh_private_key": keypath,
             },
         )
-        c = rh.cluster(**args).save()
+        c = rh.cluster(**args)
         init_args[id(c)] = args
-
-        # Save the test account config to ~/.rh directory in the container
-        rh_config = rh.configs.load_defaults_from_file()
 
         rh.env(
             reqs=["pytest"],
             working_dir=None,
             setup_cmds=[
                 f"mkdir -p ~/.rh; touch ~/.rh/config.yaml; "
-                f"echo '{rh_config}' > ~/.rh/config.yaml"
+                f'echo "{yaml.safe_dump(test_account_dict)}" > ~/.rh/config.yaml'
             ],
             name="base_env",
         ).to(c)
+        c.save()
 
-        # Yield the cluster
-        yield c
+    # Yield the cluster
+    yield c
 
-        # Stop the Docker container
-        if not detached:
-            client.containers.get(container_name).stop()
-            client.containers.prune()
-            client.images.prune()
+    # Stop the Docker container
+    if not detached:
+        client.containers.get(container_name).stop()
+        client.containers.prune()
+        client.images.prune()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_resources/test_resource.py
+++ b/tests/test_resources/test_resource.py
@@ -12,6 +12,14 @@ from tests.test_resources.conftest import (
 )
 
 
+def load_shared_resource_config(original_resource):
+    loaded_resource = original_resource.__class__.from_name(
+        original_resource.rns_address, dryrun=True
+    )
+    return loaded_resource.config_for_rns
+    # TODO allow resource subclass tests to extend set of properties to test
+
+
 class TestResource:
 
     UNIT = {"resource": [unnamed_resource, named_resource, local_named_resource]}
@@ -79,6 +87,36 @@ class TestResource:
 
         resource.delete_configs()
         assert not rh.exists(resource.rns_address)
+
+    def test_sharing(self, resource, local_test_account_cluster_public_key):
+        if resource.name is None:
+            with pytest.raises(ValueError):
+                resource.save()
+            assert resource.name is None
+            return
+
+        if resource.rns_address.startswith("~"):
+            # For `local_named_resource` resolve the rns address so it can be shared and loaded
+            from runhouse.globals import rns_client
+
+            resource.rns_address = rns_client.local_to_remote_address(
+                resource.rns_address
+            )
+
+        # Test saving, then share with test user
+        resource.save()
+
+        resource.share(
+            users=["info@run.house"],
+            access_type="read",
+            notify_users=False,
+        )
+
+        load_shared_resource_config_cluster = rh.function(
+            load_shared_resource_config,
+            system=local_test_account_cluster_public_key,
+        )
+        assert load_shared_resource_config_cluster(resource) == resource.config_for_rns
 
     def test_history(self, resource):
         if resource.name is None or resource.rns_address[:2] == "~/":

--- a/tests/test_servers/test_http_server_with_auth.py
+++ b/tests/test_servers/test_http_server_with_auth.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import httpx
+# import httpx
 import pytest
 
 import runhouse as rh
@@ -13,17 +13,14 @@ import runhouse as rh
 from runhouse.globals import rns_client
 from runhouse.servers.http.http_utils import b64_unpickle, pickle_b64
 
-from tests.test_servers.conftest import BASE_URL, http_server_is_up, summer
+from tests.test_servers.conftest import summer
 
 
 @pytest.fixture(scope="function")
 def base_cluster(local_docker_cluster_public_key_logged_in):
-    if http_server_is_up():
-        resp = httpx.get(f"{BASE_URL}/keys")
-        # Should receive a 404 (no token provided in request) when den auth is enabled
-        if resp.status_code != 404:
-            # Restart the server with den auth
-            local_docker_cluster_public_key_logged_in.restart_server()
+
+    local_docker_cluster_public_key_logged_in.den_auth = True
+    local_docker_cluster_public_key_logged_in.restart_server()
 
     return local_docker_cluster_public_key_logged_in
 


### PR DESCRIPTION
I introduce a sharing test for sharing resources generically with another user. This uses another local cluster that is logged in as a test user. 