### PR TITLE
Add ssh port to folder resource's fsspec fs

### DIFF
--- a/runhouse/resources/folders/folder.py
+++ b/runhouse/resources/folders/folder.py
@@ -210,6 +210,8 @@ class Folder(Resource):
             }
             ret_config = self._data_config.copy()
             ret_config.update(config_creds)
+            if creds and self.system.ssh_port:
+                ret_config["port"] = self.system.ssh_port
             return ret_config
         return self._data_config
 


### PR DESCRIPTION
was running into connection error when trying to fetch file/folder contents on testing docker container. adding port to the data config resolves this error.