### PR TITLE
Fix test_from_config to correctly use existing env.

### DIFF
--- a/tests/test_resources/test_modules/test_functions/test_function.py
+++ b/tests/test_resources/test_modules/test_functions/test_function.py
@@ -456,15 +456,15 @@ class TestFunction:
         my_summer_func = my_summer_func.to(system=cluster)
         assert my_summer_func(4, 6) == 10
 
-        np_summer_pointers = rh.Function._extract_pointers(np_summer, reqs=["numpy"])
+        np_summer_pointers = rh.Function._extract_pointers(
+            np_summer, reqs=["numpy", "./"]
+        )
         np_summer_config = {
             "fn_pointers": np_summer_pointers,
             "system": None,
-            "env": None,
+            "env": {"reqs": ["numpy"], "working_dir": "./"},
         }
-        my_np_func = rh.Function.from_config(np_summer_config).to(
-            system=cluster, env=["numpy"]
-        )
+        my_np_func = rh.Function.from_config(np_summer_config).to(system=cluster)
         assert my_np_func(1, 3) == 4
 
     @pytest.mark.level("local")


### PR DESCRIPTION
Passing an env as a part of `.to` overrides the entire existing env initialized as part of the function definition. This is, for now, expected behavior.

Moreover, when initializing from_config, we need to explicitly set the working_dir else it'll be set to None, and the current function will not be pushed up. 

**Testing**: `pytest -v --level local -k "TestFunction"`