### PR TITLE
Fix small bug with reloading module from name

### DIFF
--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -426,7 +426,7 @@ class Module(Resource):
             # Handle properties
             if is_prop:
                 return attr
-        except AttributeError as e:
+        except (ModuleNotFoundError, AttributeError) as e:
             if item in self.signature:
                 _, is_prop, is_async, is_gen, local_default = list(
                     self.signature.get(item).values()

--- a/runhouse/resources/resource.py
+++ b/runhouse/resources/resource.py
@@ -370,8 +370,7 @@ class Resource:
         if isinstance(access_type, str):
             access_type = ResourceAccess(access_type)
 
-        if not rns_client.exists(self.rns_address):
-            self.save(name=rns_client.local_to_remote_address(self.rns_address))
+        self.save()
 
         if isinstance(users, str):
             users = [users]

--- a/runhouse/scripts/sagemaker_cluster/launch_instance.py
+++ b/runhouse/scripts/sagemaker_cluster/launch_instance.py
@@ -62,7 +62,7 @@ def read_cluster_config() -> Dict:
     """Read the autostop from the cluster's config - this will get populated when the cluster is created,
     or via the autostop APIs (e.g. `pause_autostop` or `keep_warm`)"""
     try:
-        # Note: Runhouse has not yet been installed at this stage on the cluster, 
+        # Note: Runhouse has not yet been installed at this stage on the cluster,
         # so we can't import CLUSTER_CONFIG_PATH, we just need to hardcode it.
         with open(os.path.expanduser("~/.rh/cluster_config.json"), "r") as f:
             cluster_config = json.load(f)


### PR DESCRIPTION
We weren't catching ModuleNotFoundErrors to default to the signature in cases where the function's
package is not present, only AttributeErrors, which is the case when a Module's backing code isn't
present.