### PR TITLE
Fix Sharing Behavior of Local Cluster in Unit

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  all-tests-level-unit:
+  all-tests-logged-out-level-unit:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -16,7 +16,25 @@ jobs:
         uses: ./.github/workflows/setup_runhouse
 
       - name: pytest -v --level unit
-        env:
-          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
         run: pytest -v --level unit
+
+#  all-tests-logged-in-level-unit:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Runhouse
+#        uses: ./.github/workflows/setup_runhouse
+#
+#      - name: Setup ~/.rh/config.yaml
+#        uses: ./.github/workflows/setup_rh_config
+#        with:
+#          username: ${{ secrets.CI_ACCOUNT_USERNAME }}
+#          token: ${{ secrets.CI_ACCOUNT_TOKEN }}
+#
+#      - name: pytest -v --level unit -k "not den_auth"
+#        env:
+#          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+#          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+#        run: pytest -v --level unit

--- a/runhouse/rns/defaults.py
+++ b/runhouse/rns/defaults.py
@@ -128,6 +128,8 @@ class Defaults:
     ):
         config_path = Path(config_path or self.CONFIG_PATH)
         defaults = defaults or self.defaults_cache
+        if not defaults:
+            return
 
         if not config_path.exists():
             config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,10 +35,10 @@ pytest -s -v --level "unit" tests/test_resources/test_resource.py::TestResource:
 
 To run tests across multiple suites but only including a specific fixture, you can do:
 ```bash
-pytest -s -v --level "local" -k "local_docker_cluster_pk_ssh_no_auth" tests
+pytest -s -v --level "local" -k "docker_cluster_pk_ssh_no_auth" tests
 ```
 Make sure the fixture(s) of interest are included in the level you're running at, or they won't natch with any tests.
-You can also exclude fixtures with "-m" and a tilde, e.g. "-m ~local_docker_cluster_public_key".
+You can also exclude fixtures with "-m" and a tilde, e.g. "-m ~docker_cluster_public_key".
 
 ## Sample Workflow
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,10 +28,10 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     UNIT = {"cluster": ["named_cluster"]}
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_pk_ssh_no_auth",
-            "local_docker_cluster_pk_ssh_den_auth",
-            "local_docker_cluster_pk_ssh_telemetry",
-            "local_docker_cluster_pwd_ssh_no_auth",
+            "docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pk_ssh_den_auth",
+            "docker_cluster_pk_ssh_telemetry",
+            "docker_cluster_pwd_ssh_no_auth",
         ]
     }
     MINIMAL = {"cluster": ["static_cpu_cluster"]}
@@ -148,19 +148,19 @@ init_args = {}
 
 # ----------------- Clusters -----------------
 
-from tests.fixtures.local_docker_cluster_fixtures import (
+from tests.fixtures.docker_cluster_fixtures import (
     build_and_run_image,  # noqa: F401
     byo_cpu,  # noqa: F401
     cluster,  # noqa: F401
-    local_docker_cluster_pk_http_exposed,  # noqa: F401
-    local_docker_cluster_pk_ssh,  # noqa: F401
-    local_docker_cluster_pk_ssh_den_auth,  # noqa: F401
-    local_docker_cluster_pk_ssh_no_auth,  # noqa: F401
-    local_docker_cluster_pk_ssh_telemetry,  # noqa: F401
-    local_docker_cluster_pk_ssh_test_account_logged_in,  # noqa: F401
-    local_docker_cluster_pk_tls_den_auth,  # noqa: F401
-    local_docker_cluster_pk_tls_exposed,  # noqa: F401
-    local_docker_cluster_pwd_ssh_no_auth,  # noqa: F401
+    docker_cluster_pk_http_exposed,  # noqa: F401
+    docker_cluster_pk_ssh,  # noqa: F401
+    docker_cluster_pk_ssh_den_auth,  # noqa: F401
+    docker_cluster_pk_ssh_no_auth,  # noqa: F401
+    docker_cluster_pk_ssh_telemetry,  # noqa: F401
+    docker_cluster_pk_ssh_test_account_logged_in,  # noqa: F401
+    docker_cluster_pk_tls_den_auth,  # noqa: F401
+    docker_cluster_pk_tls_exposed,  # noqa: F401
+    docker_cluster_pwd_ssh_no_auth,  # noqa: F401
     named_cluster,  # noqa: F401
     password_cluster,  # noqa: F401
     shared_cluster,  # noqa: F401
@@ -281,16 +281,16 @@ default_fixtures[TestLevels.UNIT] = {
 }
 default_fixtures[TestLevels.LOCAL] = {
     "cluster": [
-        "local_docker_cluster_pk_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_den_auth",
+        "docker_cluster_pk_ssh_no_auth",
+        "docker_cluster_pk_ssh_den_auth",
     ]
 }
 default_fixtures[TestLevels.MINIMAL] = {"cluster": ["ondemand_cpu_cluster"]}
 default_fixtures[TestLevels.THOROUGH] = {
     "cluster": [
-        "local_docker_cluster_pk_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_den_auth",
-        "local_docker_cluster_pwd_ssh_no_auth",
+        "docker_cluster_pk_ssh_no_auth",
+        "docker_cluster_pk_ssh_den_auth",
+        "docker_cluster_pwd_ssh_no_auth",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",
@@ -300,10 +300,10 @@ default_fixtures[TestLevels.THOROUGH] = {
 }
 default_fixtures[TestLevels.MAXIMAL] = {
     "cluster": [
-        "local_docker_cluster_pk_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_den_auth",
-        "local_docker_cluster_pwd_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_telemetry",
+        "docker_cluster_pk_ssh_no_auth",
+        "docker_cluster_pk_ssh_den_auth",
+        "docker_cluster_pwd_ssh_no_auth",
+        "docker_cluster_pk_ssh_telemetry",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",

--- a/tests/fixtures/docker_cluster_fixtures.py
+++ b/tests/fixtures/docker_cluster_fixtures.py
@@ -361,7 +361,7 @@ def set_up_local_cluster(
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_pk_tls_exposed(request):
+def docker_cluster_pk_tls_exposed(request):
     """This basic cluster fixture is set up with:
     - Public key authentication
     - Nginx set up on startup to forward Runhouse HTTP server to port 443
@@ -389,7 +389,7 @@ def local_docker_cluster_pk_tls_exposed(request):
         port_fwds=[f"{local_ssh_port}:22", f"{local_client_port}:443"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
-            "name": "local_docker_cluster_pk_tls_exposed",
+            "name": "docker_cluster_pk_tls_exposed",
             "server_connection_type": "tls",
             "server_port": 443,
             "client_port": local_client_port,
@@ -406,7 +406,7 @@ def local_docker_cluster_pk_tls_exposed(request):
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_pk_ssh(request):
+def docker_cluster_pk_ssh(request):
     """This basic cluster fixture is set up with:
     - Public key authentication
     - Nginx set up on startup to forward Runhouse HTTP server to port 443
@@ -433,7 +433,7 @@ def local_docker_cluster_pk_ssh(request):
         port_fwds=[f"{local_ssh_port}:22"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
-            "name": "local_docker_cluster_pk_ssh",
+            "name": "docker_cluster_pk_ssh",
             "server_connection_type": "ssh",
         },
     )
@@ -450,8 +450,8 @@ def local_docker_cluster_pk_ssh(request):
 # the same image, but we switch the cluster parameters.
 # These depend on the base fixture above and swap out the cluster parameters as needed.
 @pytest.fixture(scope="function")
-def local_docker_cluster_pk_tls_den_auth(
-    local_docker_cluster_pk_tls_exposed,
+def docker_cluster_pk_tls_den_auth(
+    docker_cluster_pk_tls_exposed,
 ):
     """This is one of our key use cases -- TLS + Den Auth set up.
 
@@ -459,12 +459,12 @@ def local_docker_cluster_pk_tls_den_auth(
     from 443 to 32300, and we set the cluster parameters to use the correct ports to communicate
     with the server, in case they had been changed.
     """
-    return local_docker_cluster_pk_tls_exposed
+    return docker_cluster_pk_tls_exposed
 
 
 @pytest.fixture(scope="function")
-def local_docker_cluster_pk_ssh_den_auth(
-    local_docker_cluster_pk_ssh,
+def docker_cluster_pk_ssh_den_auth(
+    docker_cluster_pk_ssh,
 ):
     """This is our other key use case -- SSH with any Den Auth.
 
@@ -472,13 +472,13 @@ def local_docker_cluster_pk_ssh_den_auth(
     the cluster using the base SSH credentials already present on the machine. We send a request
     to enable den auth server side.
     """
-    local_docker_cluster_pk_ssh.enable_den_auth()
-    return local_docker_cluster_pk_ssh
+    docker_cluster_pk_ssh.enable_den_auth()
+    return docker_cluster_pk_ssh
 
 
 @pytest.fixture(scope="function")
-def local_docker_cluster_pk_ssh_no_auth(
-    local_docker_cluster_pk_ssh,
+def docker_cluster_pk_ssh_no_auth(
+    docker_cluster_pk_ssh,
 ):
     """This is our other key use case -- SSH without any Den Auth.
 
@@ -486,12 +486,12 @@ def local_docker_cluster_pk_ssh_no_auth(
     the cluster using the base SSH credentials already present on the machine. We send a request
     to disable den auth server side.
     """
-    local_docker_cluster_pk_ssh.disable_den_auth()
-    return local_docker_cluster_pk_ssh
+    docker_cluster_pk_ssh.disable_den_auth()
+    return docker_cluster_pk_ssh
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_pk_http_exposed(request):
+def docker_cluster_pk_http_exposed(request):
     """This basic cluster fixture is set up with:
     - Public key authentication
     - Den auth enabled
@@ -520,7 +520,7 @@ def local_docker_cluster_pk_http_exposed(request):
         port_fwds=[f"{local_ssh_port}:22", f"{local_client_port}:80"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
-            "name": "local_docker_cluster_with_nginx",
+            "name": "docker_cluster_with_nginx",
             "server_connection_type": "none",
             "server_port": 80,
             "client_port": local_client_port,
@@ -536,7 +536,7 @@ def local_docker_cluster_pk_http_exposed(request):
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_pwd_ssh_no_auth(request):
+def docker_cluster_pwd_ssh_no_auth(request):
     """This basic cluster fixture is set up with:
     - Password authentication
     - No Den Auth
@@ -564,7 +564,7 @@ def local_docker_cluster_pwd_ssh_no_auth(request):
         port_fwds=[f"{local_ssh_port}:22"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
-            "name": "local_docker_cluster_pwd_ssh_no_auth",
+            "name": "docker_cluster_pwd_ssh_no_auth",
             "server_connection_type": "ssh",
             "ssh_creds": {"ssh_user": SSH_USER, "password": pwd},
         },
@@ -578,7 +578,7 @@ def local_docker_cluster_pwd_ssh_no_auth(request):
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_pk_ssh_telemetry(request, detached=True):
+def docker_cluster_pk_ssh_telemetry(request, detached=True):
     """This basic cluster fixture is set up with:
     - Public key authentication
     - No Den Auth
@@ -607,7 +607,7 @@ def local_docker_cluster_pk_ssh_telemetry(request, detached=True):
         port_fwds=[f"{local_ssh_port}:22"],
         local_ssh_port=local_ssh_port,
         additional_cluster_init_args={
-            "name": "local_docker_cluster_pk_ssh_telemetry",
+            "name": "docker_cluster_pk_ssh_telemetry",
             "server_connection_type": "ssh",
             "use_local_telemetry": True,
         },
@@ -621,7 +621,7 @@ def local_docker_cluster_pk_ssh_telemetry(request, detached=True):
 
 
 @pytest.fixture(scope="session")
-def local_docker_cluster_pk_ssh_test_account_logged_in(request):
+def docker_cluster_pk_ssh_test_account_logged_in(request):
     """
     This fixture is not parameterized for every test; it is a separate cluster started with a test account
     (username: kitchen_tester) in order to test sharing resources with other users.
@@ -647,7 +647,7 @@ def local_docker_cluster_pk_ssh_test_account_logged_in(request):
             port_fwds=[f"{local_ssh_port}:22"],
             local_ssh_port=local_ssh_port,
             additional_cluster_init_args={
-                "name": "local_docker_cluster_pk_ssh_test_account_logged_in",
+                "name": "docker_cluster_pk_ssh_test_account_logged_in",
                 "server_connection_type": "ssh",
                 "den_auth": "den_auth" in request.keywords,
             },
@@ -662,12 +662,12 @@ def local_docker_cluster_pk_ssh_test_account_logged_in(request):
 
 
 @pytest.fixture(scope="session")
-def shared_cluster(local_docker_cluster_pk_ssh_test_account_logged_in):
+def shared_cluster(docker_cluster_pk_ssh_test_account_logged_in):
     username_to_share = rh.configs.get("username")
     with test_account():
         # Share the cluster with the test account
-        local_docker_cluster_pk_ssh_test_account_logged_in.share(
+        docker_cluster_pk_ssh_test_account_logged_in.share(
             username_to_share, notify_users=False, access_level="read"
         )
 
-    return local_docker_cluster_pk_ssh_test_account_logged_in
+    return docker_cluster_pk_ssh_test_account_logged_in

--- a/tests/test_obj_store.py
+++ b/tests/test_obj_store.py
@@ -20,15 +20,15 @@ logger = logging.getLogger(__name__)
 UNIT = {"cluster": []}
 LOCAL = {
     "cluster": [
-        "local_docker_cluster_pwd_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_no_auth",
+        "docker_cluster_pwd_ssh_no_auth",
+        "docker_cluster_pk_ssh_no_auth",
     ]
 }
 MINIMAL = {"cluster": ["ondemand_cpu_cluster"]}
 THOROUGH = {
     "cluster": [
-        "local_docker_cluster_pwd_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_no_auth",
+        "docker_cluster_pwd_ssh_no_auth",
+        "docker_cluster_pk_ssh_no_auth",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",
@@ -38,8 +38,8 @@ THOROUGH = {
 }
 MAXIMAL = {
     "cluster": [
-        "local_docker_cluster_pwd_ssh_no_auth",
-        "local_docker_cluster_pk_ssh_no_auth",
+        "docker_cluster_pwd_ssh_no_auth",
+        "docker_cluster_pk_ssh_no_auth",
         "ondemand_cpu_cluster",
         "ondemand_https_cluster_with_auth",
         "password_cluster",

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -32,9 +32,9 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     UNIT = {"cluster": ["named_cluster"]}
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_pk_ssh_no_auth",
-            "local_docker_cluster_pk_ssh_den_auth",
-            "local_docker_cluster_pwd_ssh_no_auth",
+            "docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pk_ssh_den_auth",
+            "docker_cluster_pwd_ssh_no_auth",
         ]
     }
     MINIMAL = {"cluster": ["static_cpu_cluster"]}
@@ -43,10 +43,10 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     }
     MAXIMAL = {
         "cluster": [
-            "local_docker_cluster_pk_ssh_no_auth",
-            "local_docker_cluster_pk_ssh_den_auth",
-            "local_docker_cluster_pwd_ssh_no_auth",
-            "local_docker_cluster_pk_ssh_telemetry",
+            "docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pk_ssh_den_auth",
+            "docker_cluster_pwd_ssh_no_auth",
+            "docker_cluster_pk_ssh_telemetry",
             "static_cpu_cluster",
             "password_cluster",
             "multinode_cpu_cluster",
@@ -78,13 +78,11 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
             assert cluster.cert_config.cert_path == args["ssl_certfile"]
 
     @pytest.mark.level("local")
-    def test_local_docker_cluster_fixture_is_logged_out(
-        self, local_docker_cluster_pk_ssh_no_auth
-    ):
+    def test_docker_cluster_fixture_is_logged_out(self, docker_cluster_pk_ssh_no_auth):
         save_resource_and_return_config_cluster = rh.function(
             save_resource_and_return_config,
             name="save_resource_and_return_config_cluster",
-            system=local_docker_cluster_pk_ssh_no_auth,
+            system=docker_cluster_pk_ssh_no_auth,
         )
         saved_config_on_cluster = save_resource_and_return_config_cluster()
         # This cluster was created without any logged in Runhouse config. Make sure that the simple resource

--- a/tests/test_resources/test_clusters/test_pwd_cluster.py
+++ b/tests/test_resources/test_clusters/test_pwd_cluster.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 
-from tests.conftest import local_docker_cluster_pwd_ssh_no_auth, password_cluster
+from tests.conftest import docker_cluster_pwd_ssh_no_auth, password_cluster
 from tests.test_obj_store import (
     test_cancel_run,  # noqa: F401
     test_get_from_cluster,  # noqa: F401
@@ -17,9 +17,9 @@ from tests.test_obj_store import (
 
 logger = logging.getLogger(__name__)
 
-UNIT = {"cluster": [local_docker_cluster_pwd_ssh_no_auth]}
-LOCAL = {"cluster": [local_docker_cluster_pwd_ssh_no_auth]}
-MINIMAL = {"cluster": [password_cluster, local_docker_cluster_pwd_ssh_no_auth]}
+UNIT = {"cluster": [docker_cluster_pwd_ssh_no_auth]}
+LOCAL = {"cluster": [docker_cluster_pwd_ssh_no_auth]}
+MINIMAL = {"cluster": [password_cluster, docker_cluster_pwd_ssh_no_auth]}
 
 
 if __name__ == "__main__":

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -45,7 +45,7 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
     LOCAL = {
         "env": ["base_env"],
         "cluster": [
-            "local_docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pk_ssh_no_auth",
         ]
         # TODO: extend envs to "base_conda_env", "conda_env_from_dict"],
         # and add local clusters once conda docker container is set up
@@ -61,8 +61,8 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
             "static_cpu_cluster",
             "password_cluster",
             "multinode_cpu_cluster",
-            "local_docker_cluster_pk_ssh_no_auth",
-            "local_docker_cluster_pwd_ssh_no_auth",
+            "docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pwd_ssh_no_auth",
         ],
     }
     MAXIMAL = {

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -654,7 +654,7 @@ class TestModule:
     def test_shared_readonly(
         self,
         ondemand_https_cluster_with_auth,
-        local_docker_cluster_pk_ssh_test_account_logged_in,
+        docker_cluster_pk_ssh_test_account_logged_in,
     ):
         if ondemand_https_cluster_with_auth.address == "localhost":
             pytest.skip("Skipping sharing test on local cluster")
@@ -680,7 +680,7 @@ class TestModule:
             )[0][1]
         )
         test_fn = rh.fn(test_load_and_use_readonly_module).to(
-            local_docker_cluster_pk_ssh_test_account_logged_in
+            docker_cluster_pk_ssh_test_account_logged_in
         )
         test_fn(mod_name=remote_df.rns_address, cpu_count=cpu_count, size=size)
 

--- a/tests/test_resources/test_resource.py
+++ b/tests/test_resources/test_resource.py
@@ -128,12 +128,9 @@ class TestResource:
         )  # To deal with tuples and non-json types
         for k, v in history[0]["data"].items():
             assert config[k] == v
-        resource.delete_configs()
 
     @pytest.mark.level("local")
-    def test_sharing(
-        self, resource, local_docker_cluster_pk_ssh_test_account_logged_in
-    ):
+    def test_sharing(self, resource, docker_cluster_pk_ssh_test_account_logged_in):
 
         # Unnamed resources can't even be saved, let alone shared
         if resource.name is None:
@@ -179,7 +176,7 @@ class TestResource:
         load_shared_resource_config_cluster = rh.function(
             load_shared_resource_config
         ).to(
-            system=local_docker_cluster_pk_ssh_test_account_logged_in,
+            system=docker_cluster_pk_ssh_test_account_logged_in,
             env=rh.env(
                 working_dir=None,
                 # TODO: If we are testing with an ondemand_cluster we need these secrets

--- a/tests/test_resources/test_secrets/test_secret.py
+++ b/tests/test_resources/test_secrets/test_secret.py
@@ -69,7 +69,7 @@ class TestSecret(tests.test_resources.test_resource.TestResource):
     LOCAL = {
         "secret": ["test_secret"] + provider_secrets + api_secrets,
         "cluster": [
-            "local_docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pk_ssh_no_auth",
         ],
     }
     MINIMAL = {
@@ -92,8 +92,8 @@ class TestSecret(tests.test_resources.test_resource.TestResource):
             "static_cpu_cluster",
             "password_cluster",
             "multinode_cpu_cluster",
-            "local_docker_cluster_pk_ssh_no_auth",
-            "local_docker_cluster_pwd_ssh_no_auth",
+            "docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pwd_ssh_no_auth",
         ],
     }
 

--- a/tests/test_servers/conftest.py
+++ b/tests/test_servers/conftest.py
@@ -27,7 +27,7 @@ def summer(a, b):
 # -------- FIXTURES ----------- #
 @pytest.fixture(scope="module")
 def http_client():
-    with httpx.Client(base_url=BASE_URL, timeout=10.0) as client:
+    with httpx.Client(base_url=BASE_URL, timeout=60.0) as client:
         yield client
 
 
@@ -39,10 +39,11 @@ async def async_http_client():
 
 @pytest.fixture(scope="session")
 def local_cluster():
-    c = rh.cluster(
-        name="local_cluster", host="localhost", server_connection_type="none"
+    return rh.cluster(
+        name="faux_local_cluster",
+        server_connection_type="none",
+        host="localhost",
     )
-    return c
 
 
 @pytest.fixture(scope="session")
@@ -57,6 +58,9 @@ def local_client():
 
 @pytest.fixture(scope="function")
 def local_client_with_den_auth():
+    if not rh.configs.get("token"):
+        pytest.skip("`TEST_TOKEN` or ~/.rh/config.yaml not set, skipping test.")
+
     from fastapi.testclient import TestClient
 
     HTTPServer()
@@ -89,38 +93,16 @@ def obj_store(request):
 
 
 @pytest.fixture(scope="class")
-def setup_cluster_config():
+def setup_cluster_config(local_cluster):
     # Create a temporary directory that simulates the user's home directory
     home_dir = Path("~/.rh").expanduser()
     home_dir.mkdir(exist_ok=True)
 
     cluster_config_path = home_dir / "cluster_config.json"
-    rns_address = "/kitchen_tester/local_cluster"
-
-    cluster_config = {
-        "name": rns_address,
-        "resource_type": "cluster",
-        "resource_subtype": "Cluster",
-        "server_port": 32300,
-        "den_auth": True,
-        "server_connection_type": "ssh",
-        "ips": ["localhost"],
-    }
-    try:
-        c = rh.Cluster.from_name(rns_address)
-    except ValueError:
-        c = None
 
     try:
-        if not c:
-            current_username = rh.configs.get("username")
-            if current_username:
-                with test_account():
-                    c = rh.cluster(name="local_cluster", den_auth=True).save()
-                    c.share(current_username, access_level="write", notify_users=False)
-
         with open(cluster_config_path, "w") as file:
-            json.dump(cluster_config, file)
+            json.dump(local_cluster.config_for_rns, file)
 
         yield
 

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -34,14 +34,14 @@ class TestHTTPServerDocker:
 
     UNIT = {
         "cluster": [
-            "local_docker_cluster_pk_ssh_den_auth",
-            "local_docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pk_ssh_den_auth",
+            "docker_cluster_pk_ssh_no_auth",
         ]
     }
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_pk_ssh_den_auth",
-            "local_docker_cluster_pk_ssh_no_auth",
+            "docker_cluster_pk_ssh_den_auth",
+            "docker_cluster_pk_ssh_no_auth",
         ]
     }
 
@@ -216,11 +216,11 @@ class TestHTTPServerDockerDenAuthOnly:
     but it is a server without Den Auth enabled at all?
     """
 
-    UNIT = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
-    LOCAL = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
+    UNIT = {"cluster": ["docker_cluster_pk_ssh_den_auth"]}
+    LOCAL = {"cluster": ["docker_cluster_pk_ssh_den_auth"]}
     MINIMAL = {"cluster": []}
-    THOROUGH = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
-    MAXIMAL = {"cluster": ["local_docker_cluster_pk_ssh_den_auth"]}
+    THOROUGH = {"cluster": ["docker_cluster_pk_ssh_den_auth"]}
+    MAXIMAL = {"cluster": ["docker_cluster_pk_ssh_den_auth"]}
 
     # -------- INVALID TOKEN / CLUSTER ACCESS TESTS ----------- #
 
@@ -241,11 +241,24 @@ class TestHTTPServerDockerDenAuthOnly:
 
     @pytest.mark.level("local")
     def test_no_access_to_cluster(self, http_client, cluster):
-        with test_account():
+        # Make sure test account doesn't have access to the cluster (created by logged-in account, Den Tester in CI)
+        cluster.revoke(["info@run.house"])
+        cluster.enable_den_auth()  # Flush auth cache
+
+        import requests
+
+        with test_account():  # Test accounts with Den auth are created under test_account
+            res = requests.get(
+                f"{rns_client.api_server_url}/resource",
+                headers=rns_client.request_headers(),
+            )
+            assert cluster.rns_address not in [
+                config["name"] for config in res.json()["data"]
+            ]
             response = http_client.get("/keys", headers=rns_client.request_headers())
 
-            assert response.status_code == 403
-            assert "Cluster access is required for API" in response.text
+        assert response.status_code == 403
+        assert "Cluster access is required for API" in response.text
 
     @pytest.mark.level("local")
     def test_request_with_no_token(self, http_client):

--- a/tests/test_servers/test_nginx.py
+++ b/tests/test_servers/test_nginx.py
@@ -415,32 +415,32 @@ class TestNginxServerLocally:
 
     UNIT = {
         "cluster": [
-            "local_docker_cluster_pk_http_exposed",
-            "local_docker_cluster_pk_tls_den_auth",
+            "docker_cluster_pk_http_exposed",
+            "docker_cluster_pk_tls_den_auth",
         ]
     }
     LOCAL = {
         "cluster": [
-            "local_docker_cluster_pk_http_exposed",
-            "local_docker_cluster_pk_tls_den_auth",
+            "docker_cluster_pk_http_exposed",
+            "docker_cluster_pk_tls_den_auth",
         ]
     }
     MINIMAL = {
         "cluster": [
-            "local_docker_cluster_pk_http_exposed",
-            "local_docker_cluster_pk_tls_den_auth",
+            "docker_cluster_pk_http_exposed",
+            "docker_cluster_pk_tls_den_auth",
         ]
     }
     THOROUGH = {
         "cluster": [
-            "local_docker_cluster_pk_http_exposed",
-            "local_docker_cluster_pk_tls_den_auth",
+            "docker_cluster_pk_http_exposed",
+            "docker_cluster_pk_tls_den_auth",
         ]
     }
     MAXIMAL = {
         "cluster": [
-            "local_docker_cluster_pk_http_exposed",
-            "local_docker_cluster_pk_tls_den_auth",
+            "docker_cluster_pk_http_exposed",
+            "docker_cluster_pk_tls_den_auth",
         ]
     }
 

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -148,10 +148,10 @@ class TestServlet:
 
     @pytest.mark.skip("Not implemented yet.")
     @pytest.mark.level("unit")
-    def test_call(self, base_servlet, local_docker_cluster_pk_ssh_no_auth):
+    def test_call(self, base_servlet, docker_cluster_pk_ssh_no_auth):
         token_hash = None
         den_auth = False
-        remote_func = rh.function(summer, system=local_docker_cluster_pk_ssh_no_auth)
+        remote_func = rh.function(summer, system=docker_cluster_pk_ssh_no_auth)
 
         method_name = "call"
         module_name = remote_func.name

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -5,8 +5,8 @@ import requests
 
 
 @pytest.mark.level("local")
-def test_public_key_cluster_has_telemetry(local_docker_cluster_pk_ssh_telemetry):
-    cluster = local_docker_cluster_pk_ssh_telemetry
+def test_public_key_cluster_has_telemetry(docker_cluster_pk_ssh_telemetry):
+    cluster = docker_cluster_pk_ssh_telemetry
     cluster.check_server()
     assert cluster.is_up()  # Should be true for a Cluster object
 


### PR DESCRIPTION
1. Make `setup_cluster_config` much simpler, just save down a cluster config without sharing anything. Previously, the test_account was creating the cluster and sharing it with Den Tester, which is incorrect because then we were checking if test_account would be blocked from cluster access. Also, in nearly all other logged-in tests, the Den Tester account creates the cluster and shares with Test Account, so the reverse happening here was confusing.
1. Revert the incorrect resource.revoke that was added before.
1. Rename `local_docker_cluster_...` fixtures to `docker_cluster_...`
1. Prevent configs cache from being writen as ~/.rh/config.yaml if empty
1. Skip local/no docker den_auth tests if no token is set.
1. Increase httpx latency timeout for local_client fixture, Den latency spike was causing failure when auth cache needs to be refreshed (should be addressed separately).

Still TODO (in subsequent PRs):
- [x] Rename test_account fixture to friend_test_account
- [x] Introduce logged_in_test_account fixture
- [ ] Fix all usages of test_account which should really be logged_in_test_account
- [ ] Introduce corrupted_token() and logged_out() test utils to test those behaviors more comprehensively
- [x] Allow rns_client.load_account_from_env to accept .env path so Pycharm testers don't have .env silently missed (and pass runhouse/.env by default)
- [ ] Introduce RH_DISABLE_USAGE_COLLECTION