### PR TITLE
Get rid of base_cluster

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ class TestLevels(str, enum.Enum):
     MAXIMAL = "maximal"
 
 
-DEFAULT_LEVEL = TestLevels.LOCAL
+DEFAULT_LEVEL = TestLevels.UNIT
 
 
 def pytest_addoption(parser):

--- a/tests/test_resources/test_clusters/conftest.py
+++ b/tests/test_resources/test_clusters/conftest.py
@@ -355,6 +355,19 @@ def local_docker_cluster_public_key_logged_in(local_docker_cluster_public_key):
     return local_docker_cluster_public_key
 
 
+@pytest.fixture(scope="function")
+def local_docker_cluster_public_key_den_auth(local_docker_cluster_public_key):
+    local_docker_cluster_public_key.run(
+        [
+            f"mkdir -p ~/.rh; touch ~/.rh/config.yaml; "
+            f'echo "{yaml.safe_dump(rh.configs.defaults_cache)}" > ~/.rh/config.yaml'
+        ],
+    )
+    local_docker_cluster_public_key.den_auth = True
+    local_docker_cluster_public_key.restart_server(resync_rh=False)
+    return local_docker_cluster_public_key
+
+
 @pytest.fixture(scope="session")
 def local_docker_cluster_telemetry_public_key(request, detached=True):
     image_name = "keypair-telemetry"

--- a/tests/test_resources/test_clusters/conftest.py
+++ b/tests/test_resources/test_clusters/conftest.py
@@ -339,7 +339,7 @@ def local_docker_cluster_public_key_logged_out(local_docker_cluster_public_key):
     local_docker_cluster_public_key.run(
         ["rm ~/.rh/config.yaml"],
     )
-    local_docker_cluster_public_key.restart_server()
+    local_docker_cluster_public_key.restart_server(resync_rh=False)
     return local_docker_cluster_public_key
 
 
@@ -351,7 +351,7 @@ def local_docker_cluster_public_key_logged_in(local_docker_cluster_public_key):
             f'echo "{yaml.safe_dump(rh.configs.defaults_cache)}" > ~/.rh/config.yaml'
         ],
     )
-    local_docker_cluster_public_key.restart_server()
+    local_docker_cluster_public_key.restart_server(resync_rh=False)
     return local_docker_cluster_public_key
 
 

--- a/tests/test_servers/test_http_server_with_auth.py
+++ b/tests/test_servers/test_http_server_with_auth.py
@@ -193,9 +193,7 @@ class TestHTTPServerWithAuth:
         assert b64_unpickle(response.text) == 3
 
     @pytest.mark.asyncio
-    async def test_async_call_with_json_serialization(
-        self, async_http_client, cluster
-    ):
+    async def test_async_call_with_json_serialization(self, async_http_client, cluster):
         remote_func = rh.function(summer, system=cluster)
         method = "call"
 
@@ -209,18 +207,14 @@ class TestHTTPServerWithAuth:
 
     # -------- INVALID TOKEN / CLUSTER ACCESS TESTS ----------- #
     def test_request_with_no_cluster_config_yaml(self, http_client, cluster):
-        cluster.run(
-            ["mv ~/.rh/cluster_config.yaml ~/.rh/cluster_config_temp.yaml"]
-        )
+        cluster.run(["mv ~/.rh/cluster_config.yaml ~/.rh/cluster_config_temp.yaml"])
         try:
             response = http_client.get("/keys", headers=rns_client.request_headers)
 
             assert response.status_code == 404
             assert "Failed to load current cluster" in response.text
         finally:
-            cluster.run(
-                ["mv ~/.rh/cluster_config_temp.yaml ~/.rh/cluster_config.yaml"]
-            )
+            cluster.run(["mv ~/.rh/cluster_config_temp.yaml ~/.rh/cluster_config.yaml"])
         response = http_client.get("/keys", headers=self.invalid_headers)
 
         assert response.status_code == 403
@@ -249,9 +243,7 @@ class TestHTTPServerWithAuth:
         # Should be able to ping the server even without a valid token
         assert response.status_code == 200
 
-    def test_put_resource_with_invalid_token(
-        self, http_client, blob_data, cluster
-    ):
+    def test_put_resource_with_invalid_token(self, http_client, blob_data, cluster):
         state = None
         resource = rh.blob(blob_data, system=cluster)
         data = pickle_b64((resource.config_for_rns, state, resource.dryrun))

--- a/tests/test_servers/test_http_server_with_auth.py
+++ b/tests/test_servers/test_http_server_with_auth.py
@@ -20,7 +20,7 @@ from tests.test_servers.conftest import summer
 def base_cluster(local_docker_cluster_public_key_logged_in):
 
     local_docker_cluster_public_key_logged_in.den_auth = True
-    local_docker_cluster_public_key_logged_in.restart_server()
+    local_docker_cluster_public_key_logged_in.restart_server(resync_rh=False)
 
     return local_docker_cluster_public_key_logged_in
 
@@ -55,7 +55,7 @@ class TestHTTPServerWithAuth:
         )
         assert response.status_code == 200
 
-    def test_put_object(self, http_client):
+    def test_put_object_and_get_keys(self, http_client):
         key = "key1"
         test_list = list(range(5, 50, 2)) + ["a string"]
         response = http_client.post(
@@ -66,6 +66,7 @@ class TestHTTPServerWithAuth:
         assert response.status_code == 200
 
         response = http_client.get("/keys", headers=rns_client.request_headers)
+        assert response.status_code == 200
         assert key in b64_unpickle(response.json().get("data"))
 
     def test_rename_object(self, http_client):
@@ -79,11 +80,6 @@ class TestHTTPServerWithAuth:
 
         response = http_client.get("/keys", headers=rns_client.request_headers)
         assert new_key in b64_unpickle(response.json().get("data"))
-
-    def test_get_keys(self, http_client):
-        response = http_client.get("/keys", headers=rns_client.request_headers)
-        assert response.status_code == 200
-        assert "key2" in b64_unpickle(response.json().get("data"))
 
     def test_delete_obj(self, http_client):
         # https://www.python-httpx.org/compatibility/#request-body-on-http-methods


### PR DESCRIPTION
- Get rid of "base_cluster" in test_http_server.py, as it runs restart_server twice in each test, and doesn't allow us to dynamically swap in other cluster levels to test.
- Default resync_rh=False when creating cluster fixtures, just to save time between tests.
- Fix a few test idempotence bugs in test_http_server.py and test_http_server_with_auth.py

test_http_server.py passes