### PR TITLE
Module/Cluster client() contract

### DIFF
--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -16,6 +16,7 @@ from runhouse.resources.packages import Package
 from runhouse.resources.resource import Resource
 from runhouse.rns.utils.api import ResourceAccess, ResourceVisibility
 from runhouse.rns.utils.names import _generate_default_name
+from runhouse.servers.http import HTTPClient
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,12 @@ logger = logging.getLogger(__name__)
 # Should we just be using inspect.getclasstree to get signatures without the Module methods instead?
 LOCAL_METHODS = dir(Resource) + [
     "_pointers",
+    "_endpoint",
+    "endpoint",
+    "_client",
+    "access_level",
+    "visibility",
+    "_visibility",
     "env",
     "_env",
     "_extract_pointers",
@@ -46,6 +53,7 @@ LOCAL_METHODS = dir(Resource) + [
     "signature",
     "_signature",
     "method_signature",
+    "keep_warm",
 ]
 
 
@@ -84,6 +92,7 @@ class Module(Resource):
             self._env.working_dir = self._env.working_dir or "./"
             pointers = Module._extract_pointers(self.__class__, reqs=self._env.reqs)
         self._pointers = pointers
+        self._endpoint = endpoint
         self._signature = signature
         self._resolve = False
 
@@ -115,6 +124,8 @@ class Module(Resource):
         # they're called via HTTP and 2) we want to preserve the exact set of methods in case the methods on built-in
         # modules change across Runhouse versions.
         config["signature"] = self.signature
+
+        config["endpoint"] = self.endpoint
         return config
 
     @classmethod
@@ -134,7 +145,7 @@ class Module(Resource):
                     # and this may a "type" module rather than an "instance". The user might instantiate it later, or
                     # it may be populated with attributes by the servlet's put_resource.
                     module_cls = _module_subclass_factory(
-                        module_cls, config.get("pointers")
+                        module_cls, config.get("pointers"), remote_init=True
                     )
             except ModuleNotFoundError:
                 # If we fail to construct the module class from the pointers, we check if the code is not local,
@@ -153,6 +164,7 @@ class Module(Resource):
             new_module.name = config.pop("name", None)
             new_module.access_level = config.pop("access_level", ResourceAccess.WRITE)
             new_module.visibility = config.pop("visibility", ResourceVisibility.PRIVATE)
+            new_module._endpoint = config.pop("endpoint", None)
             new_module._pointers = config.pop("pointers", None)
             new_module._signature = config.pop("signature", None)
             new_module.dryrun = config.pop("dryrun", False)
@@ -205,11 +217,19 @@ class Module(Resource):
 
     @property
     def signature(self):
-        return self._signature or {
+        if self._signature:
+            return self._signature
+
+        var_attrs = {
+            name: self.method_signature(getattr(self, name))
+            for name in self._extract_state()
+        }
+        member_attrs = {
             name: self.method_signature(method)
             for (name, method) in inspect.getmembers(self.__class__)
             if not name[0] == "_" and name not in LOCAL_METHODS
         }
+        return {**var_attrs, **member_attrs}
 
     def method_signature(self, method, rich=False):
         """Extracts the properties of a method that we want to preserve when sending the method over the wire."""
@@ -242,6 +262,39 @@ class Module(Resource):
             )
 
         return signature_metadata
+
+    @property
+    def endpoint(self):
+        """The endpoint of the module on the cluster. If the module is local, this will be None."""
+        # Only return an endpoint if it's external, local endpoints are not useful
+        if (
+            self._system
+            and hasattr(self._system, "endpoint")
+            and self._system.endpoint(external=True)
+        ):
+            return f"{self._system.endpoint(external=True)}/{self.name}"
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, new_endpoint: str):
+        self._endpoint = new_endpoint
+
+    def _client(self):
+        """Return the client through which to interact with the source-of-truth Module. If this module is local,
+        i.e. this module is its own source of truth, return None."""
+        if (
+            hasattr(self, "_system")
+            and self._system
+            and hasattr(self._system, "_client")
+        ):
+            return self._system._client()
+        if (
+            hasattr(self, "_endpoint")
+            and self._endpoint
+            and isinstance(self._endpoint, str)
+        ):
+            return HTTPClient.from_endpoint(self._endpoint)
+        return None
 
     def _remote_init(self, *args, **kwargs):
         if len(self.__class__.__bases__) > 1:
@@ -289,6 +342,18 @@ class Module(Resource):
                 module_name
             )
         return getattr(obj_store.imported_modules[module_name], obj_name)
+
+    def _extract_state(self):
+        # Exclude anything already being sent in the config and private module attributes
+        state = {}
+        # We only send over state for instances, not classes
+        if not isinstance(self, type):
+            state = {
+                attr: val
+                for attr, val in self.__dict__.items()
+                if attr not in LOCAL_METHODS
+            }
+        return state
 
     def to(
         self,
@@ -353,6 +418,7 @@ class Module(Resource):
             if system.on_this_cluster():
                 new_module.pin()
             else:
+                # TODO dedup with _extract_state
                 # Exclude anything already being sent in the config and private module attributes
                 excluded_state_keys = list(new_module.config_for_rns.keys()) + [
                     "_system",
@@ -406,18 +472,14 @@ class Module(Resource):
     def __getattribute__(self, item):
         """Override to allow for remote execution if system is a remote cluster. If not, the subclass's own
         __getattr__ will be called."""
-        if item in LOCAL_METHODS or not hasattr(self, "_system"):
+        if item in LOCAL_METHODS or not hasattr(self, "_client"):
             return super().__getattribute__(item)
-        system = super().__getattribute__("_system")
+        client = super().__getattribute__("_client")()
 
         try:
             attr = super().__getattribute__(item)
 
-            if (
-                not system
-                or not isinstance(system, Cluster)
-                or system.on_this_cluster()
-            ):
+            if not client:
                 return attr
 
             # Don't try to run private methods or attributes remotely
@@ -457,7 +519,7 @@ class Module(Resource):
                 if is_async:
 
                     def call_wrapper():
-                        return system.call(
+                        return client.call(
                             name,
                             item,
                             *args,
@@ -480,7 +542,7 @@ class Module(Resource):
                     loop = asyncio.get_event_loop()
                     return asyncio.create_task(async_call())
 
-                return system.call(
+                return client.call(
                     name,
                     item,
                     *args,
@@ -518,17 +580,12 @@ class Module(Resource):
     def __setattr__(self, key, value):
         """Override to allow for remote execution if system is a remote cluster. If not, the subclass's own
         __setattr__ will be called."""
-        if key in LOCAL_METHODS or not hasattr(self, "_system"):
+        if key in LOCAL_METHODS or not hasattr(self, "_client"):
             return super().__setattr__(key, value)
-        if (
-            not self._system
-            or not isinstance(self._system, Cluster)
-            or self._system.on_this_cluster()
-            or not self._name
-        ):
+        if not self._client() or not self._name:
             return super().__setattr__(key, value)
 
-        return self._system.call(
+        return self._client().call(
             module_name=self._name,
             method_name=key,
             new_value=value,
@@ -556,6 +613,7 @@ class Module(Resource):
             >>> my_module.remote._my_private_property
             >>> my_module.remote.size = 14
         """
+        client = super().__getattribute__("_client")()
         system = super().__getattribute__("_system")
         name = super().__getattribute__("_name")
 
@@ -565,7 +623,7 @@ class Module(Resource):
         class RemotePropertyWrapper:
             @classmethod
             def __getattribute__(cls, item):
-                if not isinstance(system, Cluster) or not name:
+                if not client or not name:
                     return outer_super_gettattr(item)
 
                 if isinstance(system, Cluster) and name and system.on_this_cluster():
@@ -575,18 +633,14 @@ class Module(Resource):
                     else:
                         return self.__getattribute__(item)
 
-                return system.call(name, item, stream_logs=False)
+                return client.call(name, item, stream_logs=False)
 
             @classmethod
             def __setattr__(cls, key, value):
-                if (
-                    not isinstance(system, Cluster)
-                    or not name
-                    or system.on_this_cluster()
-                ):
+                if not client or not name:
                     return outer_super_setattr(key, value)
 
-                return system.call(
+                return client.call(
                     module_name=name,
                     method_name=key,
                     new_value=value,
@@ -672,12 +726,13 @@ class Module(Resource):
             >>> await my_module.fetch_async("my_property")
             >>> await my_module.fetch_async("_my_private_property")
         """
+        client = super().__getattribute__("_client")()
         system = super().__getattribute__("_system")
         name = super().__getattribute__("_name")
 
         def call_wrapper():
             if not key:
-                return system.get(name, remote=remote, stream_logs=stream_logs)
+                return client.get(name, remote=remote, stream_logs=stream_logs)
 
             if isinstance(system, Cluster) and name and system.on_this_cluster():
                 obj_store_obj = obj_store.get(name, check_other_envs=True)
@@ -685,7 +740,7 @@ class Module(Resource):
                     return obj_store_obj.__getattribute__(key)
                 else:
                     return self.__getattribute__(key)
-            return system.call(name, key, remote=remote, stream_logs=stream_logs)
+            return client.call(name, key, remote=remote, stream_logs=stream_logs)
 
         try:
             is_gen = (key and hasattr(self, key)) and inspect.isasyncgenfunction(
@@ -717,16 +772,12 @@ class Module(Resource):
             >>> await my_module.set_async("my_property", my_value)
             >>> await my_module.set_async("_my_private_property", my_value)
         """
-        if (
-            not self._system
-            or not isinstance(self._system, Cluster)
-            or self._system.on_this_cluster()
-            or not self._name
-        ):
+        client = super().__getattribute__("_client")()
+        if not client or not self._name:
             return super().__setattr__(key, value)
 
         def call_wrapper():
-            return self._system.call(
+            return self._client().call(
                 module_name=self._name,
                 method_name=key,
                 new_value=value,
@@ -802,12 +853,14 @@ class Module(Resource):
             return
         old_name = self.name
         self.name = name  # Goes through Resource setter to parse name properly (e.g. if rns path)
-        if not self.system or not isinstance(self.system, Cluster):
-            return
-        if self.system.on_this_cluster():
+        if (
+            self.system
+            and isinstance(self.system, Cluster)
+            and self.system.on_this_cluster()
+        ):
             obj_store.rename(old_key=old_name, new_key=self.name)
-        else:
-            self.system.rename(old_key=old_name, new_key=self.name)
+        elif self._client():
+            self._client().rename(old_key=old_name, new_key=self.name)
 
     def save(
         self,
@@ -937,7 +990,7 @@ class Module(Resource):
     #     full_name = func_name
 
 
-def _module_subclass_factory(cls, cls_pointers):
+def _module_subclass_factory(cls, cls_pointers, remote_init=False):
     def __init__(
         self,
         *args,
@@ -964,7 +1017,7 @@ def _module_subclass_factory(cls, cls_pointers):
         )
         # This allows a class which is already on the cluster to construct an instance of itself with a factory
         # method, e.g. my_module = MyModuleCls.factory_constructor(*args, **kwargs)
-        if self.system and self.system.on_this_cluster():
+        if self.system and self.system.on_this_cluster() and remote_init:
             self._remote_init(*args, **kwargs)
 
     def __call__(
@@ -1103,7 +1156,6 @@ def module(
         cls_pointers[2] if cls_pointers else _generate_default_name(prefix="module")
     )
 
-    # return _module_subclass_factory(cls, pointers, system, env, name, signature)
     module_subclass = _module_subclass_factory(cls, cls_pointers)
     return module_subclass(
         system=system,

--- a/runhouse/resources/resource.py
+++ b/runhouse/resources/resource.py
@@ -33,7 +33,7 @@ class Resource:
         dryrun: bool = False,
         provenance=None,
         access_level: Optional[ResourceAccess] = ResourceAccess.WRITE,
-        global_visibility: Optional[ResourceVisibility] = ResourceVisibility.PRIVATE,
+        visibility: Optional[ResourceVisibility] = ResourceVisibility.PRIVATE,
         **kwargs,
     ):
         """
@@ -76,7 +76,7 @@ class Resource:
             else provenance
         )
         self.access_level = access_level
-        self.global_visibility = global_visibility
+        self._visibility = visibility
 
     # TODO add a utility to allow a parameter to be specified as "default" and then use the default value
 
@@ -87,7 +87,7 @@ class Resource:
             "resource_type": self.RESOURCE_TYPE,
             "resource_subtype": self.__class__.__name__,
             "provenance": self.provenance.config_for_rns if self.provenance else None,
-            "visibility": self.global_visibility,
+            "visibility": self.visibility,
         }
         return config
 
@@ -129,6 +129,14 @@ class Resource:
             self._name, self._rns_folder = split_rns_name_and_path(
                 resolve_rns_path(name)
             )
+
+    @property
+    def visibility(self):
+        return self._visibility
+
+    @visibility.setter
+    def visibility(self, visibility):
+        self._visibility = visibility
 
     @rns_address.setter
     def rns_address(self, new_address):
@@ -334,14 +342,14 @@ class Resource:
         """Grant access to the resource for a list of users (or a single user). If a user has a Runhouse account they
         will receive an email notifying them of their new access. If the user does not have a Runhouse account they will
         also receive instructions on creating one, after which they will be able to have access to the Resource. If
-        ``global_visibility`` is set to ``public``, users will not be notified.
+        ``visibility`` is set to ``public``, users will not be notified.
 
         .. note::
             You can only grant access to other users if you have write access to the resource.
 
         Args:
             users (Union[str, list], optional): Single user or list of user emails and / or runhouse account usernames.
-                If none are provided and ``global_visibility`` is set to ``public``, resource will be made publicly
+                If none are provided and ``visibility`` is set to ``public``, resource will be made publicly
                 available to all users. Defaults to ``read``.
             access_level (:obj:`ResourceAccess`, optional): Access level to provide for the resource.
             global_visibility (:obj:`ResourceVisibility`, optional): Type of visibility to provide for the shared
@@ -365,7 +373,7 @@ class Resource:
             >>> my_resource.share(users=["username1", "user2@gmail.com"], access_level='write')
 
             >>> # Make resource public, with read access to the resource for all users
-            >>> my_resource.share(global_visibility='public')
+            >>> my_resource.share(visibility='public')
         """
         if self.name is None:
             raise ValueError("Resource must have a name in order to share")
@@ -401,9 +409,9 @@ class Resource:
 
         if global_visibility is not None:
             # Update the resource in Den with this global visibility value
-            self.global_visibility = global_visibility
+            self.visibility = global_visibility
 
-            logger.info(f"Updating resource with visibility: {self.global_visibility}")
+            logger.info(f"Updating resource with visibility: {self.visibility}")
 
         self.save()
 

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -3,7 +3,7 @@ import logging
 import time
 import warnings
 from pathlib import Path
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 import requests
 
@@ -27,7 +27,13 @@ class HTTPClient:
     CHECK_TIMEOUT_SEC = 10
 
     def __init__(
-        self, host: str, port: int, auth=None, cert_path=None, use_https=False
+        self,
+        host: str,
+        port: int,
+        auth=None,
+        cert_path=None,
+        use_https=False,
+        system=None,
     ):
         self.host = host
         self.port = port
@@ -35,6 +41,7 @@ class HTTPClient:
         self.cert_path = cert_path
         self.use_https = use_https
         self.verify = self._use_cert_verification()
+        self.system = system
 
     def _use_cert_verification(self):
         if not self.use_https:
@@ -58,6 +65,16 @@ class HTTPClient:
             return False
 
         return True
+
+    @staticmethod
+    def from_endpoint(endpoint: str, auth=None, cert_path=None):
+        protocol, uri = endpoint.split("://")
+        host, port_and_route = uri.split(":", 1)
+        port, _ = port_and_route.split("/", 1)
+        use_https = protocol == "https"
+        client = HTTPClient(host, int(port), auth, cert_path, use_https=False)
+        client.use_https = use_https
+        return client
 
     def _formatted_url(self, endpoint: str):
         prefix = "https" if self.use_https else "http"
@@ -149,7 +166,33 @@ class HTTPClient:
         with open(self.cert_path, "wb") as file:
             file.write(cert)
 
-    def call_module_method(
+    def call(
+        self,
+        module_name,
+        method_name,
+        *args,
+        stream_logs=True,
+        run_name=None,
+        remote=False,
+        run_async=False,
+        save=False,
+        **kwargs,
+    ):
+        """wrapper to temporarily support cluster's call signature"""
+        return self.call_module_method(
+            module_name,
+            method_name,
+            stream_logs=stream_logs,
+            run_name=run_name,
+            remote=remote,
+            run_async=run_async,
+            save=save,
+            args=args,
+            kwargs=kwargs,
+            system=self.system,
+        )
+
+    def call_module_method(  # TODO rename call_module_method to call
         self,
         module_name,
         method_name,
@@ -277,6 +320,28 @@ class HTTPClient:
             env=env,
             err_str=f"Error putting resource {resource.name or type(resource)}",
         )
+
+    def get(
+        self, key: str, default: Any = None, remote=False, stream_logs: bool = False
+    ):
+        """Provides compatibility with cluster's get."""
+        try:
+            res = self.call_module_method(
+                key,
+                None,
+                remote=remote,
+                stream_logs=stream_logs,
+                system=self,
+            )
+        except KeyError as e:
+            if default == KeyError:
+                raise e
+            return default
+        return res
+
+    def rename(self, old_key: str, new_key: str):
+        """Provides compatibility with cluster's rename."""
+        return self.rename_object(old_key, new_key)
 
     def rename_object(self, old_key, new_key):
         self.request(

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -38,6 +38,7 @@ class ObjStore:
         cuda_visible_devices = list(range(int(num_gpus)))
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, cuda_visible_devices))
         self._kv_store = Kvstore()
+        self._kv_store.system = None  # sometimes this gets set to _current_cluster, which can only create problems
         self._env_for_key = (
             ray.remote(Kvstore)
             .options(
@@ -46,7 +47,9 @@ class ObjStore:
                 lifetime="detached",
                 namespace="runhouse",
             )
-            .remote()
+            .remote(
+                system="here"
+            )  # Same here, we don't want to use the _current_cluster system
         )
         self._auth_cache = (
             ray.remote(AuthCache)

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 import runhouse as rh
 
@@ -126,3 +127,26 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         new_cluster.run(["echo hello"])
         # Check that the same underlying ssh connection was used
         assert len(rh.globals.ssh_tunnel_cache) == num_open_tunnels
+
+    @pytest.mark.level("local")
+    def test_cluster_endpoint(self, cluster):
+        if not cluster.address:
+            assert cluster.endpoint() is None
+            return
+
+        endpoint = cluster.endpoint()
+        if cluster.server_connection_type in ["ssh", "aws_ssm"]:
+            assert cluster.endpoint(external=True) is None
+            assert endpoint == f"http://{rh.Cluster.LOCALHOST}:{cluster.client_port}"
+        else:
+            url_base = "https" if cluster.server_connection_type == "tls" else "http"
+            assert endpoint == f"{url_base}://{cluster.address}:{cluster.server_port}"
+
+        # Try to curl docs
+        r = requests.get(
+            f"{endpoint}/docs",
+            verify=False,
+            headers=rh.globals.rns_client.request_headers,
+        )
+        assert r.status_code == 200
+        assert "FastAPI" in r.text

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -503,7 +503,7 @@ class TestModule:
     def test_signature(self):
 
         SlowNumpy = rh.module(SlowNumpyArray)
-        assert set(SlowNumpy.signature.keys()) == {
+        assert set(SlowNumpy.signature) == {
             "slow_iter",
             "cpu_count",
             "size_minus_cpus",
@@ -541,42 +541,66 @@ class TestModule:
         }
 
         arr = SlowNumpy(size=5)
-        assert set(arr.signature.keys()) == {
+        assert set(arr.signature) == {
+            "size",
+            "_hidden_1",
             "slow_iter",
-            "cpu_count",
             "size_minus_cpus",
+            "arr",
+            "cpu_count",
             "factory_constructor",
         }
 
         df = SlowPandas(size=10)
         assert df.signature == {
+            "_hidden_1": {
+                "async": False,
+                "gen": False,
+                "local": False,
+                "property": True,
+                "signature": None,
+            },
             "cpu_count": {
-                "signature": "(self, local=True)",
-                "property": False,
                 "async": False,
                 "gen": False,
                 "local": True,
+                "property": False,
+                "signature": "(self, local=True)",
             },
             "cpu_count_async": {
-                "signature": "(self, local=True)",
-                "property": False,
                 "async": True,
                 "gen": False,
                 "local": True,
+                "property": False,
+                "signature": "(self, local=True)",
+            },
+            "df": {
+                "async": False,
+                "gen": False,
+                "local": False,
+                "property": True,
+                "signature": None,
+            },
+            "size": {
+                "async": False,
+                "gen": False,
+                "local": False,
+                "property": True,
+                "signature": None,
             },
             "slow_iter": {
-                "signature": "(self)",
-                "property": False,
                 "async": False,
                 "gen": True,
                 "local": False,
+                "property": False,
+                "signature": "(self)",
             },
             "slow_iter_async": {
-                "signature": "(self)",
-                "property": False,
                 "async": True,
                 "gen": True,
                 "local": False,
+                "property": False,
+                "signature": "(self)",
             },
         }
 
@@ -626,8 +650,7 @@ class TestModule:
             },
         }
 
-    @pytest.mark.skip("Not working yet")
-    @pytest.mark.level("minimal")
+    @pytest.mark.level("thorough")
     def test_shared_readonly(
         self, ondemand_https_cluster_with_auth, local_test_account_cluster_public_key
     ):
@@ -657,7 +680,7 @@ class TestModule:
         test_fn = rh.fn(test_load_and_use_readonly_module).to(
             local_test_account_cluster_public_key
         )
-        test_fn.remote(mod_name=remote_df.rns_address, cpu_count=cpu_count, size=size)
+        test_fn(mod_name=remote_df.rns_address, cpu_count=cpu_count, size=size)
 
 
 def test_load_and_use_readonly_module(mod_name, cpu_count, size=3):
@@ -683,7 +706,7 @@ def test_load_and_use_readonly_module(mod_name, cpu_count, size=3):
 
     # Check that stdout was captured. Skip the last result because sometimes we
     # don't catch it and it makes the test flaky.
-    for i in range(remote_df.size - 1):
+    for i in range(size - 1):
         assert f"Hello from the cluster stdout! {i}" in out
         assert f"Hello from the cluster logs! {i}" in out
 
@@ -701,6 +724,7 @@ def test_load_and_use_readonly_module(mod_name, cpu_count, size=3):
 
     remote_df.size = 20
     assert remote_df.remote.size == 20
+    remote_df.size = size  # reset to original value for second test
 
 
 if __name__ == "__main__":

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -12,7 +12,6 @@ from tests.test_servers.conftest import summer
 from tests.utils import test_account
 
 
-@pytest.mark.usefixtures("setup_cluster_config")
 class TestServlet:
     @pytest.mark.level("unit")
     def test_put_resource(self, base_servlet, blob_data):


### PR DESCRIPTION
Refactor Module and Cluster so Module methods can be called without Cluster access. test_module passes with MINIMAL, except final sharing test.

Still TODO:
- [x] Add call to obj_store and match obj_store to client API
- [ ] Update fetch properly
- [x] Get sharing test working
- [ ] Fix certs behavior in from_endpoint in http_client