### PR TITLE
Fix streaming with HTTP/HTTPS/Nginx

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -107,7 +107,7 @@ def _start_server(
     den_auth=False,
     ssl_keyfile=None,
     ssl_certfile=None,
-    force_reinstall=False,
+    restart_proxy=False,
     use_nginx=False,
     certs_address=None,
     use_local_telemetry=False,
@@ -125,7 +125,7 @@ def _start_server(
         den_auth=den_auth,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
-        force_reinstall=force_reinstall,
+        restart_proxy=restart_proxy,
         use_nginx=use_nginx,
         certs_address=certs_address,
         use_local_telemetry=use_local_telemetry,
@@ -248,7 +248,7 @@ def restart(
     ssl_certfile: Optional[str] = typer.Option(
         None, help="Path to custom SSL cert file to use for enabling HTTPS"
     ),
-    force_reinstall: bool = typer.Option(
+    restart_proxy: bool = typer.Option(
         False, help="Whether to reinstall Nginx and other server configs on the cluster"
     ),
     use_nginx: bool = typer.Option(
@@ -282,7 +282,7 @@ def restart(
         den_auth=use_den_auth,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
-        force_reinstall=force_reinstall,
+        restart_proxy=restart_proxy,
         use_nginx=use_nginx,
         certs_address=certs_address,
         use_local_telemetry=use_local_telemetry,

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -651,7 +651,7 @@ class Cluster(Resource):
         den_auth,
         ssl_keyfile,
         ssl_certfile,
-        force_reinstall,
+        restart_proxy,
         use_nginx,
         certs_address,
         use_local_telemetry,
@@ -674,10 +674,10 @@ class Cluster(Resource):
             logger.info("Starting server with Den auth.")
             flags.append(den_auth_flag)
 
-        force_reinstall_flag = " --force-reinstall" if force_reinstall else ""
-        if force_reinstall_flag:
+        restart_proxy_flag = " --restart-proxy" if restart_proxy else ""
+        if restart_proxy_flag:
             logger.info("Reinstalling Nginx and server configs.")
-            flags.append(force_reinstall_flag)
+            flags.append(restart_proxy_flag)
 
         use_nginx_flag = " --use-nginx" if use_nginx else ""
         if use_nginx_flag:

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -240,7 +240,16 @@ class HTTPClient:
         # maybe a stream of results), so we need to separate these out.
         non_generator_result = None
         res_iter = res.iter_lines(chunk_size=None)
-        for responses_json in res_iter:
+        # We need to manually iterate through res_iter so we can try/except to bypass a ChunkedEncodingError bug
+        while True:
+            try:
+                responses_json = next(res_iter)
+            except requests.exceptions.ChunkedEncodingError:
+                # Some silly bug in urllib3, see https://github.com/psf/requests/issues/4248
+                continue
+            except StopIteration:
+                break
+
             resp = json.loads(responses_json)
             output_type = resp["output_type"]
             result = handle_response(resp, output_type, error_str)

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -2,7 +2,7 @@ import codecs
 import logging
 import re
 import sys
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 from ray import cloudpickle as pickle
@@ -27,9 +27,9 @@ class Args(BaseModel):
 
 
 class Response(BaseModel):
-    data: Union[None, str, List[str], Dict]
-    error: Optional[str]
-    traceback: Optional[str]
+    data: Any = None
+    error: Optional[str] = None
+    traceback: Optional[str] = None
     output_type: str
 
 

--- a/runhouse/servers/nginx/config.py
+++ b/runhouse/servers/nginx/config.py
@@ -104,10 +104,8 @@ class NginxConfig:
             server_name {server_name};
 
             location / {{
+                proxy_buffering off;
                 proxy_pass {proxy_pass};
-                proxy_buffer_size 128k;
-                proxy_buffers 4 256k;
-                proxy_busy_buffers_size 256k;
             }}
         }}
         """
@@ -134,10 +132,8 @@ class NginxConfig:
             ssl_certificate_key {ssl_key_path};
 
             location / {{
+                proxy_buffering off;
                 proxy_pass {proxy_pass};
-                proxy_buffer_size 128k;
-                proxy_buffers 4 256k;
-                proxy_busy_buffers_size 256k;
             }}
         }}
         """

--- a/tests/test_servers/test_nginx.py
+++ b/tests/test_servers/test_nginx.py
@@ -332,10 +332,8 @@ class TestNginxConfiguration:
                 server_name {config.address};
 
                 location / {{
+                    proxy_buffering off;
                     proxy_pass http://127.0.0.1:{config.rh_server_port}/;
-                    proxy_buffer_size 128k;
-                    proxy_buffers 4 256k;
-                    proxy_busy_buffers_size 256k;
                 }}
             }}
             """
@@ -401,10 +399,8 @@ class TestNginxConfiguration:
                 ssl_certificate_key {config.ssl_key_path};
 
                 location / {{
+                    proxy_buffering off;
                     proxy_pass http://127.0.0.1:{config.rh_server_port}/;
-                    proxy_buffer_size 128k;
-                    proxy_buffers 4 256k;
-                    proxy_busy_buffers_size 256k;
                 }}
             }}
             """


### PR DESCRIPTION
Nginx's proxy buffers were holding back the stream of results before returning them to the client, so this turns it off. Also fixes a few other small bugs.