### PR TITLE
Remove add_secrets endpoint

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -311,12 +311,3 @@ class HTTPClient:
             env = _get_env_from(env)
             env = env.name
         return self.request(f"keys/?env={env}" if env else "keys", req_type="get")
-
-    def add_secrets(self, secrets):
-        failed_providers = self.request(
-            "secrets",
-            req_type="post",
-            data=pickle_b64(secrets),
-            err_str="Error sending secrets",
-        )
-        return failed_providers

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -567,14 +567,6 @@ class HTTPServer:
         return HTTPServer.call_in_env_servlet("get_keys", [], env=env)
 
     @staticmethod
-    @app.post("/secrets")
-    @validate_cluster_access
-    def add_secrets(request: Request, message: Message):
-        return HTTPServer.call_in_env_servlet(
-            "add_secrets", [message], env=message.env, create=True
-        )
-
-    @staticmethod
     @app.post("/call/{module}/{method}")
     @validate_cluster_access
     async def call(


### PR DESCRIPTION
no longer needed after converting secrets to a resource type. can just use general resource endpoint