### PR TITLE
Update deprecations and corresponding fn signatures

### DIFF
--- a/runhouse/__init__.py
+++ b/runhouse/__init__.py
@@ -3,8 +3,8 @@ from runhouse.resources.envs import conda_env, CondaEnv, env, Env
 from runhouse.resources.folders import Folder, folder, GCSFolder, S3Folder
 from runhouse.resources.functions.aws_lambda import LambdaFunction
 from runhouse.resources.functions.aws_lambda_factory import aws_lambda_fn
-from runhouse.resources.functions.funciton_factory import function
 from runhouse.resources.functions.function import Function
+from runhouse.resources.functions.function_factory import function
 from runhouse.resources.hardware import (
     _current_cluster,
     cluster,

--- a/runhouse/resources/functions/__init__.py
+++ b/runhouse/resources/functions/__init__.py
@@ -1,4 +1,4 @@
 from .aws_lambda import LambdaFunction
 from .aws_lambda_factory import aws_lambda_fn
-from .funciton_factory import function
 from .function import Function
+from .function_factory import function

--- a/runhouse/resources/functions/function.py
+++ b/runhouse/resources/functions/function.py
@@ -69,22 +69,21 @@ class Function(Module):
         self,
         system: Union[str, Cluster] = None,
         env: Union[List[str], Env] = [],
-        # Variables below are deprecated
-        reqs: Optional[List[str]] = None,
-        setup_cmds: Optional[List[str]] = [],
+        reqs: Optional[List[str]] = None,  # deprecated
+        setup_cmds: Optional[List[str]] = [],  # deprecated
         force_install: bool = False,
     ):
-        """
+        """to(system: str | Cluster | None = None, env: List[str] | Env = [], force_install: bool = False)
+
         Set up a Function and Env on the given system.
-        If the funciton is sent to AWS, the system should be ``aws_lambda``
+        If the function is sent to AWS, the system should be ``aws_lambda``
         See the args of the factory method :func:`function` for more information.
 
         Example:
             >>> rh.function(fn=local_fn).to(gpu_cluster)
             >>> rh.function(fn=local_fn).to(system=gpu_cluster, env=my_conda_env)
             >>> rh.function(fn=local_fn).to(system='aws_lambda')  # will deploy the rh.function to AWS as a Lambda.
-        """
-
+        """  # noqa: E501
         if setup_cmds:
             warnings.warn(
                 "``setup_cmds`` argument has been deprecated. "

--- a/runhouse/resources/functions/function_factory.py
+++ b/runhouse/resources/functions/function_factory.py
@@ -20,11 +20,12 @@ def function(
     dryrun: bool = False,
     load_secrets: bool = False,
     serialize_notebook_fn: bool = False,
-    # args below are deprecated
-    reqs: Optional[List[str]] = None,
-    setup_cmds: Optional[List[str]] = None,
+    reqs: Optional[List[str]] = None,  # deprecated
+    setup_cmds: Optional[List[str]] = None,  # deprecated
 ):
-    """Builds an instance of :class:`Function`.
+    """runhouse.function(fn: str | Callable | None = None, name: str | None = None, system: str | Cluster | None = None, env: str | List[str] | Env | None = None, dryrun: bool = False, load_secrets: bool = False, serialize_notebook_fn: bool = False)
+
+    Builds an instance of :class:`Function`.
 
     Args:
         fn (Optional[str or Callable]): The function to execute on the remote system when the function is called.
@@ -58,7 +59,7 @@ def function(
 
         >>> # Load function from above
         >>> reloaded_function = rh.function(name="my_func")
-    """
+    """  # noqa: E501
     if name and not any([fn, system, env]):
         # Try reloading existing function
         return Function.from_name(name, dryrun)

--- a/runhouse/resources/resource.py
+++ b/runhouse/resources/resource.py
@@ -326,8 +326,11 @@ class Resource:
         global_visibility: Optional[ResourceVisibility] = None,
         notify_users: bool = True,
         headers: Optional[Dict] = None,
+        access_type: Union[ResourceAccess, str] = None,  # deprecated
     ) -> Tuple[Dict[str, ResourceAccess], Dict[str, ResourceAccess]]:
-        """Grant access to the resource for the list of users (or a single user). If a user has a Runhouse account they
+        """share(users: str | List[str], access_level: ResourceAccess | str = ResourceAccess.READ, notify_users: bool = True, headers: Dict | None = None)
+
+        Grant access to the resource for the list of users (or a single user). If a user has a Runhouse account they
         will receive an email notifying them of their new access. If the user does not have a Runhouse account they will
         also receive instructions on creating one, after which they will be able to have access to the Resource.
 
@@ -351,13 +354,13 @@ class Resource:
 
         Example:
             >>> added_users, new_users = my_resource.share(users=["username1", "user2@gmail.com"], access_level='write')
-        """
+        """  # noqa: E501
         if self.name is None:
             raise ValueError("Resource must have a name in order to share")
 
         if hasattr(self, "system") and self.system in ["ssh", "sftp"]:
             logger.warning(
-                "Sharing a resource located on a cluster is not recommended. For persistence, we suggest"
+                "Sharing a resource located on a cluster is not recommended. For persistence, we suggest "
                 "saving to a cloud storage system (ex: `s3` or `gs`). You can copy your cluster based "
                 f"{self.RESOURCE_TYPE} to your desired storage provider using the `.to()` method. "
                 f"For example: `{self.RESOURCE_TYPE}.to(system='rh-cpu')`"
@@ -376,6 +379,13 @@ class Resource:
                     f"located on a cluster or a remote system. You can use the `.to()` method to do so. "
                     f"For example: `{self.name}.to(system='s3')`"
                 )
+
+        if access_type:
+            logger.warning(
+                "``access_type`` argument is deprecated and will be removed in a future release. "
+                "Please use ``access_level`` instead."
+            )
+            access_level = access_type
 
         if isinstance(access_level, str):
             access_level = ResourceAccess(access_level)


### PR DESCRIPTION
* deprecate access_type, with warning, instead of BC-breaking (remove in future release)
* update function signatures w/ deprecated arguments to hide those arguments
* correct funciton_factory file name to function_factory