### PR TITLE
Minor SageMaker launch fixes 

### DIFF
--- a/runhouse/resources/hardware/sagemaker_cluster.py
+++ b/runhouse/resources/hardware/sagemaker_cluster.py
@@ -95,7 +95,7 @@ class SageMakerCluster(Cluster):
             ssh_creds=kwargs.pop("ssh_creds", {}),
             ssh_port=kwargs.pop("ssh_port", self.DEFAULT_SSH_PORT),
             server_host=server_host,
-            server_port=kwargs.pop("server_port", self.DEFAULT_SERVER_PORT),
+            server_port=server_port,
             server_connection_type=server_connection_type,
             ssl_certfile=ssl_certfile,
             ssl_keyfile=ssl_keyfile,
@@ -275,7 +275,6 @@ class SageMakerCluster(Cluster):
 
     @property
     def _use_https(self) -> bool:
-        """Use HTTPS if cert or private key file paths are provided."""
         # Note: Since always connecting via SSM no need for HTTPS
         return False
 
@@ -840,7 +839,7 @@ class SageMakerCluster(Cluster):
                     # the bash script with a different set of ports
                     # E.g. ❯ lsof -i:11022,32300
                     # COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
-                    # ssh     97115 myuser    3u  IPv4 0xcf81f230786cc9fd      0t0  TCP localhost:50052 (LISTEN)
+                    # ssh     97115 myuser    3u  IPv4 0xcf81f230786cc9fd      0t0  TCP localhost:32300 (LISTEN)
                     # ssh     97115 myuser    6u  IPv4 0xcf81f230786eff6d      0t0  TCP localhost:11022 (LISTEN)
                     raise ConnectionError
 

--- a/runhouse/scripts/sagemaker_cluster/launch_instance.py
+++ b/runhouse/scripts/sagemaker_cluster/launch_instance.py
@@ -7,8 +7,6 @@ import warnings
 from pathlib import Path
 from typing import Dict
 
-from runhouse.resources.hardware.utils import CLUSTER_CONFIG_PATH
-
 DEFAULT_AUTOSTOP = -1
 MAIN_DIR = "/opt/ml/code"
 OUT_FILE = "sm_cluster.out"
@@ -61,15 +59,16 @@ def run_training_job(path_to_job: str, num_attempts: int):
 
 
 def read_cluster_config() -> Dict:
+    """Read the autostop from the cluster's config - this will get populated when the cluster is created,
+    or via the autostop APIs (e.g. `pause_autostop` or `keep_warm`)"""
     try:
-        # Read the autostop from the cluster's config - this will get populated when the cluster
-        # is created (via check_server) or via the autostop APIs (e.g. pause_autostop or keep_warm)
-        with open(os.path.expanduser(CLUSTER_CONFIG_PATH), "r") as f:
-            config = json.load(f)
+        # Note: Runhouse has not yet been installed at this stage on the cluster
+        with open(os.path.expanduser("~/.rh/cluster_config.json"), "r") as f:
+            cluster_config = json.load(f)
     except FileNotFoundError:
-        config = {}
+        cluster_config = {}
 
-    return config
+    return cluster_config
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Remove runhouse as dependency from launch script, as it has not yet been installed on the cluster
- Simplify init of `server_port` 