### PR TITLE
Fix basic access flow in resources

### DIFF
--- a/runhouse/resources/function.py
+++ b/runhouse/resources/function.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 class Function(Module):
     RESOURCE_TYPE = "function"
-    DEFAULT_ACCESS = "write"
 
     def __init__(
         self,
@@ -28,7 +27,6 @@ class Function(Module):
         system: Optional[Cluster] = None,
         env: Optional[Env] = None,
         dryrun: bool = False,
-        access: Optional[str] = None,
         **kwargs,  # We have this here to ignore extra arguments when calling from from_config
     ):
         """
@@ -39,7 +37,6 @@ class Function(Module):
                 To create a Function, please use the factory method :func:`function`.
         """
         self.fn_pointers = fn_pointers
-        self.access = access or self.DEFAULT_ACCESS
         super().__init__(name=name, dryrun=dryrun, system=system, env=env, **kwargs)
 
     # ----------------- Constructor helper methods -----------------
@@ -106,11 +103,7 @@ class Function(Module):
             env = env or self.env or Env(name=Env.DEFAULT_NAME)
             env = _get_env_from(env)
 
-        if (
-            self.dryrun
-            or not (system or self.system)
-            or self.access not in ["write", "read"]
-        ):
+        if self.dryrun or not (system or self.system):
             # don't move the function to a system
             self.env = env
             return self
@@ -469,7 +462,6 @@ def function(
 
     new_function = Function(
         fn_pointers=fn_pointers,
-        access=Function.DEFAULT_ACCESS,
         name=name,
         dryrun=dryrun,
     ).to(system=system, env=env)

--- a/runhouse/resources/resource.py
+++ b/runhouse/resources/resource.py
@@ -13,7 +13,12 @@ from runhouse.rns.top_level_rns_fns import (
     save,
     split_rns_name_and_path,
 )
-from runhouse.rns.utils.api import load_resp_content, read_resp_data, ResourceAccess
+from runhouse.rns.utils.api import (
+    load_resp_content,
+    read_resp_data,
+    ResourceAccess,
+    ResourceVisibility,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +31,8 @@ class Resource:
         name: Optional[str] = None,
         dryrun: bool = False,
         provenance=None,
+        access_type: Optional[ResourceAccess] = ResourceAccess.WRITE,
+        global_visibility: Optional[ResourceVisibility] = ResourceVisibility.PRIVATE,
         **kwargs,
     ):
         """
@@ -67,6 +74,8 @@ class Resource:
             if isinstance(provenance, Dict)
             else provenance
         )
+        self.access_type = access_type
+        self.global_visibility = global_visibility
 
     # TODO add a utility to allow a parameter to be specified as "default" and then use the default value
 
@@ -314,6 +323,7 @@ class Resource:
         self,
         users: Union[str, List[str]],
         access_type: Union[ResourceAccess, str] = ResourceAccess.READ,
+        global_visibility: Optional[ResourceVisibility] = None,
         notify_users: bool = True,
         headers: Optional[Dict] = None,
     ) -> Tuple[Dict[str, ResourceAccess], Dict[str, ResourceAccess]]:
@@ -370,6 +380,8 @@ class Resource:
         if isinstance(access_type, str):
             access_type = ResourceAccess(access_type)
 
+        if global_visibility is not None:
+            self.global_visibility = global_visibility
         self.save()
 
         if isinstance(users, str):

--- a/runhouse/rns/utils/api.py
+++ b/runhouse/rns/utils/api.py
@@ -91,3 +91,9 @@ class ResourceAccess(str, Enum):
     WRITE = "write"
     READ = "read"
     PROXY = "proxy"
+
+
+class ResourceVisibility(str, Enum):
+    PRIVATE = "private"
+    PUBLIC = "public"
+    SEARCHABLE = "searchable"


### PR DESCRIPTION
Store basic access info in resources. Make users an optional argument to resource.share, allowing users to control default visibility (i.e. share with the world) via resource.share().