### PR TITLE
Refactor env tests and add env fixtures

### DIFF
--- a/runhouse/resources/envs/env_factory.py
+++ b/runhouse/resources/envs/env_factory.py
@@ -17,7 +17,7 @@ def env(
     setup_cmds: List[str] = None,
     env_vars: Union[Dict, str] = {},
     working_dir: Optional[Union[str, Path]] = "./",
-    dryrun: bool = True,
+    dryrun: bool = False,
 ):
     """Builds an instance of :class:`Env`.
 
@@ -32,7 +32,7 @@ def env(
             environment variables. (Default: {})
         working_dir (str or Path): Working directory of the environment, to be loaded onto the system.
             (Default: "./")
-        dryrun (bool, optional): Whether to run in dryrun mode. (Default: ``True``)
+        dryrun (bool, optional): Whether to run in dryrun mode. (Default: ``False``)
 
 
     Returns:
@@ -86,7 +86,7 @@ def conda_env(
     setup_cmds: List[str] = None,
     env_vars: Optional[Dict] = {},
     working_dir: Optional[Union[str, Path]] = "./",
-    dryrun: bool = True,
+    dryrun: bool = False,
 ):
     """Builds an instance of :class:`CondaEnv`.
 
@@ -101,7 +101,7 @@ def conda_env(
             environment variables. (Default: {})
         working_dir (str or Path): Working directory of the environment, to be loaded onto the system.
             (Default: "./")
-        dryrun (bool, optional): Whether to run in dryrun mode. (Default: ``True``)
+        dryrun (bool, optional): Whether to run in dryrun mode. (Default: ``False``)
 
     Returns:
         CondaEnv: The resulting CondaEnv object.

--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -70,7 +70,7 @@ def _get_conda_yaml(conda_env=None):
             res = subprocess.check_output(
                 f"conda env export -n {conda_env} --no-build".split(" ")
             ).decode("utf-8")
-            conda_yaml = yaml.load(res)
+            conda_yaml = yaml.safe_load(res)
         else:
             raise Exception(
                 f"{conda_env} must be a Dict or point to an existing path or conda environment."

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -1126,6 +1126,7 @@ class Cluster(Resource):
         # If invoking a run as part of the python commands also return the Run object
         return_codes = self.run(
             [formatted_command],
+            env=env,
             stream_logs=stream_logs,
             port_forward=port_forward,
             run_name=run_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,8 +155,12 @@ from tests.test_resources.test_clusters.test_sagemaker_cluster.conftest import (
 # ----------------- Envs -----------------
 
 from tests.test_resources.test_envs.conftest import (
+    base_conda_env,  # noqa: F401
+    base_env,  # noqa: F401
+    conda_env_from_dict,  # noqa: F401
+    conda_env_from_local,  # noqa: F401
+    conda_env_from_path,  # noqa: F401
     env,  # noqa: F401
-    test_env,  # noqa: F401
 )
 
 # ----------------- Blobs -----------------

--- a/tests/test_resources/test_envs/assets/test_conda_env.yml
+++ b/tests/test_resources/test_envs/assets/test_conda_env.yml
@@ -1,0 +1,5 @@
+channels:
+- defaults
+dependencies:
+- python=3.10.9
+name: conda_from_path

--- a/tests/test_resources/test_envs/conftest.py
+++ b/tests/test_resources/test_envs/conftest.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 import runhouse as rh
-import yaml
 
 from tests.conftest import init_args
 
@@ -55,21 +54,26 @@ def conda_env_from_dict():
 @pytest.fixture(scope="function")
 def conda_env_from_path():
     env_name = "conda_from_path"
-    file_path = f"{env_name}.yml"
-    yaml.dump(_get_conda_env(name=env_name), open(file_path, "w"))
+    file_path = os.path.join(os.path.dirname(__file__), "assets", "test_conda_env.yml")
 
     args = {"name": env_name, "conda_env": file_path}
     env = rh.conda_env(**args)
     init_args[id(env)] = args
     yield env
 
-    os.remove(file_path)
+
+@pytest.fixture(scope="session")
+def _local_conda_env():
+    env_name = "test_conda_local_env"
+    os.system(f"conda create -n {env_name} -y python==3.10.9")
+    yield
+
+    os.system(f"conda env remove -n {env_name}")
 
 
 @pytest.fixture(scope="function")
-def conda_env_from_local():
+def conda_env_from_local(_local_conda_env):
     env_name = "test_conda_local_env"
-    os.system(f"conda create -n {env_name} -y python==3.10.6")
 
     args = {"name": env_name, "conda_env": env_name}
     env = rh.conda_env(**args)

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import unittest
 
 from pathlib import Path
@@ -7,97 +6,17 @@ from pathlib import Path
 import pytest
 
 import runhouse as rh
-import yaml
-from runhouse.resources.folders.folder import Folder
-from runhouse.resources.packages import Package
 
-pip_reqs = ["torch", "numpy"]
+from tests.conftest import init_args, ondemand_cpu_cluster, password_cluster
+from tests.test_resources.test_resource import TestResource
 
-# -------- BASE ENV TESTS ----------- #
-
-
-def test_create_env_from_name_local():
-    env_name = "~/local_env"
-    local_env = rh.env(name=env_name, reqs=pip_reqs).save()
-    del local_env
-
-    remote_env = rh.env(name=env_name)
-    assert set(pip_reqs).issubset(set(remote_env.reqs))
-
-
-@pytest.mark.rnstest
-def test_create_env_from_name_rns():
-    env_name = "rns_env"
-    env = rh.env(name=env_name, reqs=pip_reqs).save()
-    del env
-
-    remote_env = rh.env(name=env_name)
-    assert set(pip_reqs).issubset(set(remote_env.reqs))
-
-
-def test_create_env():
-    test_env = rh.env(name="test_env", reqs=pip_reqs)
-    assert len(test_env.reqs) >= 2
-    assert set(pip_reqs).issubset(set(test_env.reqs))
-
-
-@pytest.mark.clustertest
-@pytest.mark.parametrize("env_name", ["base", "test_env"])
-def test_to_cluster(cluster, env_name):
-    test_env = rh.env(name=env_name, reqs=["transformers"])
-
-    test_env.to(cluster, force_install=True)
-    res = cluster.run_python(["import transformers"])
-    assert res[0][0] == 0  # import was successful
-
-    cluster.run(["pip uninstall transformers -y"])
-
-
-@pytest.mark.awstest
-@pytest.mark.clustertest
-def test_to_fs_to_cluster(cluster, s3_package):
-    cluster.install_packages(["s3fs"])
-
-    test_env_s3 = rh.env(name="test_env_s3", reqs=["s3fs", "scipy", s3_package]).to(
-        "s3"
-    )
-    for req in test_env_s3.reqs:
-        if isinstance(req, Package) and isinstance(req.install_target, Folder):
-            assert req.install_target.system == "s3"
-            assert req.install_target.exists_in_system()
-
-    folder_name = "test_package"
-    test_env_cluster = test_env_s3.to(
-        system=cluster, path=folder_name, mount=True, force_install=True
-    )
-    for req in test_env_cluster.reqs:
-        if isinstance(req, Package) and isinstance(req.install_target, Folder):
-            assert req.install_target.system == cluster
-
-    assert "sample_file_0.txt" in cluster.run([f"ls {folder_name}"])[0][1]
-    cluster.run([f"rm -r {folder_name}"])
-
-
-@pytest.mark.clustertest
-def test_function_to_env(cluster):
-    test_env = rh.env(name="test-env", reqs=["parameterized"]).save()
-
-    def summer(a, b):
-        return a + b
-
-    rh.function(summer).to(cluster, test_env, force_install=True)
-    res = cluster.run_python(["import parameterized"])
-    assert res[0][0] == 0
-
-    cluster.run(["pip uninstall parameterized -y"])
-    res = cluster.run_python(["import parameterized"])
-    assert res[0][0] == 1
-
-    rh.function(summer).to(system=cluster, env="test-env", force_install=True)
-    res = cluster.run_python(["import parameterized"])
-    assert res[0][0] == 0
-
-    cluster.run(["pip uninstall parameterized -y"])
+from .conftest import (
+    base_conda_env,
+    base_env,
+    conda_env_from_dict,
+    conda_env_from_local,
+    conda_env_from_path,
+)
 
 
 def _get_env_var_value(env_var):
@@ -106,235 +25,10 @@ def _get_env_var_value(env_var):
     return os.environ[env_var]
 
 
-@pytest.mark.clustertest
-def test_function_env_vars(cluster):
-    test_env_var = "TEST_ENV_VAR"
-    test_value = "value"
-    test_env = rh.env(env_vars={test_env_var: test_value})
-
-    get_env_var_cpu = rh.function(_get_env_var_value).to(cluster, test_env)
-    res = get_env_var_cpu(test_env_var)
-
-    assert res == test_value
-
-
-@pytest.mark.clustertest
-def test_function_env_vars_file(cluster):
-    env_file = ".env"
-    contents = ["# comment", "", "ENV_VAR1=value", "# comment with =", "ENV_VAR2 =val2"]
-    with open(env_file, "w") as f:
-        for line in contents:
-            f.write(line + "\n")
-
-    test_env = rh.env(name="test-env", env_vars=env_file)
-
-    get_env_var_cpu = rh.function(_get_env_var_value).to(cluster, test_env)
-    assert get_env_var_cpu("ENV_VAR1") == "value"
-    assert get_env_var_cpu("ENV_VAR2") == "val2"
-
-    os.remove(env_file)
-    assert not Path(env_file).exists()
-
-
-@pytest.mark.clustertest
-def test_env_vars_to_cluster(cluster):
-    env_vars = {"TEST_ENV_VAR": "value"}
-    env = rh.env(name="base", reqs=["parameterized"], env_vars=env_vars)
-    env.to(cluster, force_install=True)
-
-
-@pytest.mark.clustertest
-def test_env_vars_conda_env(cluster):
-    test_env_var = "TEST_ENV_VAR_CONDA"
-    test_value = "conda"
-    conda_dict = _get_conda_env(name="conda_env_vars")
-    test_env = rh.env(conda_env=conda_dict, env_vars={test_env_var: test_value})
-
-    get_env_var_cpu = rh.function(_get_env_var_value).to(cluster, test_env)
-    res = get_env_var_cpu(test_env_var)
-
-    assert res == test_value
-
-
-@pytest.mark.clustertest
-def test_env_git_reqs(cluster):
-    git_package = rh.GitPackage(
-        git_url="https://github.com/huggingface/diffusers.git",
-        install_method="pip",
-        revision="v0.11.1",
-    )
-    env = rh.env(reqs=[git_package])
-    env.to(cluster)
-    res = cluster.run(["pip freeze | grep diffusers"])
-    assert "diffusers" in res[0][1]
-    cluster.run(["pip uninstall diffusers -y"])
-
-
-@pytest.mark.clustertest
-def test_working_dir(cluster, tmp_path):
-    working_dir = tmp_path / "test_working_dir"
-    working_dir.mkdir(exist_ok=True)
-
-    env = rh.env(working_dir=str(working_dir))
-    assert str(working_dir) in env.reqs
-
-    env.to(cluster)
-    assert working_dir.name in cluster.run(["ls"])[0][1]
-
-    cluster.run([f"rm -r {working_dir.name}"])
-    assert working_dir.name not in cluster.run(["ls"])[0][1]
-
-
-# -------- CONDA ENV TESTS ----------- #
-
-
-def _get_conda_env(name="rh-test", python_version="3.10.9"):
-    conda_env = {
-        "name": name,
-        "channels": ["defaults"],
-        "dependencies": [
-            f"python={python_version}",
-        ],
-    }
-    return conda_env
-
-
-def _get_conda_python_version(env, system):
-    env.to(system)
-    py_version = system.run([f"{env._run_cmd} python --version"])
-    return py_version[0][1]
-
-
-def test_conda_env_from_name_local():
-    env_name = "~/local_conda_env"
-    conda_env = _get_conda_env()
-    local_env = rh.env(name=env_name, conda_env=conda_env).save()
-    del local_env
-
-    remote_env = rh.env(name=env_name, dryrun=True)
-    assert remote_env.conda_yaml == conda_env
-    assert remote_env.env_name == conda_env["name"]
-
-
-@pytest.mark.rnstest
-def test_conda_env_from_name_rns():
-    env_name = "rns_conda_env"
-    conda_env = _get_conda_env()
-    env = rh.env(name=env_name, conda_env=conda_env).save()
-    del env
-
-    remote_env = rh.env(name=env_name)
-    assert remote_env.conda_yaml == conda_env
-    assert remote_env.env_name == conda_env["name"]
-
-
-@pytest.mark.clustertest
-def test_conda_env_path_to_system(cluster, tmp_path):
-    env_name = "from_path"
-    python_version = "3.9.16"
-    tmp_path = tmp_path / "test-env"
-    file_path = f"{tmp_path}/{env_name}.yml"
-    tmp_path.mkdir(exist_ok=True)
-    yaml.dump(
-        _get_conda_env(name=env_name, python_version=python_version),
-        open(file_path, "w"),
-    )
-    conda_env = rh.env(conda_env=file_path)
-    shutil.rmtree(tmp_path)
-
-    assert python_version in _get_conda_python_version(conda_env, cluster)
-
-
-@pytest.mark.clustertest
-def test_conda_env_local_to_system(cluster):
-    env_name = "local-env"
-    python_version = "3.9.16"
-    os.system(f"conda create -n {env_name} -y python=={python_version}")
-
-    conda_env = rh.env(conda_env=env_name)
-    assert python_version in _get_conda_python_version(conda_env, cluster)
-
-
-@pytest.mark.clustertest
-def test_conda_env_dict_to_system(cluster):
-    conda_env = _get_conda_env(python_version="3.9.16")
-    test_env = rh.env(name="test_env", conda_env=conda_env)
-
-    assert "3.9.16" in _get_conda_python_version(test_env, cluster)
-
-    # ray installed successfully
-    res = cluster.run([f'{test_env._run_cmd} python -c "import ray"'])
-    assert res[0][0] == 0
-
-
-@pytest.mark.clustertest
-def test_function_to_conda_env(cluster):
-    conda_env = _get_conda_env(python_version="3.9.16")
-    test_env = rh.env(name="test_env", conda_env=conda_env)
-
-    def summer(a, b):
-        return a + b
-
-    rh.function(summer).to(cluster, test_env)
-    assert "3.9.16" in _get_conda_python_version(test_env, cluster)
-
-
-@pytest.mark.clustertest
-def test_conda_additional_reqs(cluster):
-    new_conda_env = _get_conda_env(name="test-add-reqs")
-    new_conda_env = rh.env(name="conda_env", reqs=["scipy"], conda_env=new_conda_env)
-    new_conda_env.to(cluster)
-    res = cluster.run([f'{new_conda_env._run_cmd} python -c "import scipy"'])
-    assert res[0][0] == 0  # reqs successfully installed
-    cluster.run([f"{new_conda_env._run_cmd} pip uninstall scipy"])
-
-
-@pytest.mark.clustertest
-def test_conda_git_reqs(cluster):
-    conda_env = _get_conda_env(name="test-add-reqs")
-    git_package = rh.GitPackage(
-        git_url="https://github.com/huggingface/diffusers.git",
-        install_method="pip",
-        revision="v0.11.1",
-    )
-    conda_env = rh.env(conda_env=conda_env, reqs=[git_package])
-    conda_env.to(cluster)
-    res = cluster.run([f"{conda_env._run_cmd} pip freeze | grep diffusers"])
-    assert "diffusers" in res[0][1]
-    cluster.run([f"{conda_env._run_cmd} pip uninstall diffusers"])
-
-
-@pytest.mark.clustertest
-def test_conda_env_to_fs_to_cluster(cluster, s3_package):
-    conda_env = _get_conda_env(name="s3-env")
-    conda_env_s3 = rh.env(reqs=["s3fs", "scipy", s3_package], conda_env=conda_env).to(
-        "s3"
-    )
-    count = 0
-    for req in conda_env_s3.reqs:
-        if isinstance(req, Package) and isinstance(req.install_target, Folder):
-            assert req.install_target.system == "s3"
-            assert req.install_target.exists_in_system()
-            count += 1
-    assert count >= 1
-
-    folder_name = "test_package"
-    count = 0
-    conda_env_cluster = conda_env_s3.to(system=cluster, path=folder_name, mount=True)
-    for req in conda_env_cluster.reqs:
-        if isinstance(req, Package) and isinstance(req.install_target, Folder):
-            assert req.install_target.system == cluster
-            count += 1
-    assert count >= 1
-
-    assert "sample_file_0.txt" in cluster.run([f"ls {folder_name}"])[0][1]
-    assert "s3-env" in cluster.run(["conda info --envs"])[0][1]
-
-    cluster.run([f"rm -r {folder_name}"])
-    cluster.run(["conda env remove -n s3-env"])
-
-
-# -------- CONDA ENV + FUNCTION TESTS ----------- #
+def _uninstall_env(env, cluster):
+    for req in env.reqs:
+        if req != "./":
+            cluster.run([f"pip uninstall {req} -y"], env=env)
 
 
 def np_summer(a, b):
@@ -343,25 +37,168 @@ def np_summer(a, b):
     return int(np.sum([a, b]))
 
 
-@pytest.mark.clustertest
-def test_conda_call_fn(cluster):
-    conda_dict = _get_conda_env(name="c")
-    conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])
-    fn = rh.function(np_summer).to(system=cluster, env=conda_env)
-    result = fn(1, 4)
-    assert result == 5
+class TestEnv(TestResource):
 
+    MAP_FIXTURES = {"resource": "env"}
 
-@unittest.skip("Map does not work properly following Module refactor.")
-@pytest.mark.clustertest
-def test_conda_map_fn(cluster):
-    conda_dict = _get_conda_env(name="test-map-fn")
-    conda_env = rh.env(conda_env=conda_dict, reqs=["pytest", "numpy"])
-    map_fn = rh.function(np_summer, system=cluster, env=conda_env)
-    inputs = list(zip(range(5), range(4, 9)))
-    results = map_fn.starmap(inputs)
-    assert results == [4, 6, 8, 10, 12]
+    UNIT = {
+        "env": [
+            base_env,
+            base_conda_env,
+            conda_env_from_dict,
+            conda_env_from_local,
+            conda_env_from_path,
+        ]
+    }
+    LOCAL = {
+        "env": [
+            base_env,
+            base_conda_env,
+            conda_env_from_dict,
+            conda_env_from_local,
+            conda_env_from_path,
+        ],
+        # TODO: add local clusters once conda docker container is set up
+    }
+    MINIMAL = {"env": [base_env, base_conda_env], "cluster": [ondemand_cpu_cluster]}
+    THOROUGH = {
+        "env": [
+            base_env,
+            base_conda_env,
+            conda_env_from_dict,
+            conda_env_from_local,
+            conda_env_from_path,
+        ],
+        "cluster": [ondemand_cpu_cluster, password_cluster],
+    }
+    MAXIMAL = {
+        "env": [
+            base_env,
+            base_conda_env,
+            conda_env_from_dict,
+            conda_env_from_local,
+            conda_env_from_path,
+        ],
+        "cluster": [ondemand_cpu_cluster, password_cluster],
+    }
 
+    @pytest.mark.level("unit")
+    def test_env_factory_and_properties(self, env):
+        assert isinstance(env, rh.Env)
 
-if __name__ == "__main__":
-    unittest.main()
+        args = init_args[id(env)]
+        if "reqs" in args:
+            assert set(args["reqs"]).issubset(env.reqs)
+
+        if isinstance(env, rh.CondaEnv):
+            assert env.conda_yaml
+
+    @pytest.mark.level("minimal")
+    def test_env_to_cluster(self, env, cluster):
+        env.to(cluster)
+
+        for req in env.reqs:
+            if not req == "./":
+                res = cluster.run([f"pip freeze | grep {req}"], env=env)
+                assert res[0][0] == 0  # installed properly
+
+        _uninstall_env(env, cluster)
+
+    @unittest.skip("Running into s3 folder issue")
+    @pytest.mark.level("minimal")
+    def test_env_to_fs_to_cluster(self, env, cluster):
+        s3_env = env.to("s3")
+        for req in s3_env.reqs:
+            if isinstance(req, rh.Package) and isinstance(
+                req.install_target, rh.Folder
+            ):
+                assert req.install_target.system == "s3"
+                assert req.install_target.exists_in_system()
+                count += 1
+        assert count >= 1
+
+        folder_name = "test_package"
+        count = 0
+        conda_env_cluster = s3_env.to(system=cluster, path=folder_name, mount=True)
+        for req in conda_env_cluster.reqs:
+            if isinstance(req, rh.Package) and isinstance(
+                req.install_target, rh.Folder
+            ):
+                assert req.install_target.system == cluster
+                count += 1
+        assert count >= 1
+
+        assert "sample_file_0.txt" in cluster.run([f"ls {folder_name}"])[0][1]
+        cluster.run([f"rm -r {folder_name}"])
+
+    @pytest.mark.level("minimal")
+    def test_addtl_env_reqs(self, env, cluster):
+        package = "jedi"
+        env.reqs = env.reqs + [package] if env.reqs else [package]
+        env.to(cluster)
+
+        res = cluster.run([f"pip freeze | grep {package}"], env=env)
+        assert res[0][0] == 0
+        assert package in env.reqs
+
+        _uninstall_env(env, cluster)
+
+    @pytest.mark.level("minimal")
+    def test_fn_to_env(self, env, cluster):
+        package = "numpy"
+        env.reqs = env.reqs + [package] or [package]
+        fn = rh.function(np_summer).to(system=cluster, env=env)
+        assert fn(1, 4) == 5
+
+    @pytest.mark.level("minimal")
+    def test_env_vars_dict(self, env, cluster):
+        test_env_var = "TEST_ENV_VAR"
+        test_value = "value"
+        env.env_vars = {test_env_var: test_value}
+
+        get_env_var_cpu = rh.function(_get_env_var_value).to(cluster, env)
+        res = get_env_var_cpu(test_env_var)
+
+        assert res == test_value
+
+        _uninstall_env(env, cluster)
+
+    @pytest.mark.level("minimal")
+    def test_env_vars_file(self, env, cluster):
+        env_file = ".env"
+        contents = [
+            "# comment",
+            "",
+            "ENV_VAR1=value",
+            "# comment with =",
+            "ENV_VAR2 =val2",
+        ]
+        with open(env_file, "w") as f:
+            for line in contents:
+                f.write(line + "\n")
+
+        env.env_vars = env_file
+
+        get_env_var_cpu = rh.function(_get_env_var_value).to(cluster, env)
+        assert get_env_var_cpu("ENV_VAR1") == "value"
+        assert get_env_var_cpu("ENV_VAR2") == "val2"
+
+        os.remove(env_file)
+        assert not Path(env_file).exists()
+
+        _uninstall_env(env, cluster)
+
+    @pytest.mark.level("minimal")
+    def test_working_dir_env(self, env, cluster, tmp_path):
+        working_dir = tmp_path / "test_working_dir"
+        working_dir.mkdir(exist_ok=True)
+        env.working_dir = str(working_dir)
+
+        assert str(working_dir) in env.reqs
+        env.to(cluster)
+        assert working_dir.name in cluster.run(["ls"])[0][1]
+
+        cluster.run([f"rm -r {working_dir.name}"])
+        assert working_dir.name not in cluster.run(["ls"])[0][1]
+
+        _uninstall_env(env, cluster)

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from pathlib import Path
+from typing import Dict
 
 import pytest
 
@@ -56,24 +57,12 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
         ]
     }
     LOCAL = {
-        "env": [
-            base_env,
-            base_conda_env,
-            conda_env_from_dict,
-            conda_env_from_local,
-            conda_env_from_path,
-        ],
-        # # TODO: add local clusters once conda docker container is set up
+        "env": [base_env, base_conda_env, conda_env_from_dict],
+        # TODO: add local clusters once conda docker container is set up
     }
     MINIMAL = {"env": [base_env, base_conda_env], "cluster": [ondemand_cpu_cluster]}
     THOROUGH = {
-        "env": [
-            base_env,
-            base_conda_env,
-            conda_env_from_dict,
-            conda_env_from_local,
-            conda_env_from_path,
-        ],
+        "env": [base_env, base_conda_env, conda_env_from_dict],
         "cluster": [ondemand_cpu_cluster, static_cpu_cluster, password_cluster],
     }
     MAXIMAL = {
@@ -97,6 +86,8 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
 
         if isinstance(env, rh.CondaEnv):
             assert env.conda_yaml
+            assert isinstance(env.conda_yaml, Dict)
+            assert set(["dependencies", "name"]).issubset(set(env.conda_yaml.keys()))
 
         if "working_dir" not in args:
             assert env.working_dir == "./"


### PR DESCRIPTION
* added fixtures for various types of base and conda envs
* refactored env tests to subclass resource test and reuse tests across fixtures
* usage: `pytest -v --level "minimal" tests/test_resources/test_envs/test_env.py`

next steps for env testing
* conda docker container working to enable local tests
* cut down on testing time
