### PR TITLE
Cluster bugfixes / Move rh version mismatch check

### DIFF
--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -307,7 +307,7 @@ def ondemand_cluster(
 
     if open_ports:
         open_ports = [str(p) for p in open_ports]
-        if server_port in open_ports:
+        if str(server_port) in open_ports:
             if (
                 server_connection_type
                 in [ServerConnectionType.TLS, ServerConnectionType.NONE]

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -28,6 +28,15 @@ logger = logging.getLogger(__name__)
 RESERVED_SYSTEM_NAMES = ["file", "s3", "gs", "azure", "here", "ssh", "sftp"]
 
 
+# Get rid of the constant "Found credentials in shared credentials file: ~/.aws/credentials" message
+try:
+    import boto3
+    import logging
+
+    boto3.set_stream_logger(name='botocore.credentials', level=logging.ERROR)
+except ImportError:
+    pass
+
 class ServerConnectionType(str, Enum):
     """Manage the type of connection Runhouse will make with the API server started on the cluster.
     ``ssh``: Use port forwarding to connect to the server via SSH, by default on port 32300.

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -30,12 +30,14 @@ RESERVED_SYSTEM_NAMES = ["file", "s3", "gs", "azure", "here", "ssh", "sftp"]
 
 # Get rid of the constant "Found credentials in shared credentials file: ~/.aws/credentials" message
 try:
-    import boto3
     import logging
 
-    boto3.set_stream_logger(name='botocore.credentials', level=logging.ERROR)
+    import boto3
+
+    boto3.set_stream_logger(name="botocore.credentials", level=logging.ERROR)
 except ImportError:
     pass
+
 
 class ServerConnectionType(str, Enum):
     """Manage the type of connection Runhouse will make with the API server started on the cluster.

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -212,7 +212,9 @@ class HTTPServer:
             if not ray.is_initialized():
                 raise Exception("Ray is not initialized, restart the server.")
             logger.info("Server is up.")
-            return
+
+            import runhouse
+            return {"rh_version": runhouse.__version__}
         except Exception as e:
             logger.exception(e)
             HTTPServer.register_activity()

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -214,6 +214,7 @@ class HTTPServer:
             logger.info("Server is up.")
 
             import runhouse
+
             return {"rh_version": runhouse.__version__}
         except Exception as e:
             logger.exception(e)

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -23,6 +23,8 @@ class TestHTTPClient:
     def test_check_server(self, mock_get):
         mock_response = Mock()
         mock_response.status_code = 200
+        rh_version_resp = {"rh_version": rh.__version__}
+        mock_response.json.return_value = rh_version_resp
         mock_get.return_value = mock_response
 
         self.client.check_server()

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -37,6 +37,7 @@ class TestHTTPServer:
     def test_check_server(self, http_client):
         response = http_client.get("/check")
         assert response.status_code == 200
+        assert rh.__version__ == response.json().get("rh_version")
 
     def test_put_resource(self, http_client, cluster, local_blob):
         state = None
@@ -219,6 +220,7 @@ class TestHTTPServerLocally:
     def test_check_server(self, local_client):
         response = local_client.get("/check")
         assert response.status_code == 200
+        assert rh.__version__ == response.json().get("rh_version")
 
     def test_put_resource(self, local_client, blob_data):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Bugfixes to enable HTTPS/Den Auth service sharing, and general robustness.

- cluster.address is now a property and no longer duplicative with cluster.ips.
- Move rh_version check to between http_client and http_server, and happen over RPC
- Fix warnings about aws credentials and server_port not being in open_ports

test_modules.py, test_server/, and test_cluster.py all pass with LOCAL.