### PR TITLE
Bugfix - exctract path to code correctly from pointers

### DIFF
--- a/runhouse/resources/functions/aws_lambda.py
+++ b/runhouse/resources/functions/aws_lambda.py
@@ -267,7 +267,8 @@ class LambdaFunction(Function):
     @classmethod
     def _paths_to_code_from_fn_pointers(cls, fn_pointers):
         """creates path to code from fn_pointers"""
-        root_dir = rns_client.locate_working_dir()
+        # root_dir = rns_client.locate_working_dir()
+        root_dir = Path(fn_pointers[0]).absolute()
         file_path = fn_pointers[1].replace(".", "/") + ".py"
         paths_to_code = [os.path.join(root_dir, file_path)]
         return paths_to_code

--- a/runhouse/resources/functions/aws_lambda.py
+++ b/runhouse/resources/functions/aws_lambda.py
@@ -267,6 +267,7 @@ class LambdaFunction(Function):
     @classmethod
     def _paths_to_code_from_fn_pointers(cls, fn_pointers):
         """creates path to code from fn_pointers"""
+        # TODO [SB]: need to refactor
         if "." in fn_pointers[1]:
             root_dir = rns_client.locate_working_dir()
             file_path = fn_pointers[1].replace(".", "/") + ".py"

--- a/runhouse/resources/functions/aws_lambda.py
+++ b/runhouse/resources/functions/aws_lambda.py
@@ -2,6 +2,7 @@ import base64
 import contextlib
 import json
 import logging
+import os
 import time
 import zipfile
 from pathlib import Path
@@ -266,10 +267,14 @@ class LambdaFunction(Function):
     @classmethod
     def _paths_to_code_from_fn_pointers(cls, fn_pointers):
         """creates path to code from fn_pointers"""
-        # root_dir = rns_client.locate_working_dir()
-        file_path = fn_pointers[1].replace(".", "/") + ".py"
-        file_path = Path(file_path).absolute()
-        paths_to_code = [file_path]
+        if "." in fn_pointers[1]:
+            root_dir = rns_client.locate_working_dir()
+            file_path = fn_pointers[1].replace(".", "/") + ".py"
+            paths_to_code = [os.path.join(root_dir, file_path)]
+        else:
+            file_path = fn_pointers[1].replace(".", "/") + ".py"
+            file_path = Path(file_path).absolute()
+            paths_to_code = [file_path]
         return paths_to_code
 
     def _update_lambda_config(self, env_vars):

--- a/runhouse/resources/functions/aws_lambda.py
+++ b/runhouse/resources/functions/aws_lambda.py
@@ -2,7 +2,6 @@ import base64
 import contextlib
 import json
 import logging
-import os
 import time
 import zipfile
 from pathlib import Path
@@ -268,9 +267,9 @@ class LambdaFunction(Function):
     def _paths_to_code_from_fn_pointers(cls, fn_pointers):
         """creates path to code from fn_pointers"""
         # root_dir = rns_client.locate_working_dir()
-        root_dir = Path(fn_pointers[0]).absolute()
         file_path = fn_pointers[1].replace(".", "/") + ".py"
-        paths_to_code = [os.path.join(root_dir, file_path)]
+        file_path = Path(file_path).absolute()
+        paths_to_code = [file_path]
         return paths_to_code
 
     def _update_lambda_config(self, env_vars):


### PR DESCRIPTION
When creating a lambda from a callable python function, the paths_to_code were not extracted correctly.  