### PR TITLE
Support unlisted and public visiblity module calls

### DIFF
--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -883,6 +883,14 @@ class Module(Resource):
                         self.system.put_resource(self)
         return super().save(overwrite=overwrite)
 
+    def share(self, *args, global_visibility=None, **kwargs):
+        if global_visibility and not global_visibility == self.visibility:
+            self.visibility = global_visibility
+            self.remote.visibility = (
+                global_visibility  # Sets the visibility on the remote resource
+            )
+        super().share(*args, **kwargs, global_visibility=global_visibility)
+
     @staticmethod
     def _extract_module_path(raw_cls_or_fn: Union[Type, Callable]):
         py_module = inspect.getmodule(raw_cls_or_fn)

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -11,7 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 class Message(BaseModel):
-    data: str = None
+    data: Any = None
+    serialization: str = None
     env: str = None
     key: Optional[str] = None
     stream_logs: Optional[bool] = True


### PR DESCRIPTION
- Hack http_server to accept get requests for calling modules so we can call from a browser
- Hack http_server to accept json serialization and query params as inputs
- Change module and function's share to change the visibility of the remote resource
- Change cluster auth to allow calling without a token if module visibility allows
- Change call_module_method in the servlet to only allow unpickling if already authenticated