### PR TITLE
Avoid ever importing fixtures from conftest.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,54 @@ import pytest
 
 from runhouse.globals import rns_client
 
+"""
+HOW TO USE FIXTURES IN RUNHOUSE TESTS
+
+You can parameterize a fixture to run on many variations for any test.
+
+Make sure your parameterized fixture is defined in this file (can be imported from some other file)
+like so:
+
+@pytest.fixture(scope="function")
+def cluster(request):
+    return request.getfixturevalue(request.param)
+
+You can define default_fixtures for any parameterized fixture below.
+
+You can use MAP_FIXTURES to map a parameterized fixture to a different name. This
+is useful if you have a subclass that you want to test the parent's parameterized
+fixtures with.  Moreover, you can override the fixture parameters in your actual Test class.
+See examples for both of these below:
+
+class TestCluster(tests.test_resources.test_resource.TestResource):
+
+    MAP_FIXTURES = {"resource": "cluster"}
+
+    UNIT = {"cluster": ["named_cluster"]}
+    LOCAL = {
+        "cluster": [
+            "local_docker_cluster_public_key_logged_in",
+            "local_docker_cluster_public_key_logged_out",
+            "local_docker_cluster_telemetry_public_key",
+            "local_docker_cluster_passwd",
+        ]
+    }
+    MINIMAL = {"cluster": ["static_cpu_cluster"]}
+    THOROUGH = {"cluster": ["static_cpu_cluster", "password_cluster"]}
+    MAXIMAL = {"cluster": ["static_cpu_cluster", "password_cluster"]}
+
+Some key things to avoid:
+- Avoid ever importing from any conftest.py file. This can cause erratic
+behavior in fixture initialization, and should always be avoided. Put test
+utility items in `tests/<some path>` and import from there instead.
+
+- Avoid using nested conftest.py files if we can avoid it. We should be
+able to put most of our info in our top level conftest.py file, with
+`tests/fixtures/<some path>` as an organizational spot for more fixtures.
+Imports that you see below from nested conftest.py files will slowly be eliminated.
+
+"""
+
 
 class TestLevels(str, enum.Enum):
     UNIT = "unit"
@@ -120,12 +168,13 @@ def test_account():
 
 # ----------------- Clusters -----------------
 
-from tests.test_resources.test_clusters.conftest import (
+from tests.fixtures.local_docker_cluster_fixtures import (
     build_and_run_image,  # noqa: F401
     byo_cpu,  # noqa: F401
     cluster,  # noqa: F401
     local_docker_cluster_passwd,  # noqa: F401
     local_docker_cluster_public_key,  # noqa: F401
+    local_docker_cluster_public_key_den_auth,  # noqa: F401
     local_docker_cluster_public_key_logged_in,  # noqa: F401
     local_docker_cluster_public_key_logged_out,  # noqa: F401
     local_docker_cluster_telemetry_public_key,  # noqa: F401
@@ -226,38 +275,38 @@ from tests.test_resources.test_modules.test_tables.conftest import (
 default_fixtures = {}
 default_fixtures[TestLevels.UNIT] = {
     "cluster": [
-        local_docker_cluster_public_key_logged_in,
-        local_docker_cluster_public_key_logged_out,
+        "local_docker_cluster_public_key_logged_in",
+        "local_docker_cluster_public_key_logged_out",
     ]
 }
 default_fixtures[TestLevels.LOCAL] = {
     "cluster": [
-        local_docker_cluster_public_key_logged_in,
-        local_docker_cluster_public_key_logged_out,
-        local_docker_cluster_passwd,
+        "local_docker_cluster_public_key_logged_in",
+        "local_docker_cluster_public_key_logged_out",
+        "local_docker_cluster_passwd",
     ]
 }
-default_fixtures[TestLevels.MINIMAL] = {"cluster": [ondemand_cpu_cluster]}
+default_fixtures[TestLevels.MINIMAL] = {"cluster": ["ondemand_cpu_cluster"]}
 default_fixtures[TestLevels.THOROUGH] = {
     "cluster": [
-        local_docker_cluster_passwd,
-        local_docker_cluster_public_key_logged_in,
-        local_docker_cluster_public_key_logged_out,
-        ondemand_cpu_cluster,
-        ondemand_https_cluster_with_auth,
-        password_cluster,
-        static_cpu_cluster,
+        "local_docker_cluster_passwd",
+        "local_docker_cluster_public_key_logged_in",
+        "local_docker_cluster_public_key_logged_out",
+        "ondemand_cpu_cluster",
+        "ondemand_https_cluster_with_auth",
+        "password_cluster",
+        "static_cpu_cluster",
     ]
 }
 default_fixtures[TestLevels.MAXIMAL] = {
     "cluster": [
-        local_docker_cluster_passwd,
-        local_docker_cluster_public_key_logged_in,
-        local_docker_cluster_public_key_logged_out,
-        local_docker_cluster_telemetry_public_key,
-        ondemand_cpu_cluster,
-        ondemand_https_cluster_with_auth,
-        password_cluster,
-        static_cpu_cluster,
+        "local_docker_cluster_passwd",
+        "local_docker_cluster_public_key_logged_in",
+        "local_docker_cluster_public_key_logged_out",
+        "local_docker_cluster_telemetry_public_key",
+        "ondemand_cpu_cluster",
+        "ondemand_https_cluster_with_auth",
+        "password_cluster",
+        "static_cpu_cluster",
     ]
 }

--- a/tests/fixtures/local_docker_cluster_fixtures.py
+++ b/tests/fixtures/local_docker_cluster_fixtures.py
@@ -25,7 +25,7 @@ def get_rh_parent_path():
 
 @pytest.fixture(scope="function")
 def cluster(request):
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_resources/conftest.py
+++ b/tests/test_resources/conftest.py
@@ -13,7 +13,7 @@ RESOURCE_NAME = "my_resource"
 
 @pytest.fixture(scope="function")
 def resource(request):
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -5,16 +5,6 @@ import runhouse as rh
 import tests.test_resources.test_resource
 from tests.conftest import init_args
 
-from .conftest import (
-    local_docker_cluster_passwd,
-    local_docker_cluster_public_key_logged_in,
-    local_docker_cluster_public_key_logged_out,
-    local_docker_cluster_telemetry_public_key,
-    named_cluster,
-    password_cluster,
-    static_cpu_cluster,
-)
-
 """ TODO:
 1) In subclasses, test factory methods create same type as parent
 2) In subclasses, use monkeypatching to make sure `up()` is called for various methods if the server is not up
@@ -36,18 +26,18 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
 
     MAP_FIXTURES = {"resource": "cluster"}
 
-    UNIT = {"cluster": [named_cluster]}
+    UNIT = {"cluster": ["named_cluster"]}
     LOCAL = {
         "cluster": [
-            local_docker_cluster_public_key_logged_in,
-            local_docker_cluster_public_key_logged_out,
-            local_docker_cluster_telemetry_public_key,
-            local_docker_cluster_passwd,
+            "local_docker_cluster_public_key_logged_in",
+            "local_docker_cluster_public_key_logged_out",
+            "local_docker_cluster_telemetry_public_key",
+            "local_docker_cluster_passwd",
         ]
     }
-    MINIMAL = {"cluster": [static_cpu_cluster]}
-    THOROUGH = {"cluster": [static_cpu_cluster, password_cluster]}
-    MAXIMAL = {"cluster": [static_cpu_cluster, password_cluster]}
+    MINIMAL = {"cluster": ["static_cpu_cluster"]}
+    THOROUGH = {"cluster": ["static_cpu_cluster", "password_cluster"]}
+    MAXIMAL = {"cluster": ["static_cpu_cluster", "password_cluster"]}
 
     @pytest.mark.level("unit")
     def test_cluster_factory_and_properties(self, cluster):

--- a/tests/test_resources/test_clusters/test_on_demand_cluster/conftest.py
+++ b/tests/test_resources/test_clusters/test_on_demand_cluster/conftest.py
@@ -12,7 +12,7 @@ from ....conftest import init_args
 
 @pytest.fixture(scope="session")
 def on_demand_cluster(request):
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(

--- a/tests/test_resources/test_clusters/test_sagemaker_cluster/conftest.py
+++ b/tests/test_resources/test_clusters/test_sagemaker_cluster/conftest.py
@@ -15,7 +15,7 @@ from ....conftest import init_args
 
 @pytest.fixture(scope="session")
 def sagemaker_cluster(request):
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_resources/test_envs/conftest.py
+++ b/tests/test_resources/test_envs/conftest.py
@@ -21,7 +21,7 @@ def _get_conda_env(name="rh-test", python_version="3.10.9"):
 @pytest.fixture(scope="function")
 def env(request):
     """Parametrize over multiple envs - useful for running the same test on multiple envs."""
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -9,20 +9,7 @@ import runhouse as rh
 
 import tests.test_resources.test_resource
 
-from tests.conftest import (
-    init_args,
-    ondemand_cpu_cluster,
-    password_cluster,
-    static_cpu_cluster,
-)
-
-from .conftest import (
-    base_conda_env,
-    base_env,
-    conda_env_from_dict,
-    conda_env_from_local,
-    conda_env_from_path,
-)
+from tests.conftest import init_args
 
 
 def _get_env_var_value(env_var):
@@ -48,31 +35,34 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
 
     UNIT = {
         "env": [
-            base_env,
-            base_conda_env,
-            conda_env_from_dict,
-            conda_env_from_local,
-            conda_env_from_path,
+            "base_env",
+            "base_conda_env",
+            "conda_env_from_dict",
+            "conda_env_from_local",
+            "conda_env_from_path",
         ]
     }
     LOCAL = {
-        "env": [base_env, base_conda_env, conda_env_from_dict],
+        "env": ["base_env", "base_conda_env", "conda_env_from_dict"],
         # TODO: add local clusters once conda docker container is set up
     }
-    MINIMAL = {"env": [base_env, base_conda_env], "cluster": [ondemand_cpu_cluster]}
+    MINIMAL = {
+        "env": ["base_env", "base_conda_env"],
+        "cluster": ["ondemand_cpu_cluster"],
+    }
     THOROUGH = {
-        "env": [base_env, base_conda_env, conda_env_from_dict],
-        "cluster": [ondemand_cpu_cluster, static_cpu_cluster, password_cluster],
+        "env": ["base_env", "base_conda_env", "conda_env_from_dict"],
+        "cluster": ["ondemand_cpu_cluster", "static_cpu_cluster", "password_cluster"],
     }
     MAXIMAL = {
         "env": [
-            base_env,
-            base_conda_env,
-            conda_env_from_dict,
-            conda_env_from_local,
-            conda_env_from_path,
+            "base_env",
+            "base_conda_env",
+            "conda_env_from_dict",
+            "conda_env_from_local",
+            "conda_env_from_path",
         ],
-        "cluster": [ondemand_cpu_cluster, static_cpu_cluster, password_cluster],
+        "cluster": ["ondemand_cpu_cluster", "static_cpu_cluster", "password_cluster"],
     }
 
     @pytest.mark.level("unit")

--- a/tests/test_resources/test_modules/test_blobs/conftest.py
+++ b/tests/test_resources/test_modules/test_blobs/conftest.py
@@ -9,13 +9,13 @@ from tests.conftest import init_args
 @pytest.fixture
 def blob(request):
     """Parametrize over multiple blobs - useful for running the same test on multiple storage types."""
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture
 def file(request):
     """Parametrize over multiple files - useful for running the same test on multiple storage types."""
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_resources/test_modules/test_blobs/test_blob.py
+++ b/tests/test_resources/test_modules/test_blobs/test_blob.py
@@ -25,7 +25,7 @@ def test_save_local_blob_fails(local_blob, blob_data):
 @pytest.mark.clustertest
 @pytest.mark.parametrize(
     "blob",
-    ["cluster_blob", "cluster_file", "local_file", "s3_blob", "gcs_blob"],
+    ["local_file", "s3_blob", "gcs_blob"],
     indirect=True,
 )
 def test_reload_blob_with_name(blob):

--- a/tests/test_resources/test_modules/test_folders/conftest.py
+++ b/tests/test_resources/test_modules/test_folders/conftest.py
@@ -10,7 +10,7 @@ from .utils import create_gcs_bucket, create_s3_bucket
 @pytest.fixture
 def folder(request):
     """Parametrize over multiple folders - useful for running the same test on multiple storage types."""
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture

--- a/tests/test_resources/test_modules/test_folders/test_packages/conftest.py
+++ b/tests/test_resources/test_modules/test_folders/test_packages/conftest.py
@@ -8,7 +8,7 @@ from tests.conftest import init_args
 @pytest.fixture(scope="session")
 def package(request):
     """Parametrize over multiple packages - useful for running the same test on multiple storage types."""
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture

--- a/tests/test_resources/test_modules/test_tables/conftest.py
+++ b/tests/test_resources/test_modules/test_tables/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture(scope="session")
 def table(request):
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture

--- a/tests/test_resources/test_resource.py
+++ b/tests/test_resources/test_resource.py
@@ -5,12 +5,6 @@ import runhouse as rh
 
 from tests.conftest import init_args
 
-from tests.test_resources.conftest import (
-    local_named_resource,
-    named_resource,
-    unnamed_resource,
-)
-
 
 def load_shared_resource_config(original_resource):
     loaded_resource = original_resource.__class__.from_name(
@@ -22,11 +16,13 @@ def load_shared_resource_config(original_resource):
 
 class TestResource:
 
-    UNIT = {"resource": [unnamed_resource, named_resource, local_named_resource]}
-    LOCAL = {"resource": [unnamed_resource, named_resource, local_named_resource]}
-    MINIMAL = {"resource": [named_resource]}
-    THOROUGH = {"resource": [unnamed_resource, named_resource, local_named_resource]}
-    FULL = {"resource": [unnamed_resource, named_resource, local_named_resource]}
+    UNIT = {"resource": ["unnamed_resource", "named_resource", "local_named_resource"]}
+    LOCAL = {"resource": ["unnamed_resource", "named_resource", "local_named_resource"]}
+    MINIMAL = {"resource": ["named_resource"]}
+    THOROUGH = {
+        "resource": ["unnamed_resource", "named_resource", "local_named_resource"]
+    }
+    FULL = {"resource": ["unnamed_resource", "named_resource", "local_named_resource"]}
 
     @pytest.mark.level("unit")
     def test_resource_factory_and_properties(self, resource):

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -12,14 +12,11 @@ import runhouse as rh
 from runhouse.globals import rns_client
 from runhouse.servers.http.http_utils import b64_unpickle, pickle_b64
 
-from tests.test_resources.test_clusters.conftest import (
-    local_docker_cluster_public_key_den_auth,
-    local_docker_cluster_public_key_logged_in,
-)
-
-from tests.test_servers.conftest import local_client, local_client_with_den_auth, summer
-
 INVALID_HEADERS = {"Authorization": "Bearer InvalidToken"}
+
+# Helper used for testing rh.Function
+def summer(a, b):
+    return a + b
 
 
 @pytest.mark.usefixtures("cluster")
@@ -33,14 +30,14 @@ class TestHTTPServerDocker:
 
     UNIT = {
         "cluster": [
-            local_docker_cluster_public_key_den_auth,
-            local_docker_cluster_public_key_logged_in,
+            "local_docker_cluster_public_key_den_auth",
+            "local_docker_cluster_public_key_logged_in",
         ]
     }
     LOCAL = {
         "cluster": [
-            local_docker_cluster_public_key_den_auth,
-            local_docker_cluster_public_key_logged_in,
+            "local_docker_cluster_public_key_den_auth",
+            "local_docker_cluster_public_key_logged_in",
         ]
     }
 
@@ -231,8 +228,8 @@ class TestHTTPServerDockerDenAuthOnly:
     but it is a server without Den Auth enabled at all?
     """
 
-    UNIT = {"cluster": [local_docker_cluster_public_key_den_auth]}
-    LOCAL = {"cluster": [local_docker_cluster_public_key_den_auth]}
+    UNIT = {"cluster": ["local_docker_cluster_public_key_den_auth"]}
+    LOCAL = {"cluster": ["local_docker_cluster_public_key_den_auth"]}
 
     # -------- INVALID TOKEN / CLUSTER ACCESS TESTS ----------- #
 
@@ -385,7 +382,7 @@ def setup_cluster_config(test_account):
 
 @pytest.fixture(scope="function")
 def client(request):
-    return request.getfixturevalue(request.param.__name__)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.mark.den_auth
@@ -400,11 +397,11 @@ class TestHTTPServerNoDocker:
 
     # There is no default for this fixture, we should specify
     # it for each testing level.
-    UNIT = {"client": [local_client, local_client_with_den_auth]}
-    LOCAL = {"client": [local_client, local_client_with_den_auth]}
-    MINIMAL = {"client": [local_client, local_client_with_den_auth]}
-    THOROUGH = {"client": [local_client, local_client_with_den_auth]}
-    MAXIMAL = {"client": [local_client, local_client_with_den_auth]}
+    UNIT = {"client": ["local_client", "local_client_with_den_auth"]}
+    LOCAL = {"client": ["local_client", "local_client_with_den_auth"]}
+    MINIMAL = {"client": ["local_client", "local_client_with_den_auth"]}
+    THOROUGH = {"client": ["local_client", "local_client_with_den_auth"]}
+    MAXIMAL = {"client": ["local_client", "local_client_with_den_auth"]}
 
     @pytest.mark.level("unit")
     def test_get_cert(self, client):


### PR DESCRIPTION
When setting up the fixture list within a class, we were doing something along the lines of:

```
class TestClass:
    UNIT = {"cluster": [local_cluster]}
```

This requires an import of `local_cluster` from conftest. Turns out, this causes session scoped fixtures to be recomputed (https://github.com/pytest-dev/pytest/issues/3217). It's bad practice to import from conftest in the first place. So, I changed the fixtures that run `getfixturevalue` to just use the string argument, and we can avoid importing, and rely on pytest to set up the fixtures correctly. Now we set up fixtures like so:

```
class TestClass:
    UNIT = {"cluster": ["local_cluster"]}
```

Moreover... if a fixture is defined in a nested `conftest.py`, and imported in the global `conftest.py`, then there can be conflicts. The way tests work is that they'll look heirarchically upward in conftest.py files, and then grab the first fixture they find that matches the name. Even if the global `conftest.py` imports from a nested `conftest.py` file, it is considered a different fixture object (unintuitive, yes). This will sometimes lead to session scoped fixtures being initialized twice in the same session. More info on nested conftest.py files [here](https://github.com/pytest-dev/pytest/issues/1931).