### PR TITLE
Fix use of open_cluster_tunnels cache to account for dead connections.

### DIFF
--- a/runhouse/globals.py
+++ b/runhouse/globals.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 configs = Defaults()
 
-open_cluster_tunnels = {}
+ssh_tunnel_cache = {}
 
 rns_client = RNSClient(configs=configs)
 

--- a/tests/fixtures/local_docker_cluster_fixtures.py
+++ b/tests/fixtures/local_docker_cluster_fixtures.py
@@ -489,7 +489,7 @@ def local_docker_cluster_with_nginx(request):
 
 
 @pytest.fixture(scope="function")
-def local_test_account_cluster_public_key(request, test_account, detached=True):
+def local_test_account_cluster_public_key(request, test_account):
     """
     This fixture is not parameterized for every test; it is a separate cluster started with a test account
     (username: kitchen_tester) in order to test sharing resources with other users.
@@ -516,10 +516,8 @@ def local_test_account_cluster_public_key(request, test_account, detached=True):
             },
         )
 
-    # Yield the cluster
     yield local_cluster
 
-    # Stop the Docker container
     cleanup()
 
 


### PR DESCRIPTION
Run local tests, but individually (when running together we still get some cluster issues):

Server tests: `pytest -v --level local -k "not TestFunction and not TestEnv and not TestCluster and not TestResource`

Cluster & Resource: `pytest -v --level local -k "TestCluster or TestResource"`

Function: `pytest -v --level local -k "TestFunction"`


