### PR TITLE
Support Python 3.11, fix CLI entrypoint issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=58.0"]
+build-backend = "setuptools.build_meta"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = -s -v
 markers =
     asyncio: marks tests which use async IO (deselect with '-m "not asyncio"')
     gputest: marks tests which require a GPU (deselect with '-m "not gputest"')

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+httpx
+pytest_asyncio

--- a/tests/test_servers/test_certs.py
+++ b/tests/test_servers/test_certs.py
@@ -105,8 +105,8 @@ class TestTLSCertConfig:
 
         resolved_path = resolve_absolute_path(self.cert_config.cert_path)
 
-        mock_expanduser.assert_called_once_with(self.cert_config.cert_path)
-        mock_abspath.assert_called_once_with(mock_expanduser.return_value)
+        mock_expanduser.assert_any_call(self.cert_config.cert_path)
+        mock_abspath.assert_any_call(mock_expanduser.return_value)
 
         assert resolved_path == mock_abspath.return_value
 


### PR DESCRIPTION
It appears we support 3.11 now that Ray does. Basic testing confirms, but typical constraints stand - we can't cloudpickles functions and send them across Python versions, which we do a couple times in tests (to be fixed shortly).

Also fixes a longtime pesky error wher we were getting a pkg_resources error when attempting to us the CLI without AWSCLI v1 isntalled. For some reason adding a nearly empty pyproject.toml fixes that. Great.