### PR TITLE
Fix two servlet bugs in LOCAL tests

### DIFF
--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -858,9 +858,9 @@ class Module(Resource):
             and isinstance(self.system, Cluster)
             and self.system.on_this_cluster()
         ):
-            obj_store.rename(old_key=old_name, new_key=self.name)
+            obj_store.rename(old_key=old_name, new_key=self.rns_address)
         elif self._client():
-            self._client().rename(old_key=old_name, new_key=self.name)
+            self._client().rename(old_key=old_name, new_key=self.rns_address)
 
     def save(
         self,


### PR DESCRIPTION
- Auth was only flowing for named resources, corrected so a user with proper cluster access also has access to unnamed resources or non-resources via call_module_method
- Renaming resources in obj_store wasn't actually changing the internal resource.name or rns_address, which was causing auth to use the old rns_address for authentication.
- The call endpoint did not support visibility, now it does