### PR TITLE
Make TLS+Den Auth universally tested.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,14 +281,14 @@ default_fixtures[TestLevels.UNIT] = {
 default_fixtures[TestLevels.LOCAL] = {
     "cluster": [
         "local_docker_cluster_pk_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_den_auth",
+        "local_docker_cluster_pk_tls_den_auth",
     ]
 }
 default_fixtures[TestLevels.MINIMAL] = {"cluster": ["ondemand_cpu_cluster"]}
 default_fixtures[TestLevels.THOROUGH] = {
     "cluster": [
         "local_docker_cluster_pk_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_den_auth",
+        "local_docker_cluster_pk_tls_den_auth",
         "local_docker_cluster_pwd_ssh_no_auth",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
@@ -299,7 +299,7 @@ default_fixtures[TestLevels.THOROUGH] = {
 default_fixtures[TestLevels.MAXIMAL] = {
     "cluster": [
         "local_docker_cluster_pk_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_den_auth",
+        "local_docker_cluster_pk_tls_den_auth",
         "local_docker_cluster_pwd_ssh_no_auth",
         "local_docker_cluster_pk_ssh_telemetry",
         "ondemand_cpu_cluster",

--- a/tests/fixtures/local_docker_cluster_fixtures.py
+++ b/tests/fixtures/local_docker_cluster_fixtures.py
@@ -466,11 +466,11 @@ def local_docker_cluster_pk_tls_den_auth(
 def local_docker_cluster_pk_ssh_den_auth(
     local_docker_cluster_pk_ssh,
 ):
-    """This is our other key use case -- SSH with any Den Auth.
+    """This is our other key use case -- SSH without any Den Auth.
 
     We use the base fixture, and ignore the nginx/https setup, instead just communicating with
     the cluster using the base SSH credentials already present on the machine. We send a request
-    to enable den auth server side.
+    to disable den auth server side
     """
     local_docker_cluster_pk_ssh.enable_den_auth()
     return local_docker_cluster_pk_ssh
@@ -484,7 +484,7 @@ def local_docker_cluster_pk_ssh_no_auth(
 
     We use the base fixture, and ignore the nginx/https setup, instead just communicating with
     the cluster using the base SSH credentials already present on the machine. We send a request
-    to disable den auth server side.
+    to disable den auth server side
     """
     local_docker_cluster_pk_ssh.disable_den_auth()
     return local_docker_cluster_pk_ssh

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -31,7 +31,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     LOCAL = {
         "cluster": [
             "local_docker_cluster_pk_ssh_no_auth",
-            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pk_tls_den_auth",
             "local_docker_cluster_pwd_ssh_no_auth",
         ]
     }
@@ -40,7 +40,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     MAXIMAL = {
         "cluster": [
             "local_docker_cluster_pk_ssh_no_auth",
-            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pk_tls_den_auth",
             "local_docker_cluster_pwd_ssh_no_auth",
             "local_docker_cluster_pk_ssh_telemetry",
             "static_cpu_cluster",

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -33,13 +33,13 @@ class TestHTTPServerDocker:
 
     UNIT = {
         "cluster": [
-            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pk_tls_den_auth",
             "local_docker_cluster_pk_ssh_no_auth",
         ]
     }
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_pk_ssh_den_auth",
+            "local_docker_cluster_pk_tls_den_auth",
             "local_docker_cluster_pk_ssh_no_auth",
         ]
     }
@@ -214,11 +214,11 @@ class TestHTTPServerDockerDenAuthOnly:
     but it is a server without Den Auth enabled at all?
     """
 
-    UNIT = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
-    LOCAL = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
+    UNIT = {"cluster": ["local_docker_cluster_pk_tls_den_auth"]}
+    LOCAL = {"cluster": ["local_docker_cluster_pk_tls_den_auth"]}
     MINIMAL = {"cluster": []}
-    THOROUGH = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
-    MAXIMAL = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
+    THOROUGH = {"cluster": ["local_docker_cluster_pk_tls_den_auth"]}
+    MAXIMAL = {"cluster": ["local_docker_cluster_pk_tls_den_auth"]}
 
     # -------- INVALID TOKEN / CLUSTER ACCESS TESTS ----------- #
 


### PR DESCRIPTION
Instead of running `local_docker_cluster_pk_ssh_den_auth` everywhere, test `local_docker_cluster_pk_tls_den_auth`. 

These are our key use cases being tested everywhere then.