### PR TITLE
Change logic for locating working dir for package installations.

### DIFF
--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -111,11 +111,11 @@ class RNSClient:
         # 4. User's cwd
 
         for search_target in [
-            "rh",
             ".git",
-            "requirements.txt",
             "setup.py",
             "pyproject.toml",
+            "rh",
+            "requirements.txt",
         ]:
             dir_with_target = cls.find_parent_with_file(cwd, search_target)
             if dir_with_target is not None:


### PR DESCRIPTION
First look for `.git` directory before `rh` directory. Sometimes, a parent directory was copied to the cluster instead because of the way Runhouse was first set up.