### PR TITLE
Change the default "unit" cluster fixtures to not use Docker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,8 +275,7 @@ from tests.test_resources.test_modules.test_tables.conftest import (
 default_fixtures = {}
 default_fixtures[TestLevels.UNIT] = {
     "cluster": [
-        "local_docker_cluster_public_key_logged_in",
-        "local_docker_cluster_public_key_logged_out",
+        "named_cluster",
     ]
 }
 default_fixtures[TestLevels.LOCAL] = {


### PR DESCRIPTION
Temporarily fixes a bug in test_module when running with unit and docker container is being created, but we should
fix this for real when we introduce proper Module unit tests.