### PR TITLE
update support for nginx / telemetry for running on local docker

### DIFF
--- a/runhouse/servers/http/certs.py
+++ b/runhouse/servers/http/certs.py
@@ -109,7 +109,13 @@ class TLSCertConfig:
         ]
 
         if address is not None:
-            subject_names.append(x509.IPAddress(ipaddress.IPv4Address(address)))
+            try:
+                # Check if the address is a valid IP address
+                ip_addr = ipaddress.IPv4Address(address)
+                subject_names.append(x509.IPAddress(ip_addr))
+            except ipaddress.AddressValueError:
+                # If not a valid IP address (e.g. "localhost"), treat it as a DNS name
+                subject_names.append(x509.DNSName(address))
 
         # Add Subject Alternative Name extension
         san = x509.SubjectAlternativeName(subject_names)

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -87,8 +87,14 @@ class HTTPClient:
             if req_type == "delete"
             else requests.post
         )
+        # Note: For localhost (e.g. docker) do not add trailing slash (will lead to connection errors)
         endpoint = endpoint.strip("/")
-        endpoint = (endpoint + "/") if "?" not in endpoint else endpoint
+        if (
+            self.host not in ["localhost", "127.0.0.1", "0.0.0.0"]
+            and "?" not in endpoint
+        ):
+            endpoint += "/"
+
         response = req_fn(
             self._formatted_url(endpoint),
             json={

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -802,7 +802,7 @@ if __name__ == "__main__":
             if https_port != default_https_port:
                 # if using a custom HTTPS port must provide private key file and certs explicitly
                 raise FileNotFoundError(
-                    f"Could not find SSL private key and cert files on the cluster, which are required when specifying"
+                    f"Could not find SSL private key and cert files on the cluster, which are required when specifying "
                     f"a custom port ({https_port}). Please specify the paths using the --ssl-certfile and "
                     f"--ssl-keyfile flags."
                 )

--- a/runhouse/servers/nginx/config.py
+++ b/runhouse/servers/nginx/config.py
@@ -62,8 +62,14 @@ class NginxConfig:
             raise RuntimeError("Failed to configure Nginx")
 
     def reload(self):
+        # If running locally (e.g. in a docker container) systemctl may not be available
+        reload_cmd = (
+            "sudo service nginx start && sudo nginx -s reload"
+            if self.address in ["localhost", "127.0.0.1", "0.0.0.0"]
+            else "sudo systemctl reload nginx"
+        )
         result = subprocess.run(
-            "sudo systemctl reload nginx",
+            reload_cmd,
             shell=True,
             check=True,
             capture_output=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,7 @@ from tests.test_resources.test_clusters.conftest import (
     local_docker_cluster_public_key_logged_in,  # noqa: F401
     local_docker_cluster_public_key_logged_out,  # noqa: F401
     local_docker_cluster_telemetry_public_key,  # noqa: F401
+    local_docker_cluster_with_nginx,  # noqa: F401
     local_test_account_cluster_public_key,  # noqa: F401
     named_cluster,  # noqa: F401
     password_cluster,  # noqa: F401

--- a/tests/test_resources/test_clusters/conftest.py
+++ b/tests/test_resources/test_clusters/conftest.py
@@ -1,3 +1,4 @@
+import json
 import pkgutil
 import shlex
 import time
@@ -12,6 +13,8 @@ from tests.conftest import init_args
 
 SSH_USER = "rh-docker-user"
 BASE_LOCAL_SSH_PORT = 32320
+LOCAL_HTTPS_SERVER_PORT = 8443
+LOCAL_HTTP_SERVER_PORT = 8080
 DEFAULT_KEYPAIR_KEYPATH = "~/.ssh/sky-key"
 
 
@@ -427,7 +430,6 @@ def local_docker_cluster_telemetry_public_key(request, detached=True):
 @pytest.fixture(scope="function")
 def local_docker_cluster_with_nginx(request):
     image_name = "keypair"
-    container_name = "rh-slim-nginx-keypair"
     dir_name = "public-key-auth"
 
     keypath = str(
@@ -448,6 +450,8 @@ def local_docker_cluster_with_nginx(request):
         server_connection_type = "none"
         client_port = LOCAL_HTTP_SERVER_PORT + 3
         port_fwds.append(f"{client_port}:80")
+
+    container_name = f"rh-slim-{protocol}-nginx"
 
     client, rh_parent_path = build_and_run_image(
         image_name=image_name,

--- a/tests/test_servers/conftest.py
+++ b/tests/test_servers/conftest.py
@@ -20,15 +20,6 @@ def summer(a, b):
     return a + b
 
 
-def http_server_is_up():
-    try:
-        resp = httpx.get(f"{BASE_URL}/check")
-        resp.raise_for_status()  # Will raise an exception for any status code 400 and above
-        return True
-    except httpx.HTTPError:
-        return False
-
-
 # -------- FIXTURES ----------- #
 @pytest.fixture(scope="module")
 def http_client():

--- a/tests/test_servers/test_nginx.py
+++ b/tests/test_servers/test_nginx.py
@@ -411,7 +411,7 @@ class TestNginxServerLocally:
         key = "key1"
         test_list = list(range(5, 50, 2)) + ["a string"]
         response = requests.post(
-            f"{protocol}://{local_docker_cluster_with_nginx.address}:{local_docker_cluster_with_nginx.server_port}/object",
+            f"{protocol}://{local_docker_cluster_with_nginx.address}:{local_docker_cluster_with_nginx.client_port}/object",
             json={"data": pickle_b64(test_list), "key": key},
             headers=rns_client.request_headers,
             verify=False,
@@ -419,7 +419,7 @@ class TestNginxServerLocally:
         assert response.status_code == 200
 
         response = requests.get(
-            f"{protocol}://{local_docker_cluster_with_nginx.address}:{local_docker_cluster_with_nginx.server_port}/keys",
+            f"{protocol}://{local_docker_cluster_with_nginx.address}:{local_docker_cluster_with_nginx.client_port}/keys",
             headers=rns_client.request_headers,
             verify=False,
         )

--- a/tests/test_servers/test_nginx.py
+++ b/tests/test_servers/test_nginx.py
@@ -4,7 +4,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
+import requests
 
+from runhouse.globals import rns_client
+from runhouse.servers.http.http_utils import b64_unpickle, pickle_b64
 from runhouse.servers.nginx.config import NginxConfig
 
 
@@ -72,10 +75,17 @@ class TestNginxConfiguration:
     def test_nginx_http_reload(self, mock_subprocess_run):
         mock_subprocess_run.return_value = MagicMock(returncode=0)
 
+        # Assuming self.http_config.address is set to a value like "localhost"
+        expected_command = (
+            "sudo service nginx start && sudo nginx -s reload"
+            if self.http_config.address in ["localhost", "127.0.0.1", "0.0.0.0"]
+            else "sudo systemctl reload nginx"
+        )
+
         self.http_config.reload()
 
         mock_subprocess_run.assert_called_once_with(
-            "sudo systemctl reload nginx",
+            expected_command,
             shell=True,
             check=True,
             capture_output=True,
@@ -86,10 +96,17 @@ class TestNginxConfiguration:
     def test_nginx_https_reload(self, mock_subprocess_run):
         mock_subprocess_run.return_value = MagicMock(returncode=0)
 
+        # Assuming self.http_config.address is set to a value like "localhost"
+        expected_command = (
+            "sudo service nginx start && sudo nginx -s reload"
+            if self.https_config.address in ["localhost", "127.0.0.1", "0.0.0.0"]
+            else "sudo systemctl reload nginx"
+        )
+
         self.https_config.reload()
 
         mock_subprocess_run.assert_called_once_with(
-            "sudo systemctl reload nginx",
+            expected_command,
             shell=True,
             check=True,
             capture_output=True,
@@ -378,6 +395,37 @@ class TestNginxConfiguration:
         )
 
         assert https_template == expected_https_template
+
+
+class TestNginxServerLocally:
+    @pytest.mark.parametrize(
+        "local_docker_cluster_with_nginx", ["http", "https"], indirect=True
+    )
+    def test_using_nginx_on_local_cluster(self, local_docker_cluster_with_nginx):
+        protocol = "https" if local_docker_cluster_with_nginx._use_https else "http"
+
+        local_docker_cluster_with_nginx.check_server()
+
+        assert local_docker_cluster_with_nginx.is_up()
+
+        key = "key1"
+        test_list = list(range(5, 50, 2)) + ["a string"]
+        response = requests.post(
+            f"{protocol}://{local_docker_cluster_with_nginx.address}:{local_docker_cluster_with_nginx.server_port}/object",
+            json={"data": pickle_b64(test_list), "key": key},
+            headers=rns_client.request_headers,
+            verify=False,
+        )
+        assert response.status_code == 200
+
+        response = requests.get(
+            f"{protocol}://{local_docker_cluster_with_nginx.address}:{local_docker_cluster_with_nginx.server_port}/keys",
+            headers=rns_client.request_headers,
+            verify=False,
+        )
+
+        assert response.status_code == 200
+        assert key in b64_unpickle(response.json().get("data"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
update support for nginx / telemetry for running on local docker

add separate fixture for local tls with nginx testing

update nginx tests for local docker

update nginx local tests to use separate containers for http / https

set up client port for nginx fixtures

update support for nginx / telemetry for running on local docker

add separate fixture for local tls with nginx testing
