### PR TITLE
Update default values behavior for sending secrets to cluster

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -267,8 +267,6 @@ class HTTPClient:
             env = _get_env_from(env)
             env = env.name or env.env_name
         config = resource.config_for_rns
-        if config["resource_type"] == "secret":
-            config["values"] = resource.values
         return self.request(
             "resource",
             req_type="post",

--- a/tests/test_resources/test_secrets/test_secret.py
+++ b/tests/test_resources/test_secrets/test_secret.py
@@ -96,6 +96,13 @@ class TestSecret(tests.test_resources.test_resource.TestResource):
         assert isinstance(secret, rh.Secret)
 
     @pytest.mark.level("local")
+    def test_provider_secret_to_cluster_values(self, secret, cluster):
+        remote_secret = secret.to(cluster)
+        assert cluster.get(remote_secret.name)
+        assert cluster.get(remote_secret.name).values
+        cluster.delete(remote_secret.name)
+
+    @pytest.mark.level("local")
     def test_provider_secret_to_cluster_path(self, secret, cluster):
         if not isinstance(secret, rh.ProviderSecret):
             return


### PR DESCRIPTION
Previously, when sending secrets to a cluster, values would be included in the obj store through the `put_resource` call.

In this PR, update the default behavior for whether or not to include `values` for the secret in the obj store.
* Values will be saved to obj store if no path or env is provided in the `.to()` call
* Values will not be saved to the obj store if the secret is not in-memory and corresponds to a path or env, or if a path or env is set in the `.to()` call. The metadata will be stored in the obj store, and values retrievable through the corresponding path or env variable.
* If `values` is explicitly set to `True` or `False` (default is `None`), then we will correspondingly force saving or not saving the values