### PR TITLE
Update Dockerfile for Sudo support + Nginx

### DIFF
--- a/runhouse/docker/slim/password-file-auth/Dockerfile
+++ b/runhouse/docker/slim/password-file-auth/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /app/ssh
 
 # Install the required packages
 RUN apt-get update --allow-insecure-repositories && \
-    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen curl && \
+    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen curl sudo ufw && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/runhouse/docker/slim/public-key-auth/Dockerfile
+++ b/runhouse/docker/slim/public-key-auth/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /app/ssh
 
 # Install the required packages
 RUN apt-get update --allow-insecure-repositories && \
-    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen curl && \
+    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen curl sudo ufw && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -26,8 +26,8 @@ RUN if [ -d "/app/runhouse" ]; then pip install -U -e '/app/runhouse[opentelemet
 # Create the privilege separation directory required by sshd
 RUN mkdir -p /run/sshd
 
-# Create a user for SSH access
-RUN useradd -m rh-docker-user
+# Create a user for SSH access and add to sudo group
+RUN useradd -m rh-docker-user && echo "rh-docker-user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/rh-docker-user
 
 # Create .ssh directory for the user
 RUN mkdir -p /home/rh-docker-user/.ssh
@@ -41,7 +41,7 @@ RUN --mount=type=secret,id=ssh_key,dst=/tmp/id_rsa.pub \
 
 # Update SSHD Configuration to allow public key authentication and disable password and root login
 RUN echo "PasswordAuthentication no" >> /etc/ssh/sshd_config && \
-    echo "PermitRootLogin no" >> /etc/ssh/sshd_config && \
+    echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && \
     echo "PubkeyAuthentication yes" >> /etc/ssh/sshd_config
 
 # Create supervisord configuration file
@@ -52,6 +52,7 @@ RUN echo "[supervisord]" > /etc/supervisor/conf.d/supervisord.conf && \
     echo "command=/usr/sbin/sshd -D" >> /etc/supervisor/conf.d/supervisord.conf && \
     echo "stdout_logfile=/var/log/sshd.log" >> /etc/supervisor/conf.d/supervisord.conf && \
     echo "stderr_logfile=/var/log/sshd.err" >> /etc/supervisor/conf.d/supervisord.conf
+
 
 # Ray dashboard port
 EXPOSE 52365

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -485,7 +485,7 @@ class Cluster(Resource):
                     self.up_if_not()
                 elif restart_server:
                     logger.info(
-                        f"Server {self.name} is up, but the HTTP server may not be up."
+                        f"Server {self.name} is up, but the Runhouse API server may not be up."
                     )
                     self.restart_server()
                     for i in range(5):
@@ -499,9 +499,9 @@ class Cluster(Resource):
                             requests.exceptions.ReadTimeout,
                         ) as error:
                             if i == 5:
-                                print(error)
+                                logger.error(error)
                             time.sleep(5)
-                raise ValueError(f"Could not connect to cluster <{self.name}>")
+                raise ValueError(f"Could not connect to server {self.name}")
 
         import runhouse
 
@@ -776,6 +776,7 @@ class Cluster(Resource):
             + (f" --ssl-certfile {cluster_cert_path}" if use_custom_cert else "")
             + (f" --ssl-keyfile {cluster_key_path}" if use_custom_key else "")
             + (" --use-local-telemetry" if use_local_telemetry else "")
+            + f" --port {self.server_port}"
         )
 
         cmd = f"{env_activate_cmd} && {cmd}" if env_activate_cmd else cmd
@@ -913,6 +914,7 @@ class Cluster(Resource):
                 runner.run(["mkdir", "-p", dest], stream_logs=False)
             else:
                 Path(dest).expanduser().parent.mkdir(parents=True, exist_ok=True)
+
             runner.rsync(
                 source,
                 dest,
@@ -920,6 +922,7 @@ class Cluster(Resource):
                 filter_options=filter_options,
                 stream_logs=stream_logs,
             )
+
         else:
             import pexpect
 


### PR DESCRIPTION
add separate fixture for local tls with nginx testing

Fix global ssh tunnel cache to use port as well. (#149)

We use a global dictionary to cache open ssh connections to particular
addresses. However, for local tests where several connections are running
locally on localhost, the cache would incorrectly hit.

Add an end-to-end test for a local docker cluster with telemetry enabled (#142)

Disable telemetry by default in the local docker public key cluster

Add ServerModule Tests (#151)

update nginx tests for local docker

Merge remote-tracking branch 'origin/main' into telemetry-nginx-docker-updates

update nginx local tests to use separate containers for http / https

set up client port for nginx fixtures