### PR TITLE
Bugfixes, LOCAL passing

### DIFF
--- a/runhouse/resources/functions/function.py
+++ b/runhouse/resources/functions/function.py
@@ -56,7 +56,7 @@ class Function(Module):
             super().remote.visibility = (
                 visibility  # do this to avoid hitting Function's .remote
             )
-        super().share(*args, **kwargs, visibility=visibility)
+        return super().share(*args, **kwargs, visibility=visibility)
 
     def to(
         self,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -889,7 +889,7 @@ class Module(Resource):
             self.remote.visibility = (
                 visibility  # Sets the visibility on the remote resource
             )
-        super().share(*args, **kwargs, visibility=visibility)
+        return super().share(*args, **kwargs, visibility=visibility)
 
     @staticmethod
     def _extract_module_path(raw_cls_or_fn: Union[Type, Callable]):

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -584,7 +584,8 @@ class HTTPServer:
         # Stream the logs and result (e.g. if it's a generator)
         HTTPServer.register_activity()
         try:
-            kwargs = request.query_params
+            kwargs = dict(request.query_params)
+            kwargs.pop("serialization", None)
             method = None if method == "None" else method
             message = Message(stream_logs=True, data=kwargs)
             env = HTTPServer.lookup_env_for_name(module)
@@ -660,7 +661,8 @@ class HTTPServer:
     ):
         kwargs = args.get("kwargs", {})
         args = args.get("args", [])
-        query_params = request.query_params
+        query_params = dict(request.query_params)
+        query_params.pop("serialization", None)
         if query_params:
             kwargs.update(query_params)
         token = get_token_from_request(request)


### PR DESCRIPTION
- Fix the way we accept query params in the http_server /call methods so serialization doesn't get passed as a kwarg
- Add missing return to module and function .share
- Fix function sharing tests