### PR TITLE
Add additional provider secrets

### DIFF
--- a/docs/api/python/secrets.rst
+++ b/docs/api/python/secrets.rst
@@ -42,7 +42,7 @@ AWSSecret Class
    .. autoattribute:: _DEFAULT_ENV_VARS
 
 AzureSecret Class
----------------
+-----------------
 .. autoclass:: runhouse.resources.secrets.provider_secrets.azure_secret.AzureSecret
    :show-inheritance:
 
@@ -60,7 +60,7 @@ GCPSecret Class
    .. autoattribute:: _DEFAULT_ENV_VARS
 
 GitHubSecret Class
----------------
+------------------
 .. autoclass:: runhouse.resources.secrets.provider_secrets.github_secret.GitHubSecret
    :show-inheritance:
 
@@ -68,7 +68,7 @@ GitHubSecret Class
    .. autoattribute:: _DEFAULT_CREDENTIALS_PATH
 
 HuggingFaceSecret Class
----------------
+-----------------------
 .. autoclass:: runhouse.resources.secrets.provider_secrets.huggingface_secret.HuggingFaceSecret
    :show-inheritance:
 
@@ -77,7 +77,7 @@ HuggingFaceSecret Class
 
 
 LambdaSecret Class
----------------
+------------------
 .. autoclass:: runhouse.resources.secrets.provider_secrets.lambda_secret.LambdaSecret
    :show-inheritance:
 
@@ -103,3 +103,51 @@ SkySecret Class
    .. autoattribute:: _PROVIDER
    .. autoattribute:: _DEFAULT_CREDENTIALS_PATH
    .. autoattribute:: _DEFAULT_KEY
+
+AnthropicSecret Class
+---------------------
+.. autoclass:: runhouse.resources.secrets.provider_secrets.anthropic_secret.AnthropicSecret
+   :show-inheritance:
+
+   .. autoattribute:: _PROVIDER
+   .. autoattribute:: _DEFAULT_ENV_VARS
+
+CohereSecret Class
+------------------
+.. autoclass:: runhouse.resources.secrets.provider_secrets.cohere_secret.CohereSecret
+   :show-inheritance:
+
+   .. autoattribute:: _PROVIDER
+   .. autoattribute:: _DEFAULT_ENV_VARS
+
+LangChainSecret Class
+---------------------
+.. autoclass:: runhouse.resources.secrets.provider_secrets.langchain_secret.LangChainSecret
+   :show-inheritance:
+
+   .. autoattribute:: _PROVIDER
+   .. autoattribute:: _DEFAULT_ENV_VARS
+
+OpenAISecret Class
+------------------
+.. autoclass:: runhouse.resources.secrets.provider_secrets.openai_secret.OpenAISecret
+   :show-inheritance:
+
+   .. autoattribute:: _PROVIDER
+   .. autoattribute:: _DEFAULT_ENV_VARS
+
+PineconeSecret Class
+--------------------
+.. autoclass:: runhouse.resources.secrets.provider_secrets.pinecone_secret.PineconeSecret
+   :show-inheritance:
+
+   .. autoattribute:: _PROVIDER
+   .. autoattribute:: _DEFAULT_ENV_VARS
+
+WandBSecret Class
+------------------
+.. autoclass:: runhouse.resources.secrets.provider_secrets.wandb_secret.WandBSecret
+   :show-inheritance:
+
+   .. autoattribute:: _PROVIDER
+   .. autoattribute:: _DEFAULT_ENV_VARS

--- a/runhouse/resources/secrets/provider_secrets/anthropic_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/anthropic_secret.py
@@ -1,0 +1,16 @@
+from runhouse.resources.secrets.provider_secrets.api_key_secret import ApiKeySecret
+
+
+class AnthropicSecret(ApiKeySecret):
+    """
+    .. note::
+            To create an AnthropicSecret, please use the factory method :func:`provider_secret`
+            with ``provider="anthropic"``.
+    """
+
+    _PROVIDER = "anthropic"
+    _DEFAULT_ENV_VARS = {"api_key": "ANTHRHOPIC_API_KEY"}
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = False):
+        return AnthropicSecret(**config, dryrun=dryrun)

--- a/runhouse/resources/secrets/provider_secrets/api_key_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/api_key_secret.py
@@ -1,0 +1,41 @@
+from typing import Dict, Optional, Union
+
+from runhouse.resources.blobs.file import File
+from runhouse.resources.envs.env import Env
+from runhouse.resources.hardware.cluster import Cluster
+from runhouse.resources.secrets.provider_secrets.provider_secret import ProviderSecret
+
+
+class ApiKeySecret(ProviderSecret):
+    """Secret class for providers consisting of a single API key, generally stored as an environment variable.
+
+    .. note::
+            To create an ApiKeySecret, please use the factory method :func:`provider_secret`
+            and passing in the corresponding provider.
+    """
+
+    def write(
+        self,
+        file: bool = False,
+        env: bool = False,
+        path: Union[str, File] = None,
+        env_vars: Dict = None,
+        overwrite: bool = False,
+    ):
+        if not file or path:
+            env = True
+        super().write(
+            file=file, env=env, path=path, env_vars=env_vars, overwrite=overwrite
+        )
+
+    def to(
+        self,
+        system: Union[str, Cluster],
+        path: Union[str, File] = None,
+        env: Union[str, Env] = None,
+        values: bool = True,
+        name: Optional[str] = None,
+    ):
+        if not (self.path or path or env):
+            env = Env()
+        return super().to(system=system, path=path, env=env, values=values, name=name)

--- a/runhouse/resources/secrets/provider_secrets/cohere_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/cohere_secret.py
@@ -1,0 +1,16 @@
+from runhouse.resources.secrets.provider_secrets.api_key_secret import ApiKeySecret
+
+
+class CohereSecret(ApiKeySecret):
+    """
+    .. note::
+            To create an CohereSecret, please use the factory method :func:`provider_secret`
+            with ``provider="cohere"``.
+    """
+
+    _PROVIDER = "cohere"
+    _DEFAULT_ENV_VARS = {"api_key": "COHERE_API_KEY"}
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = False):
+        return CohereSecret(**config, dryrun=dryrun)

--- a/runhouse/resources/secrets/provider_secrets/huggingface_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/huggingface_secret.py
@@ -17,8 +17,9 @@ class HuggingFaceSecret(ProviderSecret):
     """
 
     # values format: {"token": hf_token}
-    _DEFAULT_CREDENTIALS_PATH = "~/.cache/huggingface/token"
     _PROVIDER = "huggingface"
+    _DEFAULT_CREDENTIALS_PATH = "~/.cache/huggingface/token"
+    _DEFAULT_ENV_VARS = {"token": "HF_TOKEN"}
 
     @staticmethod
     def from_config(config: dict, dryrun: bool = False):

--- a/runhouse/resources/secrets/provider_secrets/langchain_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/langchain_secret.py
@@ -1,0 +1,16 @@
+from runhouse.resources.secrets.provider_secrets.api_key_secret import ApiKeySecret
+
+
+class LangChainSecret(ApiKeySecret):
+    """
+    .. note::
+            To create an LangChainSecret, please use the factory method :func:`provider_secret`
+            with ``provider="langchain"``.
+    """
+
+    _PROVIDER = "langchain"
+    _DEFAULT_ENV_VARS = {"api_key": "LANGCHAIN_API_KEY"}
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = False):
+        return LangChainSecret(**config, dryrun=dryrun)

--- a/runhouse/resources/secrets/provider_secrets/openai_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/openai_secret.py
@@ -1,0 +1,15 @@
+from runhouse.resources.secrets.provider_secrets.api_key_secret import ApiKeySecret
+
+
+class OpenAISecret(ApiKeySecret):
+    """
+    .. note::
+            To create an OpenAISecret, please use the factory method :func:`provider_secret` with ``provider="openai"``.
+    """
+
+    _PROVIDER = "openai"
+    _DEFAULT_ENV_VARS = {"api_key": "OPENAI_API_KEY"}
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = False):
+        return OpenAISecret(**config, dryrun=dryrun)

--- a/runhouse/resources/secrets/provider_secrets/pinecone_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/pinecone_secret.py
@@ -1,0 +1,16 @@
+from runhouse.resources.secrets.provider_secrets.api_key_secret import ApiKeySecret
+
+
+class PineconeSecret(ApiKeySecret):
+    """
+    .. note::
+            To create an PineconeSecret, please use the factory method :func:`provider_secret`
+            with ``provider="pinecone"``.
+    """
+
+    _PROVIDER = "pinecone"
+    _DEFAULT_ENV_VARS = {"api_key": "PINECONE_API_KEY"}
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = False):
+        return PineconeSecret(**config, dryrun=dryrun)

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -32,7 +32,8 @@ class ProviderSecret(Secret):
         Provider Secret class. Built-in provider classes contain default path and/or environment variable mappings,
         based on it's expected usage.
 
-        Currently supported built-in providers: aws, azure, gcp, github, huggingface, lambda, ssh, sky.
+        Currently supported built-in providers:
+        anthropic, aws, azure, gcp, github, huggingface, lambda, langchain, openai, pinecone, ssh, sky, wandb.
 
         .. note::
             To create a ProviderSecret, please use the factory method :func:`provider_secret`.

--- a/runhouse/resources/secrets/provider_secrets/providers.py
+++ b/runhouse/resources/secrets/provider_secrets/providers.py
@@ -1,25 +1,40 @@
+from runhouse.resources.secrets.provider_secrets.anthropic_secret import AnthropicSecret
 from runhouse.resources.secrets.provider_secrets.aws_secret import AWSSecret
 from runhouse.resources.secrets.provider_secrets.azure_secret import AzureSecret
+from runhouse.resources.secrets.provider_secrets.cohere_secret import CohereSecret
 from runhouse.resources.secrets.provider_secrets.gcp_secret import GCPSecret
 from runhouse.resources.secrets.provider_secrets.github_secret import GitHubSecret
 from runhouse.resources.secrets.provider_secrets.huggingface_secret import (
     HuggingFaceSecret,
 )
 from runhouse.resources.secrets.provider_secrets.lambda_secret import LambdaSecret
+from runhouse.resources.secrets.provider_secrets.langchain_secret import LangChainSecret
+from runhouse.resources.secrets.provider_secrets.openai_secret import OpenAISecret
+from runhouse.resources.secrets.provider_secrets.pinecone_secret import PineconeSecret
 from runhouse.resources.secrets.provider_secrets.provider_secret import ProviderSecret
 from runhouse.resources.secrets.provider_secrets.sky_secret import SkySecret
 from runhouse.resources.secrets.provider_secrets.ssh_secret import SSHSecret
+from runhouse.resources.secrets.provider_secrets.wandb_secret import WandBSecret
 
 
 _str_to_provider_class = {
+    # File and/or Env secrets
     "aws": AWSSecret,
     "azure": AzureSecret,
     "gcp": GCPSecret,
     "github": GitHubSecret,
     "huggingface": HuggingFaceSecret,
     "lambda": LambdaSecret,
+    # SSH secrets
     "ssh": SSHSecret,
     "sky": SkySecret,
+    # API key secrets
+    "anthropic": AnthropicSecret,
+    "cohere": CohereSecret,
+    "langchain": LangChainSecret,
+    "openai": OpenAISecret,
+    "pinecone": PineconeSecret,
+    "wandb": WandBSecret,
 }
 
 

--- a/runhouse/resources/secrets/provider_secrets/wandb_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/wandb_secret.py
@@ -1,0 +1,15 @@
+from runhouse.resources.secrets.provider_secrets.api_key_secret import ApiKeySecret
+
+
+class WandBSecret(ApiKeySecret):
+    """
+    .. note::
+            To create an WandBSecret, please use the factory method :func:`provider_secret` with ``provider="wandb"``.
+    """
+
+    _PROVIDER = "wandb"
+    _DEFAULT_ENV_VARS = {"api_key": "WANDB_API_KEY"}
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = False):
+        return WandBSecret(**config, dryrun=dryrun)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,16 +251,22 @@ from tests.test_resources.test_modules.test_tables.conftest import (
 )
 
 from tests.test_resources.test_secrets.conftest import (
+    anthropic_secret,  # noqa: F401
     aws_secret,  # noqa: F401
     azure_secret,  # noqa: F401
+    cohere_secret,  # noqa: F401
     custom_provider_secret,  # noqa: F401
     gcp_secret,  # noqa: F401
     github_secret,  # noqa: F401
     huggingface_secret,  # noqa: F401
     lambda_secret,  # noqa: F401
+    langchain_secret,  # noqa: F401
+    openai_secret,  # noqa: F401
+    pinecone_secret,  # noqa: F401
     sky_secret,  # noqa: F401
     ssh_secret,  # noqa: F401
     test_secret,  # noqa: F401
+    wandb_secret,  # noqa: F401
 )
 
 

--- a/tests/test_resources/test_secrets/conftest.py
+++ b/tests/test_resources/test_secrets/conftest.py
@@ -15,6 +15,12 @@ provider_secret_values = {
     "huggingface": {"token": "test_token"},
     "ssh": {"public_key": "test_public_key", "private_key": "test_private_key"},
     "sky": {"public_key": "test_public_key", "private_key": "test_private_key"},
+    "anthropic": {"api_key": "test_anthropic_api_key"},
+    "cohere": {"api_key": "test_cohere_api_key"},
+    "langchain": {"api_key": "test_langchain_api_key"},
+    "openai": {"api_key": "test_openai_api_key"},
+    "pinecone": {"api_key": "test_pinecone_api_key"},
+    "wandb": {"api_key": "test_wandb_api_key"},
     "custom_provider": base_secret_values,
 }
 
@@ -84,6 +90,36 @@ def ssh_secret():
 @pytest.fixture(scope="function")
 def sky_secret():
     return _provider_secret("sky")
+
+
+@pytest.fixture(scope="function")
+def anthropic_secret():
+    return _provider_secret("anthropic")
+
+
+@pytest.fixture(scope="function")
+def cohere_secret():
+    return _provider_secret("cohere")
+
+
+@pytest.fixture(scope="function")
+def langchain_secret():
+    return _provider_secret("langchain")
+
+
+@pytest.fixture(scope="function")
+def openai_secret():
+    return _provider_secret("openai")
+
+
+@pytest.fixture(scope="function")
+def pinecone_secret():
+    return _provider_secret("pinecone")
+
+
+@pytest.fixture(scope="function")
+def wandb_secret():
+    return _provider_secret("wandb")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Add secrets for new providers (anthropic, cohere, langchain, openai, pinecone, wandb). These secrets are all of the type `ApiSecretKey`, which is similar to the base `ProviderSecret` class, with the expected single value dict `{"api_key": "value..."}`, and env var `[PROVIDER]_API_KEY`, and by default we set env vars in `write()` and `to()` functions.