### PR TITLE
Enable functionality for marking tests by their level and filter these in collection.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,4 @@ markers =
     dockertest: marks tests which require Docker (deselect with '-m "not dockertest"')
     den_auth: marks test to use Runhouse Den bearer token authentication for all incoming requests.
     telemetrytest: marks tests which verify Telemetry functionality (deselect with '-m "not telemetrytest"')
+    level: mark tests with a given level that will be used when selecting tests to run

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -158,6 +158,7 @@ class Cluster(Resource):
             config["ssh_creds"] = self.ssh_creds()
         else:
             config["ips"] = [self.address]
+            config["ssh_creds"] = None
 
         if self._use_custom_cert:
             config["ssl_certfile"] = self.cert_config.cert_path

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -1,3 +1,5 @@
+import pytest
+
 import runhouse as rh
 
 import tests.test_resources.test_resource
@@ -34,12 +36,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
 
     MAP_FIXTURES = {"resource": "cluster"}
 
-    UNIT = {
-        "cluster": [
-            local_docker_cluster_public_key_logged_out,
-            local_docker_cluster_public_key_logged_in,
-        ]
-    }
+    UNIT = {"cluster": [named_cluster]}
     LOCAL = {
         "cluster": [
             local_docker_cluster_public_key_logged_in,
@@ -49,9 +46,10 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         ]
     }
     MINIMAL = {"cluster": [static_cpu_cluster]}
-    THOROUGH = {"cluster": [named_cluster, password_cluster]}
-    MAXIMAL = {"cluster": [named_cluster, password_cluster]}
+    THOROUGH = {"cluster": [static_cpu_cluster, password_cluster]}
+    MAXIMAL = {"cluster": [static_cpu_cluster, password_cluster]}
 
+    @pytest.mark.level("unit")
     def test_cluster_factory_and_properties(self, cluster):
         assert isinstance(cluster, rh.Cluster)
         args = init_args[id(cluster)]
@@ -94,6 +92,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
             # TODO: Test default behavior
             pass
 
+    @pytest.mark.level("local")
     def test_logged_in_local_cluster(self, local_docker_cluster_public_key_logged_in):
         save_resource_and_return_config_cluster = rh.function(
             save_resource_and_return_config,
@@ -107,6 +106,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
             rh.configs.defaults_cache["default_folder"]
         )
 
+    @pytest.mark.level("local")
     def test_logged_out_local_cluster(self, local_docker_cluster_public_key_logged_out):
         save_resource_and_return_config_cluster = rh.function(
             save_resource_and_return_config,


### PR DESCRIPTION
Users will now need to add `--ignore-filters` to their pytest commands in order to run tests as they were before. For example `pytest -s -v tests/test_resources/test_cluster.py --level local --ignore-filters`.

`pytest -v --level local` passes.
