### PR TITLE
Improving cluster fixtures once more to be speedy and cover use cases.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -35,7 +35,7 @@ pytest -s -v --level "unit" tests/test_resources/test_resource.py::TestResource:
 
 To run tests across multiple suites but only including a specific fixture, you can do:
 ```bash
-pytest -s -v --level "local" -k "local_docker_cluster_public_key" tests
+pytest -s -v --level "local" -k "local_docker_cluster_pk_ssh_no_auth" tests
 ```
 Make sure the fixture(s) of interest are included in the level you're running at, or they won't natch with any tests.
 You can also exclude fixtures with "-m" and a tilde, e.g. "-m ~local_docker_cluster_public_key".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,10 +28,10 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     UNIT = {"cluster": ["named_cluster"]}
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_public_key_logged_in",
-            "local_docker_cluster_public_key_logged_out",
-            "local_docker_cluster_telemetry_public_key",
-            "local_docker_cluster_passwd",
+            "local_docker_cluster_pk_ssh_no_auth",
+            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pk_ssh_telemetry",
+            "local_docker_cluster_pwd_ssh_no_auth",
         ]
     }
     MINIMAL = {"cluster": ["static_cpu_cluster"]}
@@ -152,15 +152,15 @@ from tests.fixtures.local_docker_cluster_fixtures import (
     build_and_run_image,  # noqa: F401
     byo_cpu,  # noqa: F401
     cluster,  # noqa: F401
-    local_docker_cluster_passwd,  # noqa: F401
-    local_docker_cluster_public_key,  # noqa: F401
-    local_docker_cluster_public_key_den_auth,  # noqa: F401
-    local_docker_cluster_public_key_logged_in,  # noqa: F401
-    local_docker_cluster_public_key_logged_out,  # noqa: F401
-    local_docker_cluster_telemetry_public_key,  # noqa: F401
-    local_docker_cluster_with_nginx_http,  # noqa: F401
-    local_docker_cluster_with_nginx_https,  # noqa: F401
-    local_test_account_cluster_public_key,  # noqa: F401
+    local_docker_cluster_pk_http_exposed,  # noqa: F401
+    local_docker_cluster_pk_ssh,  # noqa: F401
+    local_docker_cluster_pk_ssh_den_auth,  # noqa: F401
+    local_docker_cluster_pk_ssh_no_auth,  # noqa: F401
+    local_docker_cluster_pk_ssh_telemetry,  # noqa: F401
+    local_docker_cluster_pk_ssh_test_account_logged_in,  # noqa: F401
+    local_docker_cluster_pk_tls_den_auth,  # noqa: F401
+    local_docker_cluster_pk_tls_exposed,  # noqa: F401
+    local_docker_cluster_pwd_ssh_no_auth,  # noqa: F401
     named_cluster,  # noqa: F401
     password_cluster,  # noqa: F401
     shared_cluster,  # noqa: F401
@@ -280,17 +280,16 @@ default_fixtures[TestLevels.UNIT] = {
 }
 default_fixtures[TestLevels.LOCAL] = {
     "cluster": [
-        "local_docker_cluster_public_key_logged_in",
-        "local_docker_cluster_public_key_logged_out",
-        "local_docker_cluster_passwd",
+        "local_docker_cluster_pk_ssh_no_auth",
+        "local_docker_cluster_pk_ssh_den_auth",
     ]
 }
 default_fixtures[TestLevels.MINIMAL] = {"cluster": ["ondemand_cpu_cluster"]}
 default_fixtures[TestLevels.THOROUGH] = {
     "cluster": [
-        "local_docker_cluster_passwd",
-        "local_docker_cluster_public_key_logged_in",
-        "local_docker_cluster_public_key_logged_out",
+        "local_docker_cluster_pk_ssh_no_auth",
+        "local_docker_cluster_pk_ssh_den_auth",
+        "local_docker_cluster_pwd_ssh_no_auth",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",
@@ -299,10 +298,10 @@ default_fixtures[TestLevels.THOROUGH] = {
 }
 default_fixtures[TestLevels.MAXIMAL] = {
     "cluster": [
-        "local_docker_cluster_passwd",
-        "local_docker_cluster_public_key_logged_in",
-        "local_docker_cluster_public_key_logged_out",
-        "local_docker_cluster_telemetry_public_key",
+        "local_docker_cluster_pk_ssh_no_auth",
+        "local_docker_cluster_pk_ssh_den_auth",
+        "local_docker_cluster_pwd_ssh_no_auth",
+        "local_docker_cluster_pk_ssh_telemetry",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",

--- a/tests/fixtures/local_docker_cluster_fixtures.py
+++ b/tests/fixtures/local_docker_cluster_fixtures.py
@@ -1,3 +1,4 @@
+import logging
 import pkgutil
 import shlex
 import time
@@ -156,7 +157,7 @@ def password_cluster():
 def build_and_run_image(
     image_name: str,
     container_name: str,
-    detached: bool,
+    reuse_existing_container: bool,
     dir_name: str,
     pwd_file=None,
     keypath=None,
@@ -183,70 +184,79 @@ def build_and_run_image(
             "name": container_name,
         },
     )
-    if len(containers) > 0 and detached:
-        print(f"Container {container_name} already running, skipping build and run.")
-    else:
-        # Check if image has already been built before re-building
-        images = client.images.list(filters={"reference": f"runhouse:{image_name}"})
-        if not images or force_rebuild:
-            # Build the SSH public key based Docker image
-            if keypath:
-                build_cmd = [
-                    "docker",
-                    "build",
-                    "--pull",
-                    "--rm",
-                    "-f",
-                    str(dockerfile_path),
-                    "--build-arg",
-                    f"RUNHOUSE_PATH={rh_path}"
-                    if rh_path
-                    else f"RUNHOUSE_VERSION={rh_version}",
-                    "--secret",
-                    f"id=ssh_key,src={keypath}.pub",
-                    "-t",
-                    f"runhouse:{image_name}",
-                    ".",
-                ]
-            elif pwd_file:
-                # Build a password file based Docker image
-                build_cmd = [
-                    "docker",
-                    "build",
-                    "--pull",
-                    "--rm",
-                    "-f",
-                    str(dockerfile_path),
-                    "--build-arg",
-                    f"DOCKER_USER_PASSWORD_FILE={pwd_file}",
-                    "--build-arg",
-                    f"RUNHOUSE_PATH={rh_path}"
-                    if rh_path
-                    else f"RUNHOUSE_VERSION={rh_version}",
-                    "-t",
-                    f"runhouse:{image_name}",
-                    ".",
-                ]
-            else:
-                raise ValueError("No keypath or password file path provided")
+    if len(containers) > 0:
+        if not reuse_existing_container:
+            raise ValueError(
+                f"Container {container_name} already running, but reuse_existing_container=False"
+            )
+        else:
+            logging.info(
+                f"Container {container_name} already running, skipping build and run."
+            )
+            return client
 
-            print(shlex.join(build_cmd))
-            run_shell_command(subprocess, build_cmd, cwd=str(rh_parent_path.parent))
+    # The container is not running, so we need to build and run it
+    # Check if image has already been built before re-building
+    images = client.images.list(filters={"reference": f"runhouse:{image_name}"})
+    if not images or force_rebuild:
+        # Build the SSH public key based Docker image
+        if keypath:
+            build_cmd = [
+                "docker",
+                "build",
+                "--pull",
+                "--rm",
+                "-f",
+                str(dockerfile_path),
+                "--build-arg",
+                f"RUNHOUSE_PATH={rh_path}"
+                if rh_path
+                else f"RUNHOUSE_VERSION={rh_version}",
+                "--secret",
+                f"id=ssh_key,src={keypath}.pub",
+                "-t",
+                f"runhouse:{image_name}",
+                ".",
+            ]
+        elif pwd_file:
+            # Build a password file based Docker image
+            build_cmd = [
+                "docker",
+                "build",
+                "--pull",
+                "--rm",
+                "-f",
+                str(dockerfile_path),
+                "--build-arg",
+                f"DOCKER_USER_PASSWORD_FILE={pwd_file}",
+                "--build-arg",
+                f"RUNHOUSE_PATH={rh_path}"
+                if rh_path
+                else f"RUNHOUSE_VERSION={rh_version}",
+                "-t",
+                f"runhouse:{image_name}",
+                ".",
+            ]
+        else:
+            raise ValueError("No keypath or password file path provided")
 
-        # Run the Docker image
-        port_fwds = (
-            "".join([f"-p {port_fwd} " for port_fwd in port_fwds]).strip().split(" ")
-        )
-        run_cmd = (
-            ["docker", "run", "--name", container_name, "-d", "--rm", "--shm-size=4gb"]
-            + port_fwds
-            + [f"runhouse:{image_name}"]
-        )
-        print(shlex.join(run_cmd))
-        res = popen_shell_command(subprocess, run_cmd, cwd=str(rh_parent_path.parent))
-        stdout, stderr = res.communicate()
-        if res.returncode != 0:
-            raise RuntimeError(f"Failed to run docker image {image_name}: {stderr}")
+        print(shlex.join(build_cmd))
+        run_shell_command(subprocess, build_cmd, cwd=str(rh_parent_path.parent))
+
+    # Run the Docker image
+    port_fwds = (
+        "".join([f"-p {port_fwd} " for port_fwd in port_fwds]).strip().split(" ")
+    )
+    run_cmd = (
+        ["docker", "run", "--name", container_name, "-d", "--rm", "--shm-size=4gb"]
+        + port_fwds
+        + [f"runhouse:{image_name}"]
+    )
+    print(shlex.join(run_cmd))
+    res = popen_shell_command(subprocess, run_cmd, cwd=str(rh_parent_path.parent))
+    stdout, stderr = res.communicate()
+    if res.returncode != 0:
+        raise RuntimeError(f"Failed to run docker image {image_name}: {stderr}")
 
     return client
 
@@ -292,11 +302,12 @@ def set_up_local_cluster(
     image_name: str,
     container_name: str,
     dir_name: str,
-    detached: bool,
+    reuse_existing_container: bool,
     force_rebuild: bool,
     port_fwds: List[str],
     local_ssh_port: int,
     additional_cluster_init_args: Dict[str, Any],
+    logged_in: bool = False,
     keypath: str = None,
     pwd_file: str = None,
 ):
@@ -304,7 +315,7 @@ def set_up_local_cluster(
         image_name=image_name,
         container_name=container_name,
         dir_name=dir_name,
-        detached=detached,
+        reuse_existing_container=reuse_existing_container,
         keypath=keypath,
         pwd_file=pwd_file,
         force_rebuild=force_rebuild,
@@ -315,7 +326,6 @@ def set_up_local_cluster(
         host="localhost",
         server_host="0.0.0.0",
         ssh_port=local_ssh_port,
-        server_connection_type="ssh",
         ssh_creds={
             "ssh_user": SSH_USER,
             "ssh_private_key": keypath,
@@ -334,253 +344,331 @@ def set_up_local_cluster(
         setup_cmds=[
             f"mkdir -p ~/.rh; touch ~/.rh/config.yaml; "
             f"echo '{yaml.safe_dump(rh.configs.defaults_cache)}' > ~/.rh/config.yaml"
-        ],
+        ]
+        if logged_in
+        else False,
         name="base_env",
     ).to(rh_cluster)
 
     rh_cluster.save()
 
     def cleanup():
-        if not detached:
-            docker_client.containers.get(container_name).stop()
-            docker_client.containers.prune()
-            docker_client.images.prune()
+        docker_client.containers.get(container_name).stop()
+        docker_client.containers.prune()
+        docker_client.images.prune()
 
     return rh_cluster, cleanup
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_public_key(request):
+def local_docker_cluster_pk_tls_exposed(request):
+    """This basic cluster fixture is set up with:
+    - Public key authentication
+    - Nginx set up on startup to forward Runhouse HTTP server to port 443
+    """
+
+    # From pytest config
+    detached = request.config.getoption("--detached")
+    force_rebuild = request.config.getoption("--force-rebuild")
+
+    # Ports to use on the Docker VM such that they don't conflict
     local_ssh_port = BASE_LOCAL_SSH_PORT + 1
+    local_client_port = LOCAL_HTTPS_SERVER_PORT + 1
+
     local_cluster, cleanup = set_up_local_cluster(
         image_name="keypair",
-        container_name="rh-slim-public-key",
+        container_name="rh-pk-tls-port-fwd",
         dir_name="public-key-auth",
         keypath=str(
             Path(
                 rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
             ).expanduser()
         ),
-        detached=request.config.getoption("--detached"),
-        force_rebuild=request.config.getoption("--force-rebuild"),
-        port_fwds=[f"{local_ssh_port}:22"],
+        reuse_existing_container=detached,
+        force_rebuild=force_rebuild,
+        port_fwds=[f"{local_ssh_port}:22", f"{local_client_port}:443"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
-            "name": "local_docker_cluster_public_key",
-            "den_auth": "den_auth" in request.keywords,
+            "name": "local_docker_cluster_pk_tls_exposed",
+            "server_connection_type": "tls",
+            "server_port": 443,
+            "client_port": local_client_port,
+            "den_auth": True,
         },
     )
+
     # Yield the cluster
     yield local_cluster
 
-    # Stop the Docker container
-    cleanup()
+    # If we are running in detached mode, leave the container running, else clean it up
+    if not detached:
+        cleanup()
+
+
+@pytest.fixture(scope="session")
+def local_docker_cluster_pk_ssh(request):
+    """This basic cluster fixture is set up with:
+    - Public key authentication
+    - Nginx set up on startup to forward Runhouse HTTP server to port 443
+    """
+
+    # From pytest config
+    detached = request.config.getoption("--detached")
+    force_rebuild = request.config.getoption("--force-rebuild")
+
+    # Ports to use on the Docker VM such that they don't conflict
+    local_ssh_port = BASE_LOCAL_SSH_PORT + 2
+
+    local_cluster, cleanup = set_up_local_cluster(
+        image_name="keypair",
+        container_name="rh-pk-ssh",
+        dir_name="public-key-auth",
+        keypath=str(
+            Path(
+                rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
+            ).expanduser()
+        ),
+        reuse_existing_container=detached,
+        force_rebuild=force_rebuild,
+        port_fwds=[f"{local_ssh_port}:22"],
+        local_ssh_port=local_ssh_port,
+        additional_cluster_init_args={
+            "name": "local_docker_cluster_pk_ssh",
+            "server_connection_type": "ssh",
+        },
+    )
+
+    # Yield the cluster
+    yield local_cluster
+
+    # If we are running in detached mode, leave the container running, else clean it up
+    if not detached:
+        cleanup()
 
 
 # These two clusters cannot be used in the same test together, they are are technically
-# the same image, but we switch the log in.
+# the same image, but we switch the cluster parameters.
+# These depend on the base fixture above and swap out the cluster parameters as needed.
+@pytest.fixture(scope="function")
+def local_docker_cluster_pk_tls_den_auth(
+    local_docker_cluster_pk_tls_exposed,
+):
+    """This is one of our key use cases -- TLS + Den Auth set up.
+
+    We use the base fixture, which already has nginx set up to port forward
+    from 443 to 32300, and we set the cluster parameters to use the correct ports to communicate
+    with the server, in case they had been changed.
+    """
+    return local_docker_cluster_pk_tls_exposed
 
 
 @pytest.fixture(scope="function")
-def local_docker_cluster_public_key_logged_out(local_docker_cluster_public_key):
-    local_docker_cluster_public_key.run(
-        ["rm ~/.rh/config.yaml"],
-    )
-    local_docker_cluster_public_key.restart_server(resync_rh=False)
-    return local_docker_cluster_public_key
+def local_docker_cluster_pk_ssh_den_auth(
+    local_docker_cluster_pk_ssh,
+):
+    """This is our other key use case -- SSH with any Den Auth.
+
+    We use the base fixture, and ignore the nginx/https setup, instead just communicating with
+    the cluster using the base SSH credentials already present on the machine. We send a request
+    to enable den auth server side.
+    """
+    local_docker_cluster_pk_ssh.enable_den_auth()
+    return local_docker_cluster_pk_ssh
 
 
 @pytest.fixture(scope="function")
-def local_docker_cluster_public_key_logged_in(local_docker_cluster_public_key):
-    local_docker_cluster_public_key.run(
-        [
-            f"mkdir -p ~/.rh; touch ~/.rh/config.yaml; "
-            f'echo "{yaml.safe_dump(rh.configs.defaults_cache)}" > ~/.rh/config.yaml'
-        ],
-    )
-    local_docker_cluster_public_key.restart_server(resync_rh=False)
-    return local_docker_cluster_public_key
+def local_docker_cluster_pk_ssh_no_auth(
+    local_docker_cluster_pk_ssh,
+):
+    """This is our other key use case -- SSH without any Den Auth.
 
-
-@pytest.fixture(scope="function")
-def local_docker_cluster_public_key_den_auth(local_docker_cluster_public_key):
-    local_docker_cluster_public_key.run(
-        [
-            f"mkdir -p ~/.rh; touch ~/.rh/config.yaml; "
-            f'echo "{yaml.safe_dump(rh.configs.defaults_cache)}" > ~/.rh/config.yaml'
-        ],
-    )
-    local_docker_cluster_public_key.den_auth = True
-    local_docker_cluster_public_key.restart_server(resync_rh=False)
-    return local_docker_cluster_public_key
+    We use the base fixture, and ignore the nginx/https setup, instead just communicating with
+    the cluster using the base SSH credentials already present on the machine. We send a request
+    to disable den auth server side.
+    """
+    local_docker_cluster_pk_ssh.disable_den_auth()
+    return local_docker_cluster_pk_ssh
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_telemetry_public_key(request, detached=True):
-    local_ssh_port = BASE_LOCAL_SSH_PORT + 2
-    local_cluster, cleanup = set_up_local_cluster(
-        image_name="keypair-telemetry",
-        container_name="rh-slim-keypair-telemetry",
-        dir_name="public-key-auth",
-        keypath=str(
-            Path(
-                rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
-            ).expanduser()
-        ),
-        detached=request.config.getoption("--detached"),
-        force_rebuild=request.config.getoption("--force-rebuild"),
-        port_fwds=[f"{local_ssh_port}:22"],
-        local_ssh_port=local_ssh_port,
-        additional_cluster_init_args={
-            "name": "local_docker_cluster_telemetry_public_key",
-            "use_local_telemetry": True,
-            "den_auth": "den_auth" in request.keywords,
-        },
-    )
-    # Yield the cluster
-    yield local_cluster
+def local_docker_cluster_pk_http_exposed(request):
+    """This basic cluster fixture is set up with:
+    - Public key authentication
+    - Den auth enabled
+    - Nginx set up on startup to forward Runhouse HTTP Server to port 80
+    """
 
-    # Stop the Docker container
-    cleanup()
+    # From pytest config
+    detached = request.config.getoption("--detached")
+    force_rebuild = request.config.getoption("--force-rebuild")
 
-
-@pytest.fixture(scope="session")
-def local_docker_cluster_with_nginx_http(request):
+    # Ports to use on the Docker VM such that they don't conflict
     local_ssh_port = BASE_LOCAL_SSH_PORT + 3
-    client_port = LOCAL_HTTP_SERVER_PORT + 3
-    port_fwds = [f"{local_ssh_port}:22", f"{client_port}:80"]
+    local_client_port = LOCAL_HTTP_SERVER_PORT + 3
 
     local_cluster, cleanup = set_up_local_cluster(
         image_name="keypair",
-        container_name="rh-slim-http-nginx",
+        container_name="rh-pk-http-port-fwd",
         dir_name="public-key-auth",
         keypath=str(
             Path(
                 rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
             ).expanduser()
         ),
-        detached=request.config.getoption("--detached"),
-        force_rebuild=request.config.getoption("--force-rebuild"),
-        port_fwds=port_fwds,
+        reuse_existing_container=detached,
+        force_rebuild=force_rebuild,
+        port_fwds=[f"{local_ssh_port}:22", f"{local_client_port}:80"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
             "name": "local_docker_cluster_with_nginx",
             "server_connection_type": "none",
             "server_port": 80,
-            "client_port": client_port,
+            "client_port": local_client_port,
             "den_auth": True,
         },
     )
     # Yield the cluster
     yield local_cluster
 
-    # Stop the Docker container
-    cleanup()
+    # If we are running in detached mode, leave the container running, else clean it up
+    if not detached:
+        cleanup()
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_with_nginx_https(request):
+def local_docker_cluster_pwd_ssh_no_auth(request):
+    """This basic cluster fixture is set up with:
+    - Password authentication
+    - No Den Auth
+    - No nginx/port forwarding set up
+    """
+
+    # From pytest config
+    detached = request.config.getoption("--detached")
+    force_rebuild = request.config.getoption("--force-rebuild")
+
+    # Ports to use on the Docker VM such that they don't conflict
     local_ssh_port = BASE_LOCAL_SSH_PORT + 4
-    client_port = LOCAL_HTTPS_SERVER_PORT + 3
-    port_fwds = [f"{local_ssh_port}:22", f"{client_port}:443"]
 
-    local_cluster, cleanup = set_up_local_cluster(
-        image_name="keypair",
-        container_name="rh-slim-https-nginx",
-        dir_name="public-key-auth",
-        keypath=str(
-            Path(
-                rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
-            ).expanduser()
-        ),
-        detached=request.config.getoption("--detached"),
-        force_rebuild=request.config.getoption("--force-rebuild"),
-        port_fwds=port_fwds,
-        local_ssh_port=local_ssh_port,
-        additional_cluster_init_args={
-            "name": "local_docker_cluster_with_nginx",
-            "server_connection_type": "tls",
-            "server_port": 443,
-            "client_port": client_port,
-            "den_auth": True,
-        },
-    )
-    # Yield the cluster
-    yield local_cluster
-
-    # Stop the Docker container
-    cleanup()
-
-
-@pytest.fixture(scope="session")
-def local_test_account_cluster_public_key(request):
-    """
-    This fixture is not parameterized for every test; it is a separate cluster started with a test account
-    (username: kitchen_tester) in order to test sharing resources with other users.
-    """
-    with test_account():
-
-        local_ssh_port = BASE_LOCAL_SSH_PORT + 5
-        local_cluster, cleanup = set_up_local_cluster(
-            image_name="keypair",
-            container_name="rh-slim-test-acct",
-            dir_name="public-key-auth",
-            keypath=str(
-                Path(
-                    rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
-                ).expanduser()
-            ),
-            detached=request.config.getoption("--detached"),
-            force_rebuild=request.config.getoption("--force-rebuild"),
-            port_fwds=[f"{local_ssh_port}:22"],
-            local_ssh_port=local_ssh_port,
-            additional_cluster_init_args={
-                "name": "local_test_account_cluster_public_key",
-                "den_auth": "den_auth" in request.keywords,
-            },
-        )
-
-    yield local_cluster
-
-    cleanup()
-
-
-@pytest.fixture(scope="session")
-def shared_cluster(local_test_account_cluster_public_key):
-    username_to_share = rh.configs.get("username")
-    with test_account():
-        # Share the cluster with the test account
-        local_test_account_cluster_public_key.share(
-            username_to_share, access_level="read"
-        )
-
-    return local_test_account_cluster_public_key
-
-
-@pytest.fixture(scope="session")
-def local_docker_cluster_passwd(request):
-    local_ssh_port = BASE_LOCAL_SSH_PORT + 6
     pwd_file = "docker_user_passwd"
     rh_parent_path = get_rh_parent_path()
     pwd = (rh_parent_path.parent / pwd_file).read_text().strip()
 
     local_cluster, cleanup = set_up_local_cluster(
         image_name="pwd",
-        container_name="rh-slim-password",
+        container_name="rh-pwd",
         dir_name="password-file-auth",
         pwd_file="docker_user_passwd",
-        detached=request.config.getoption("--detached"),
-        force_rebuild=request.config.getoption("--force-rebuild"),
+        reuse_existing_container=detached,
+        force_rebuild=force_rebuild,
         port_fwds=[f"{local_ssh_port}:22"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
-            "name": "local_docker_cluster_passwd",
-            "den_auth": "den_auth" in request.keywords,
+            "name": "local_docker_cluster_pwd_ssh_no_auth",
+            "server_connection_type": "ssh",
             "ssh_creds": {"ssh_user": SSH_USER, "password": pwd},
         },
     )
     # Yield the cluster
     yield local_cluster
 
-    # Stop the Docker container
-    cleanup()
+    # If we are running in detached mode, leave the container running, else clean it up
+    if not detached:
+        cleanup()
+
+
+@pytest.fixture(scope="session")
+def local_docker_cluster_pk_ssh_telemetry(request, detached=True):
+    """This basic cluster fixture is set up with:
+    - Public key authentication
+    - No Den Auth
+    - No nginx/port forwarding set up
+    - Telemetry enabled
+    """
+
+    # From pytest config
+    detached = request.config.getoption("--detached")
+    force_rebuild = request.config.getoption("--force-rebuild")
+
+    # Ports to use on the Docker VM such that they don't conflict
+    local_ssh_port = BASE_LOCAL_SSH_PORT + 5
+
+    local_cluster, cleanup = set_up_local_cluster(
+        image_name="keypair-telemetry",
+        container_name="rh-pk-telemetry",
+        dir_name="public-key-auth",
+        keypath=str(
+            Path(
+                rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
+            ).expanduser()
+        ),
+        reuse_existing_container=detached,
+        force_rebuild=force_rebuild,
+        port_fwds=[f"{local_ssh_port}:22"],
+        local_ssh_port=local_ssh_port,
+        additional_cluster_init_args={
+            "name": "local_docker_cluster_pk_ssh_telemetry",
+            "server_connection_type": "ssh",
+            "use_local_telemetry": True,
+        },
+    )
+    # Yield the cluster
+    yield local_cluster
+
+    # If we are running in detached mode, leave the container running, else clean it up
+    if not detached:
+        cleanup()
+
+
+@pytest.fixture(scope="session")
+def local_docker_cluster_pk_ssh_test_account_logged_in(request):
+    """
+    This fixture is not parameterized for every test; it is a separate cluster started with a test account
+    (username: kitchen_tester) in order to test sharing resources with other users.
+    """
+
+    # From pytest config
+    detached = request.config.getoption("--detached")
+    force_rebuild = request.config.getoption("--force-rebuild")
+    with test_account():
+
+        # Ports to use on the Docker VM such that they don't conflict
+        local_ssh_port = BASE_LOCAL_SSH_PORT + 6
+        local_cluster, cleanup = set_up_local_cluster(
+            image_name="keypair",
+            container_name="rh-pk-test-acct",
+            dir_name="public-key-auth",
+            keypath=str(
+                Path(
+                    rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
+                ).expanduser()
+            ),
+            reuse_existing_container=detached,
+            force_rebuild=force_rebuild,
+            port_fwds=[f"{local_ssh_port}:22"],
+            local_ssh_port=local_ssh_port,
+            additional_cluster_init_args={
+                "name": "local_docker_cluster_pk_ssh_test_account_logged_in",
+                "server_connection_type": "ssh",
+                "den_auth": "den_auth" in request.keywords,
+            },
+            logged_in=True,
+        )
+
+    yield local_cluster
+
+    # If we are running in detached mode, leave the container running, else clean it up
+    if not detached:
+        cleanup()
+
+
+@pytest.fixture(scope="session")
+def shared_cluster(local_docker_cluster_pk_ssh_test_account_logged_in):
+    username_to_share = rh.configs.get("username")
+    with test_account():
+        # Share the cluster with the test account
+        local_docker_cluster_pk_ssh_test_account_logged_in.share(
+            username_to_share, access_level="read"
+        )
+
+    return local_docker_cluster_pk_ssh_test_account_logged_in

--- a/tests/test_obj_store.py
+++ b/tests/test_obj_store.py
@@ -17,13 +17,18 @@ TEMP_FOLDER = "~/runhouse-tests"
 
 logger = logging.getLogger(__name__)
 
-UNIT = {"cluster": ["local_docker_cluster_public_key"]}
-LOCAL = {"cluster": ["local_docker_cluster_passwd", "local_docker_cluster_public_key"]}
+UNIT = {"cluster": []}
+LOCAL = {
+    "cluster": [
+        "local_docker_cluster_pwd_ssh_no_auth",
+        "local_docker_cluster_pk_ssh_no_auth",
+    ]
+}
 MINIMAL = {"cluster": ["ondemand_cpu_cluster"]}
 THOROUGH = {
     "cluster": [
-        "local_docker_cluster_passwd",
-        "local_docker_cluster_public_key",
+        "local_docker_cluster_pwd_ssh_no_auth",
+        "local_docker_cluster_pk_ssh_no_auth",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",
@@ -32,8 +37,8 @@ THOROUGH = {
 }
 MAXIMAL = {
     "cluster": [
-        "local_docker_cluster_passwd",
-        "local_docker_cluster_public_key",
+        "local_docker_cluster_pwd_ssh_no_auth",
+        "local_docker_cluster_pk_ssh_no_auth",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -30,19 +30,19 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     UNIT = {"cluster": ["named_cluster"]}
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_public_key_logged_in",
-            "local_docker_cluster_public_key_logged_out",
-            "local_docker_cluster_passwd",
+            "local_docker_cluster_pk_ssh_no_auth",
+            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pwd_ssh_no_auth",
         ]
     }
     MINIMAL = {"cluster": ["static_cpu_cluster"]}
     THOROUGH = {"cluster": ["static_cpu_cluster", "password_cluster"]}
     MAXIMAL = {
         "cluster": [
-            "local_docker_cluster_public_key_logged_in",
-            "local_docker_cluster_public_key_logged_out",
-            "local_docker_cluster_telemetry_public_key",
-            "local_docker_cluster_passwd",
+            "local_docker_cluster_pk_ssh_no_auth",
+            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pwd_ssh_no_auth",
+            "local_docker_cluster_pk_ssh_telemetry",
             "static_cpu_cluster",
             "password_cluster",
         ]
@@ -64,20 +64,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         if "server_host" in args:
             assert cluster.server_host == args["server_host"]
         else:
-            # TODO: Test default behavior
-            pass
-
-        if "server_port" in args:
-            assert cluster.server_port == args["server_port"]
-        else:
-            # TODO: Test default behavior
-            pass
-
-        if "server_connection_type" in args:
-            assert cluster.server_connection_type == args["server_connection_type"]
-        else:
-            # TODO: Test default behavior
-            assert cluster.server_connection_type == "ssh"
+            assert cluster.server_host is None
 
         if "ssl_keyfile" in args:
             assert cluster.cert_config.key_path == args["ssl_keyfile"]
@@ -85,32 +72,14 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         if "ssl_certfile" in args:
             assert cluster.cert_config.cert_path == args["ssl_certfile"]
 
-        if "den_auth" in args:
-            assert cluster.den_auth == args["den_auth"]
-        else:
-            # TODO: Test default behavior
-            pass
-
     @pytest.mark.level("local")
-    def test_logged_in_local_cluster(self, local_docker_cluster_public_key_logged_in):
+    def test_local_docker_cluster_fixture_is_logged_out(
+        self, local_docker_cluster_pk_ssh_no_auth
+    ):
         save_resource_and_return_config_cluster = rh.function(
             save_resource_and_return_config,
             name="save_resource_and_return_config_cluster",
-            system=local_docker_cluster_public_key_logged_in,
-        )
-        saved_config_on_cluster = save_resource_and_return_config_cluster()
-        # This cluster was created using our own logged in Runhouse config. Make sure that the simple resource
-        # created on the cluster starts with /default_folder, e.g. /rohinb2/<resource>s
-        assert saved_config_on_cluster["name"].startswith(
-            rh.configs.defaults_cache["default_folder"]
-        )
-
-    @pytest.mark.level("local")
-    def test_logged_out_local_cluster(self, local_docker_cluster_public_key_logged_out):
-        save_resource_and_return_config_cluster = rh.function(
-            save_resource_and_return_config,
-            name="save_resource_and_return_config_cluster",
-            system=local_docker_cluster_public_key_logged_out,
+            system=local_docker_cluster_pk_ssh_no_auth,
         )
         saved_config_on_cluster = save_resource_and_return_config_cluster()
         # This cluster was created without any logged in Runhouse config. Make sure that the simple resource

--- a/tests/test_resources/test_clusters/test_pwd_cluster.py
+++ b/tests/test_resources/test_clusters/test_pwd_cluster.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 
-from tests.conftest import local_docker_cluster_passwd, password_cluster
+from tests.conftest import local_docker_cluster_pwd_ssh_no_auth, password_cluster
 from tests.test_obj_store import (
     test_cancel_run,  # noqa: F401
     test_get_from_cluster,  # noqa: F401
@@ -17,9 +17,9 @@ from tests.test_obj_store import (
 
 logger = logging.getLogger(__name__)
 
-UNIT = {"cluster": [local_docker_cluster_passwd]}
-LOCAL = {"cluster": [local_docker_cluster_passwd]}
-MINIMAL = {"cluster": [password_cluster, local_docker_cluster_passwd]}
+UNIT = {"cluster": [local_docker_cluster_pwd_ssh_no_auth]}
+LOCAL = {"cluster": [local_docker_cluster_pwd_ssh_no_auth]}
+MINIMAL = {"cluster": [password_cluster, local_docker_cluster_pwd_ssh_no_auth]}
 
 
 if __name__ == "__main__":

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -45,9 +45,7 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
     LOCAL = {
         "env": ["base_env"],
         "cluster": [
-            "local_docker_cluster_public_key_logged_in",
-            "local_docker_cluster_public_key_logged_out",
-            "local_docker_cluster_passwd",
+            "local_docker_cluster_pk_ssh_no_auth",
         ]
         # TODO: extend envs to "base_conda_env", "conda_env_from_dict"],
         # and add local clusters once conda docker container is set up
@@ -58,7 +56,13 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
     }
     THOROUGH = {
         "env": ["base_env", "base_conda_env", "conda_env_from_dict"],
-        "cluster": ["ondemand_cpu_cluster", "static_cpu_cluster", "password_cluster"],
+        "cluster": [
+            "ondemand_cpu_cluster",
+            "static_cpu_cluster",
+            "password_cluster",
+            "local_docker_cluster_pk_ssh_no_auth",
+            "local_docker_cluster_pwd_ssh_no_auth",
+        ],
     }
     MAXIMAL = {
         "env": [

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -652,7 +652,9 @@ class TestModule:
 
     @pytest.mark.level("thorough")
     def test_shared_readonly(
-        self, ondemand_https_cluster_with_auth, local_test_account_cluster_public_key
+        self,
+        ondemand_https_cluster_with_auth,
+        local_docker_cluster_pk_ssh_test_account_logged_in,
     ):
         if ondemand_https_cluster_with_auth.address == "localhost":
             pytest.skip("Skipping sharing test on local cluster")
@@ -678,7 +680,7 @@ class TestModule:
             )[0][1]
         )
         test_fn = rh.fn(test_load_and_use_readonly_module).to(
-            local_test_account_cluster_public_key
+            local_docker_cluster_pk_ssh_test_account_logged_in
         )
         test_fn(mod_name=remote_df.rns_address, cpu_count=cpu_count, size=size)
 

--- a/tests/test_resources/test_resource.py
+++ b/tests/test_resources/test_resource.py
@@ -131,7 +131,9 @@ class TestResource:
         resource.delete_configs()
 
     @pytest.mark.level("local")
-    def test_sharing(self, resource, local_test_account_cluster_public_key):
+    def test_sharing(
+        self, resource, local_docker_cluster_pk_ssh_test_account_logged_in
+    ):
         if resource.name is None:
             with pytest.raises(ValueError):
                 resource.save()
@@ -168,7 +170,7 @@ class TestResource:
         load_shared_resource_config_cluster = rh.function(
             load_shared_resource_config
         ).to(
-            system=local_test_account_cluster_public_key,
+            system=local_docker_cluster_pk_ssh_test_account_logged_in,
             env=rh.env(
                 working_dir=None,
                 # Sync sky key so loading ondemand_cluster from config works

--- a/tests/test_resources/test_secrets/test_secret.py
+++ b/tests/test_resources/test_secrets/test_secret.py
@@ -68,8 +68,7 @@ class TestSecret(tests.test_resources.test_resource.TestResource):
     LOCAL = {
         "secret": ["test_secret"] + provider_secrets + api_secrets,
         "cluster": [
-            "local_docker_cluster_public_key_logged_in",
-            "local_docker_cluster_public_key_logged_out",
+            "local_docker_cluster_pk_ssh_no_auth",
         ],
     }
     MINIMAL = {
@@ -88,7 +87,12 @@ class TestSecret(tests.test_resources.test_resource.TestResource):
     }
     MAXIMAL = {
         "secret": ["test_secret"] + provider_secrets,
-        "cluster": ["static_cpu_cluster", "password_cluster"],
+        "cluster": [
+            "static_cpu_cluster",
+            "password_cluster",
+            "local_docker_cluster_pk_ssh_no_auth",
+            "local_docker_cluster_pwd_ssh_no_auth",
+        ],
     }
 
     @pytest.mark.level("unit")

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -33,14 +33,14 @@ class TestHTTPServerDocker:
 
     UNIT = {
         "cluster": [
-            "local_docker_cluster_public_key_den_auth",
-            "local_docker_cluster_public_key_logged_in",
+            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pk_ssh_no_auth",
         ]
     }
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_public_key_den_auth",
-            "local_docker_cluster_public_key_logged_in",
+            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pk_ssh_no_auth",
         ]
     }
 
@@ -48,12 +48,6 @@ class TestHTTPServerDocker:
     def test_get_cert(self, http_client):
         response = http_client.get("/cert")
         assert response.status_code == 200
-
-        error_b64 = response.json().get("error")
-        error_message = b64_unpickle(error_b64)
-
-        assert isinstance(error_message, FileNotFoundError)
-        assert "No certificate found on cluster in path" in str(error_message)
 
     @pytest.mark.level("local")
     def test_check_server(self, http_client):
@@ -220,11 +214,11 @@ class TestHTTPServerDockerDenAuthOnly:
     but it is a server without Den Auth enabled at all?
     """
 
-    UNIT = {"cluster": ["local_docker_cluster_public_key_den_auth"]}
-    LOCAL = {"cluster": ["local_docker_cluster_public_key_den_auth"]}
+    UNIT = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
+    LOCAL = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
     MINIMAL = {"cluster": []}
-    THOROUGH = {"cluster": ["local_docker_cluster_public_key_den_auth"]}
-    MAXIMAL = {"cluster": ["local_docker_cluster_public_key_den_auth"]}
+    THOROUGH = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
+    MAXIMAL = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
 
     # -------- INVALID TOKEN / CLUSTER ACCESS TESTS ----------- #
 

--- a/tests/test_servers/test_nginx.py
+++ b/tests/test_servers/test_nginx.py
@@ -413,32 +413,32 @@ class TestNginxServerLocally:
 
     UNIT = {
         "cluster": [
-            "local_docker_cluster_with_nginx_http",
-            "local_docker_cluster_with_nginx_https",
+            "local_docker_cluster_pk_http_exposed",
+            "local_docker_cluster_pk_tls_den_auth",
         ]
     }
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_with_nginx_http",
-            "local_docker_cluster_with_nginx_https",
+            "local_docker_cluster_pk_http_exposed",
+            "local_docker_cluster_pk_tls_den_auth",
         ]
     }
     MINIMAL = {
         "cluster": [
-            "local_docker_cluster_with_nginx_http",
-            "local_docker_cluster_with_nginx_https",
+            "local_docker_cluster_pk_http_exposed",
+            "local_docker_cluster_pk_tls_den_auth",
         ]
     }
     THOROUGH = {
         "cluster": [
-            "local_docker_cluster_with_nginx_http",
-            "local_docker_cluster_with_nginx_https",
+            "local_docker_cluster_pk_http_exposed",
+            "local_docker_cluster_pk_tls_den_auth",
         ]
     }
     MAXIMAL = {
         "cluster": [
-            "local_docker_cluster_with_nginx_http",
-            "local_docker_cluster_with_nginx_https",
+            "local_docker_cluster_pk_http_exposed",
+            "local_docker_cluster_pk_tls_den_auth",
         ]
     }
 

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -147,12 +147,10 @@ class TestServlet:
 
     @pytest.mark.skip("Not implemented yet.")
     @pytest.mark.level("unit")
-    def test_call(self, base_servlet, local_docker_cluster_public_key_logged_in):
+    def test_call(self, base_servlet, local_docker_cluster_pk_ssh_no_auth):
         token_hash = None
         den_auth = False
-        remote_func = rh.function(
-            summer, system=local_docker_cluster_public_key_logged_in
-        )
+        remote_func = rh.function(summer, system=local_docker_cluster_pk_ssh_no_auth)
 
         method_name = "call"
         module_name = remote_func.name

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -6,8 +6,8 @@ import requests
 
 @pytest.mark.dockertest
 @pytest.mark.telemetrytest
-def test_public_key_cluster_has_telemetry(local_docker_cluster_telemetry_public_key):
-    cluster = local_docker_cluster_telemetry_public_key
+def test_public_key_cluster_has_telemetry(local_docker_cluster_pk_ssh_telemetry):
+    cluster = local_docker_cluster_pk_ssh_telemetry
     cluster.check_server()
     assert cluster.is_up()  # Should be true for a Cluster object
 


### PR DESCRIPTION
Passing locally:

```
pytest -v --level local -k "TestCluster or TestResource"

pytest -v --level local -k "TestEnv"
```

Yet to pass / test:

```
pytest -v --level local -k "TestFunction"

pytest -v --level local -k "TestSecret"

pytest -v --level local -k "TestModule"

pytest -v --level local tests/test_servers/
```