### PR TITLE
Support secrets in env

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -37,11 +37,11 @@ def login(
             upload_config=True,
             download_secrets=True,
             upload_secrets=True,
-            from_app=True,
+            from_cli=True,
         )
         if yes
         else runhouse.rns.login.login(
-            token=token, interactive=True, ret_token=True, from_app=True
+            token=token, interactive=True, ret_token=True, from_cli=True
         )
     )
 

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -37,9 +37,12 @@ def login(
             upload_config=True,
             download_secrets=True,
             upload_secrets=True,
+            from_app=True,
         )
         if yes
-        else runhouse.rns.login.login(token=token, interactive=True, ret_token=True)
+        else runhouse.rns.login.login(
+            token=token, interactive=True, ret_token=True, from_app=True
+        )
     )
 
     if valid_token:

--- a/runhouse/resources/blobs/blob.py
+++ b/runhouse/resources/blobs/blob.py
@@ -2,7 +2,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-from runhouse.resources.envs import _get_env_from, Env
+from runhouse.resources.envs.env import Env
+from runhouse.resources.envs.utils import _get_env_from
 from runhouse.resources.hardware import _current_cluster, _get_cluster_from, Cluster
 
 from runhouse.resources.module import Module

--- a/runhouse/resources/envs/conda_env.py
+++ b/runhouse/resources/envs/conda_env.py
@@ -9,8 +9,6 @@ from runhouse.globals import obj_store
 
 from runhouse.resources.packages import Package
 
-# from runhouse.resources.secrets.secret import Secret
-
 from .env import Env
 from .utils import _install_conda
 

--- a/runhouse/resources/envs/conda_env.py
+++ b/runhouse/resources/envs/conda_env.py
@@ -9,6 +9,8 @@ from runhouse.globals import obj_store
 
 from runhouse.resources.packages import Package
 
+# from runhouse.resources.secrets.secret import Secret
+
 from .env import Env
 from .utils import _install_conda
 
@@ -27,6 +29,7 @@ class CondaEnv(Env):
         setup_cmds: List[str] = None,
         env_vars: Optional[Dict] = {},
         working_dir: Optional[Union[str, Path]] = "./",
+        secrets: List[Union[str, "Secret"]] = [],
         dryrun: bool = True,
         **kwargs,  # We have this here to ignore extra arguments when calling from_config
     ):
@@ -44,6 +47,7 @@ class CondaEnv(Env):
             setup_cmds=setup_cmds,
             env_vars=env_vars,
             working_dir=working_dir,
+            secrets=secrets,
             dryrun=dryrun,
         )
 

--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -29,6 +29,7 @@ class Env(Resource):
         setup_cmds: List[str] = None,
         env_vars: Union[Dict, str] = {},
         working_dir: Optional[Union[str, Path]] = None,
+        secrets: Optional[Union[str, "Secret"]] = [],
         dryrun: bool = True,
         **kwargs,  # We have this here to ignore extra arguments when calling from_config
     ):
@@ -43,6 +44,7 @@ class Env(Resource):
         self.setup_cmds = setup_cmds
         self.env_vars = env_vars
         self.working_dir = working_dir
+        self.secrets = secrets
 
     @property
     def env_name(self):
@@ -119,6 +121,19 @@ class Env(Resource):
             return new_reqs[:-1], new_reqs[-1]
         return new_reqs, None
 
+    def _secrets_to(self, system: Union[str, Cluster]):
+        from runhouse.resources.secrets import Secret
+
+        new_secrets = []
+        for secret in self.secrets:
+            if isinstance(secret, str):
+                secret = Secret.from_name(secret)
+            if secret.path:
+                new_secrets.append(secret.to(system=system))
+            else:
+                new_secrets.append(secret.to(system=system, env=self))
+        return new_secrets
+
     def install(self, force=False):
         """Locally install packages and run setup commands."""
         # Hash the config_for_rns to check if we need to install
@@ -183,6 +198,7 @@ class Env(Resource):
         new_env = copy.deepcopy(self)
         # new_env.name = new_env.name or "base"
         new_env.reqs, new_env.working_dir = self._reqs_to(system, path, mount)
+        new_env.secrets = self._secrets_to(system)
 
         if isinstance(system, Cluster):
             key = system.put_resource(new_env)

--- a/runhouse/resources/envs/env_factory.py
+++ b/runhouse/resources/envs/env_factory.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 from runhouse.resources.packages import Package
+
+# from runhouse.resources.secrets.secret import Secret
 from .conda_env import CondaEnv
 
 from .env import Env
@@ -17,6 +19,7 @@ def env(
     setup_cmds: List[str] = None,
     env_vars: Union[Dict, str] = {},
     working_dir: Optional[Union[str, Path]] = "./",
+    secrets: Optional[Union[str, "Secret"]] = [],
     dryrun: bool = False,
 ):
     """Builds an instance of :class:`Env`.
@@ -51,7 +54,7 @@ def env(
         >>> conda_env = rh.env(conda_env="local-conda-env-name")     # from a existing local conda env
         >>> conda_env = rh.env(conda_env="conda_env.yaml", reqs=["pip:/accelerate"])   # with additional reqs
     """
-    if name and not any([reqs, conda_env, setup_cmds, env_vars]):
+    if name and not any([reqs, conda_env, setup_cmds, env_vars, secrets]):
         return Env.from_name(name, dryrun)
 
     reqs = _process_reqs(reqs or [])
@@ -64,6 +67,7 @@ def env(
             setup_cmds=setup_cmds,
             env_vars=env_vars,
             working_dir=working_dir,
+            secrets=secrets,
             name=name or conda_yaml["name"],
             dryrun=dryrun,
         )
@@ -73,6 +77,7 @@ def env(
         setup_cmds=setup_cmds,
         env_vars=env_vars,
         working_dir=working_dir,
+        secrets=secrets,
         name=name or Env.DEFAULT_NAME,
         dryrun=dryrun,
     )
@@ -86,6 +91,7 @@ def conda_env(
     setup_cmds: List[str] = None,
     env_vars: Optional[Dict] = {},
     working_dir: Optional[Union[str, Path]] = "./",
+    secrets: List[Union[str, "Secret"]] = [],
     dryrun: bool = False,
 ):
     """Builds an instance of :class:`CondaEnv`.
@@ -124,5 +130,6 @@ def conda_env(
         setup_cmds=setup_cmds,
         env_vars=env_vars,
         working_dir=working_dir,
+        secrets=secrets,
         dryrun=dryrun,
     )

--- a/runhouse/resources/envs/env_factory.py
+++ b/runhouse/resources/envs/env_factory.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Union
 
 from runhouse.resources.packages import Package
 
-# from runhouse.resources.secrets.secret import Secret
 from .conda_env import CondaEnv
 
 from .env import Env

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -308,10 +308,12 @@ class Cluster(Resource):
         return self.get(run_name, remote=True).provenance
 
     # TODO This should accept an env (for env var secrets and docker envs).
-    def add_secrets(self, provider_secrets: List[str or "Secret"]):
+    def add_secrets(
+        self, provider_secrets: List[str or "Secret"], env: Union[str, "Env"] = None
+    ):
         """Copy secrets from current environment onto the cluster"""
         self.check_server()
-        self.sync_secrets(provider_secrets)
+        self.sync_secrets(provider_secrets, env=env)
 
     def put(self, key: str, obj: Any, env=None):
         """Put the given object on the cluster's object store at the given key."""
@@ -1130,7 +1132,11 @@ class Cluster(Resource):
 
         return return_codes
 
-    def sync_secrets(self, providers: Optional[List[str or "Secret"]] = None):
+    def sync_secrets(
+        self,
+        providers: Optional[List[str or "Secret"]] = None,
+        env: Union[str, "Env"] = None,
+    ):
         """Send secrets for the given providers.
 
         Args:
@@ -1142,6 +1148,11 @@ class Cluster(Resource):
         """
         self.check_server()
         from runhouse.resources.secrets import Secret
+
+        if isinstance(env, str):
+            from runhouse.resources.envs import Env
+
+            env = Env.from_name(env)
 
         secrets = []
         if providers:
@@ -1156,7 +1167,7 @@ class Cluster(Resource):
             secrets = secrets.values()
 
         for secret in secrets:
-            secret.to(self)
+            secret.to(self, env=env)
 
     def ipython(self):
         # TODO tunnel into python interpreter in cluster

--- a/runhouse/resources/secrets/provider_secrets/anthropic_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/anthropic_secret.py
@@ -9,7 +9,7 @@ class AnthropicSecret(ApiKeySecret):
     """
 
     _PROVIDER = "anthropic"
-    _DEFAULT_ENV_VARS = {"api_key": "ANTHRHOPIC_API_KEY"}
+    _DEFAULT_ENV_VARS = {"api_key": "ANTHROPIC_API_KEY"}
 
     @staticmethod
     def from_config(config: dict, dryrun: bool = False):

--- a/runhouse/resources/secrets/provider_secrets/aws_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/aws_secret.py
@@ -33,9 +33,8 @@ class AWSSecret(ProviderSecret):
     ):
         new_secret = copy.deepcopy(self)
 
-        full_path = os.path.expanduser(path) if not isinstance(path, File) else path
         if not _check_file_for_mismatches(
-            full_path, self._from_path(full_path), values, overwrite
+            path, self._from_path(path), values, overwrite
         ):
 
             parser = configparser.ConfigParser()
@@ -60,10 +59,11 @@ class AWSSecret(ProviderSecret):
                     data = ss.read()
                 path.write(data, serialize=False, mode="w")
             else:
+                full_path = os.path.expanduser(path)
                 Path(full_path).parent.mkdir(parents=True, exist_ok=True)
                 with open(full_path, "w+") as f:
                     parser.write(f)
-                new_secret._add_to_rh_config(full_path)
+                new_secret._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/azure_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/azure_secret.py
@@ -33,7 +33,6 @@ class AzureSecret(ProviderSecret):
         overwrite: bool = False,
     ):
         new_secret = copy.deepcopy(self)
-        path = os.path.expanduser(path) if not isinstance(path, File) else path
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
         ):
@@ -55,8 +54,9 @@ class AzureSecret(ProviderSecret):
                     data = ss.read()
                 path.write(data, serialize=False, mode="w")
             else:
-                Path(path).parent.mkdir(parents=True, exist_ok=True)
-                with open(path, "w") as f:
+                full_path = os.path.expanduser(path)
+                Path(full_path).parent.mkdir(parents=True, exist_ok=True)
+                with open(full_path, "w") as f:
                     parser.write(f)
                 new_secret._add_to_rh_config(path)
 

--- a/runhouse/resources/secrets/provider_secrets/gcp_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/gcp_secret.py
@@ -32,7 +32,6 @@ class GCPSecret(ProviderSecret):
         self, path: Union[str, File], values: Dict = None, overwrite: bool = False
     ):
         new_secret = copy.deepcopy(self)
-        path = os.path.expanduser(path) if not isinstance(path, File) else path
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
         ):

--- a/runhouse/resources/secrets/provider_secrets/github_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/github_secret.py
@@ -29,7 +29,6 @@ class GitHubSecret(ProviderSecret):
         self, path: Union[str, File], values: Dict = None, overwrite: bool = False
     ):
         new_secret = copy.deepcopy(self)
-        path = os.path.expanduser(path) if not isinstance(path, File) else path
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
         ):
@@ -41,13 +40,14 @@ class GitHubSecret(ProviderSecret):
                 data = yaml.dump(config, default_flow_style=False)
                 path.write(data, serialize=False, mode="w")
             else:
-                if Path(path).exists():
-                    with open(path, "r") as stream:
+                full_path = os.path.expanduser(path)
+                if Path(full_path).exists():
+                    with open(full_path, "r") as stream:
                         config = yaml.safe_load(stream)
                 config["github.com"] = values
 
-                Path(path).parent.mkdir(parents=True, exist_ok=True)
-                with open(path, "w") as yaml_file:
+                Path(full_path).parent.mkdir(parents=True, exist_ok=True)
+                with open(full_path, "w") as yaml_file:
                     yaml.dump(config, yaml_file, default_flow_style=False)
                 new_secret._add_to_rh_config(path)
 

--- a/runhouse/resources/secrets/provider_secrets/huggingface_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/huggingface_secret.py
@@ -29,7 +29,6 @@ class HuggingFaceSecret(ProviderSecret):
         self, path: Union[str, File], values: Dict = None, overwrite: bool = False
     ):
         new_secret = copy.deepcopy(self)
-        path = os.path.expanduser(path) if not isinstance(path, File) else path
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
         ):
@@ -37,8 +36,9 @@ class HuggingFaceSecret(ProviderSecret):
             if isinstance(path, File):
                 path.write(token, serialize=False, mode="w")
             else:
-                Path(path).parent.mkdir(parents=True, exist_ok=True)
-                with open(path, "a") as f:
+                full_path = os.path.expanduser(path)
+                Path(full_path).parent.mkdir(parents=True, exist_ok=True)
+                with open(full_path, "a") as f:
                     f.write(token)
                 new_secret._add_to_rh_config(path)
 

--- a/runhouse/resources/secrets/provider_secrets/lambda_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/lambda_secret.py
@@ -28,7 +28,6 @@ class LambdaSecret(ProviderSecret):
         self, path: Union[str, File], values: Dict = None, overwrite: bool = False
     ):
         new_secret = copy.deepcopy(self)
-        path = os.path.expanduser(path) if not isinstance(path, File) else path
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
         ):
@@ -36,8 +35,9 @@ class LambdaSecret(ProviderSecret):
             if isinstance(path, File):
                 path.write(data, serialize=False, mode="w")
             else:
-                Path(path).parent.mkdir(parents=True, exist_ok=True)
-                with open(path, "w+") as f:
+                full_path = os.path.expanduser(path)
+                Path(full_path).parent.mkdir(parents=True, exist_ok=True)
+                with open(full_path, "w+") as f:
                     f.write(data)
                 new_secret._add_to_rh_config(path)
 

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -83,7 +83,7 @@ class ProviderSecret(Secret):
         self, name: str = None, save_values: bool = True, headers: Optional[Dict] = None
     ):
         name = name or self.name or self.provider
-        super().save(name=name, save_values=save_values, headers=headers)
+        return super().save(name=name, save_values=save_values, headers=headers)
 
     def delete(self, headers: Optional[Dict] = None, contents: bool = False):
         """Delete the secret config from Den and from Vault/local. Optionally also delete contents of secret file
@@ -190,13 +190,10 @@ class ProviderSecret(Secret):
         path: Union[str, File] = None,
         values: Any = None,
     ):
-        if self.path:
-            if isinstance(path, File):
-                path = path.path
-            remote_file = file(path=self.path).to(system, path=path)
-        else:
-            system.call(key, "_write_to_file", path=path, values=values)
-            remote_file = file(path=path, system=system)
+        if isinstance(path, File):
+            path = path.path
+        system.call(key, "_write_to_file", path=path, values=values)
+        remote_file = file(path=path, system=system)
         return remote_file
 
     def _write_to_file(

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -218,9 +218,14 @@ class ProviderSecret(Secret):
 
     def _write_to_env(self, env_vars: Dict, values: Any, overwrite: bool):
         existing_keys = dict(os.environ).keys()
+        added_keys = []
         for key in env_vars.keys():
             if env_vars[key] not in existing_keys or overwrite:
                 os.environ[env_vars[key]] = values[key]
+                added_keys.append(env_vars[key])
+
+        if added_keys:
+            self._add_to_rh_config(added_keys)
 
         new_secret = copy.deepcopy(self)
         new_secret._values = None
@@ -263,7 +268,7 @@ class ProviderSecret(Secret):
                     return contents
         return {}
 
-    def _add_to_rh_config(self, path):
+    def _add_to_rh_config(self, val):
         if not self.name:
             self.name = self.provider
-        configs.set_nested(key="secrets", value={self.name: path})
+        configs.set_nested(key="secrets", value={self.name: val})

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -228,18 +228,17 @@ class ProviderSecret(Secret):
         return new_secret
 
     def _from_env(self, env_vars: Dict = None):
+        env_vars = env_vars or self.env_vars
         if not env_vars:
             return {}
 
         values = {}
-        keys = self.env_vars.keys() if self.env_vars else {}
-        env_vars = env_vars or self.env_vars or {key: key for key in keys}
 
-        if not keys:
-            return {}
-
-        for key in keys:
-            values[key] = os.environ[env_vars[key]]
+        for key in env_vars.keys():
+            try:
+                values[key] = os.environ[env_vars[key]]
+            except KeyError:
+                return {}
         return values
 
     def _from_path(self, path: Union[str, File] = None):

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -104,10 +104,10 @@ class ProviderSecret(Secret):
 
     def write(
         self,
-        file: bool = False,
-        env: bool = False,
         path: Union[str, File] = None,
         env_vars: Dict = None,
+        file: bool = False,
+        env: bool = False,
         overwrite: bool = False,
     ):
         if not self.values:
@@ -213,7 +213,7 @@ class ProviderSecret(Secret):
                 os.makedirs(os.path.dirname(full_path), exist_ok=True)
                 with open(full_path, "w") as f:
                     json.dump(values, f, indent=4)
-                self._add_to_rh_config(full_path)
+                self._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/secret.py
+++ b/runhouse/resources/secrets/secret.py
@@ -75,16 +75,18 @@ class Secret(Resource):
         """Load existing Secret via its name."""
         try:
             config = load_config(name, cls.USER_ENDPOINT)
-            return cls.from_config(config=config, dryrun=dryrun)
+            if config:
+                return cls.from_config(config=config, dryrun=dryrun)
         except ValueError:
-            if name in cls.builtin_providers(as_str=True):
-                from runhouse.resources.secrets.provider_secrets.providers import (
-                    _get_provider_class,
-                )
+            pass
+        if name in cls.builtin_providers(as_str=True):
+            from runhouse.resources.secrets.provider_secrets.providers import (
+                _get_provider_class,
+            )
 
-                provider_class = _get_provider_class(name)
-                return provider_class(provider=name, dryrun=dryrun)
-            raise ValueError(f"Could not locate secret {name}")
+            provider_class = _get_provider_class(name)
+            return provider_class(provider=name, dryrun=dryrun)
+        raise ValueError(f"Could not locate secret {name}")
 
     @classmethod
     def builtin_providers(cls, as_str: bool = False) -> list:

--- a/runhouse/rns/login.py
+++ b/runhouse/rns/login.py
@@ -150,11 +150,19 @@ def _login_download_secrets(headers: Optional[str] = None):
     for name in secrets:
         try:
             secret = Secret.from_name(name)
-            if hasattr(secret, "path"):
-                download_path = secret.path or secret._DEFAULT_CREDENTIALS_PATH
-                if download_path:
-                    logger.info(f"Loading down secrets for {name} into {download_path}")
-                    secret.write()
+            if not (hasattr(secret, "path") or hasattr(secret, "env_vars")):
+                continue
+
+            download_path = secret.path or secret._DEFAULT_CREDENTIALS_PATH
+            if download_path and not secret.env_vars:
+                logger.info(f"Loading down secrets for {name} into {download_path}")
+                secret.write(path=download_path)
+            else:
+                env_vars = secret.env_vars or secret._DEFAULT_ENV_VARS
+                logger.info(
+                    f"Writing down env secrets for {name} into {env_vars.values()}"
+                )
+                secret.write(env=True)
         except ValueError as e:
             logger.warning(
                 f"Encountered {e}. Was not able to load down secrets for {name}."
@@ -246,7 +254,7 @@ def logout(
     )
 
     config_secrets = list(configs.get("secrets", {}).items())
-    for (name, path) in config_secrets:
+    for (name, value) in config_secrets:
         try:
             secret = Secret.from_name(name)
 
@@ -262,13 +270,17 @@ def logout(
 
         if interactive_session:
             delete_loaded_secrets = typer.confirm(
-                f"Delete credentials file {path} for {name}?"
+                f"Delete credentials in {value} for {name}?"
             )
 
         if delete_loaded_secrets:
-            path = os.path.expanduser(path)
-            if os.path.exists(path):
-                os.remove(path)
+            if isinstance(value, str):
+                path = os.path.expanduser(value)
+                if os.path.exists(path):
+                    os.remove(path)
+            else:  # list of env variables set
+                for key in value:
+                    del os.environ[key]
 
         configs.delete_provider(name)
 

--- a/runhouse/rns/login.py
+++ b/runhouse/rns/login.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Dict, List, Optional
 
 import requests
@@ -149,11 +150,11 @@ def _login_download_secrets(headers: Optional[str] = None):
     for name in secrets:
         try:
             secret = Secret.from_name(name)
-
-            download_path = secret.path or secret._DEFAULT_CREDENTIALS_PATH
-            if download_path:
-                logger.info(f"Loading down secrets for {name} into {download_path}")
-                secret.write()
+            if hasattr(secret, "path"):
+                download_path = secret.path or secret._DEFAULT_CREDENTIALS_PATH
+                if download_path:
+                    logger.info(f"Loading down secrets for {name} into {download_path}")
+                    secret.write()
         except ValueError as e:
             logger.warning(
                 f"Encountered {e}. Was not able to load down secrets for {name}."
@@ -244,32 +245,32 @@ def logout(
         interactive if interactive is not None else is_interactive()
     )
 
-    local_secret_names = list(configs.get("secrets", {}).keys())
-    for name in local_secret_names:
+    config_secrets = list(configs.get("secrets", {}).items())
+    for (name, path) in config_secrets:
         try:
             secret = Secret.from_name(name)
-        except ValueError:
-            configs.delete_provider(name)
-            continue
 
-        if isinstance(secret, SSHSecret):
-            logger.info(
-                "Automatic deletion for local SSH credentials file is not supported. "
-                "Please manually delete it if you would like to remove it"
-            )
-            continue
+            if isinstance(secret, SSHSecret):
+                logger.info(
+                    "Automatic deletion for local SSH credentials file is not supported. "
+                    "Please manually delete it if you would like to remove it"
+                )
+                configs.delete_provider(name)
+                continue
+        except ValueError:
+            pass
 
         if interactive_session:
             delete_loaded_secrets = typer.confirm(
-                f"Delete credentials file for {name}?"
+                f"Delete credentials file {path} for {name}?"
             )
 
-        if secret.in_vault() or secret.in_local():
-            if delete_loaded_secrets:
-                secret.delete(contents=True)
-            else:
-                secret.delete()
-                configs.delete_provider(name)
+        if delete_loaded_secrets:
+            path = os.path.expanduser(path)
+            if os.path.exists(path):
+                os.remove(path)
+
+        configs.delete_provider(name)
 
     local_secrets = Secret.local_secrets()
     for _, secret in local_secrets.items():

--- a/runhouse/rns/login.py
+++ b/runhouse/rns/login.py
@@ -25,7 +25,7 @@ def login(
     upload_secrets: bool = None,
     ret_token: bool = False,
     interactive: bool = None,
-    from_app: bool = False,
+    from_cli: bool = False,
 ):
     """Login to Runhouse. Validates token provided, with options to upload or download stored secrets or config between
     local environment and Runhouse / Vault.
@@ -135,7 +135,7 @@ def login(
 
     if download_secrets:
         _convert_secrets_resource()
-        _login_download_secrets(from_app=from_app)
+        _login_download_secrets(from_cli=from_cli)
     if upload_secrets:
         _login_upload_secrets(interactive=interactive)
 
@@ -144,7 +144,7 @@ def login(
         return token
 
 
-def _login_download_secrets(headers: Optional[str] = None, from_app=False):
+def _login_download_secrets(headers: Optional[str] = None, from_cli=False):
     from runhouse import Secret
 
     secrets = Secret.vault_secrets(headers=headers or rns_client.request_headers)
@@ -164,7 +164,7 @@ def _login_download_secrets(headers: Optional[str] = None, from_app=False):
                 logger.info(
                     f"Writing down env secrets for {name} into {env_vars.values()}"
                 )
-                if not from_app:
+                if not from_cli:
                     secret.write(env=True)
                 else:
                     for key, val in secret.values.items():
@@ -176,7 +176,7 @@ def _login_download_secrets(headers: Optional[str] = None, from_app=False):
                 f"Encountered {e}. Was not able to load down secrets for {name}."
             )
 
-    if from_app and env_secrets:
+    if from_cli and env_secrets:
         folder = os.path.expanduser("~/.rh/secrets")
         os.makedirs(folder, exist_ok=True)
         with open(f"{folder}/login.env", "w") as f:

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -208,9 +208,11 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
         api_key_secret = rh.provider_secret(
             "openai", values={"api_key": "test_openai_key"}
         )
-        named_secret = rh.provider_secret(
-            "huggingface", values={"token": "test_hf_token"}
-        ).write(path="~/hf_token")
+        named_secret = (
+            rh.provider_secret("huggingface", values={"token": "test_hf_token"})
+            .write(path="~/hf_token")
+            .save()
+        )
         secrets = [path_secret, api_key_secret, named_secret.provider]
 
         env.secrets = secrets
@@ -227,3 +229,5 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
                 env_vars = secret.env_vars or secret._DEFAULT_ENV_VARS
                 for _, var in env_vars.items():
                     assert get_env_var_cpu(var)
+
+        named_secret.delete()

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -43,8 +43,14 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
         ]
     }
     LOCAL = {
-        "env": ["base_env", "base_conda_env", "conda_env_from_dict"],
-        # TODO: add local clusters once conda docker container is set up
+        "env": ["base_env"],
+        "cluster": [
+            "local_docker_cluster_public_key_logged_in",
+            "local_docker_cluster_public_key_logged_out",
+            "local_docker_cluster_passwd",
+        ]
+        # TODO: extend envs to "base_conda_env", "conda_env_from_dict"],
+        # and add local clusters once conda docker container is set up
     }
     MINIMAL = {
         "env": ["base_env", "base_conda_env"],
@@ -200,7 +206,7 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
 
         _uninstall_env(env, cluster)
 
-    @pytest.mark.level("minimal")
+    @pytest.mark.level("local")
     def test_secrets_env(self, env, cluster):
         path_secret = rh.provider_secret(
             "lambda", values={"api_key": "test_api_key"}


### PR DESCRIPTION
* add secrets field into env, these secrets are sent to env/cluster alongside env.to or fn.to(env) calls
* add env field to cluster.sync_secrets/add_secrets
* load down env vars into env for login. write down env vars written down through runhouse
* some small bug fixes with paths and loading from name