### PR TITLE
New account testing fixtures

### DIFF
--- a/runhouse/rns/defaults.py
+++ b/runhouse/rns/defaults.py
@@ -40,9 +40,13 @@ class Defaults:
         self._username = None
         self._default_folder = None
         self._defaults_cache = defaultdict(dict)
+        self._simulate_logged_out = False
 
     @property
     def token(self):
+        if self._simulate_logged_out:
+            return None
+
         # This is not to "cache" the token, but rather to allow us to manually override it in python
         if self._token:
             return self._token
@@ -60,6 +64,9 @@ class Defaults:
 
     @property
     def username(self):
+        if self._simulate_logged_out:
+            return None
+
         # This is not to "cache" the username, but rather to allow us to manually override it in python
         if self._username:
             return self._username
@@ -77,6 +84,9 @@ class Defaults:
 
     @property
     def default_folder(self):
+        if self._simulate_logged_out:
+            return self.BASE_DEFAULTS["default_folder"]
+
         # This is not to "cache" the default_folder, but rather to allow us to manually override it in python
         if self._default_folder:
             return self._default_folder
@@ -94,6 +104,9 @@ class Defaults:
 
     @property
     def defaults_cache(self):
+        if self._simulate_logged_out:
+            return {}
+
         if not self._defaults_cache:
             self._defaults_cache = self.load_defaults_from_file()
         return self._defaults_cache
@@ -115,7 +128,7 @@ class Defaults:
     @property
     def request_headers(self):
         """Base request headers used to make requests to Runhouse Den."""
-        return {"Authorization": f"Bearer {self.token}"}
+        return {"Authorization": f"Bearer {self.token}"} if self.token else {}
 
     def upload_defaults(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import enum
 
 import pytest
 
+import runhouse as rh
+
 """
 HOW TO USE FIXTURES IN RUNHOUSE TESTS
 
@@ -141,6 +143,19 @@ def pytest_configure():
 init_args = {}
 
 
+@pytest.fixture(scope="function")
+def logged_in_account():
+    """Helper fixture for tests which require the logged-in test account. Throws an error if the wrong account
+    is logged-in for some reason, and skips the test if the logged in state is not available."""
+    token = rh.globals.configs.token
+    if not token:
+        pytest.skip("`RH_TOKEN` or ~/.rh/config.yaml not set, skipping test.")
+
+    username = rh.globals.configs.username
+    if username and not username == "den_tester":
+        raise ValueError("This test requires the `den_tester` account to be logged in.")
+
+
 # https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files
 
 ############## HELPERS ##############
@@ -157,10 +172,10 @@ from tests.fixtures.docker_cluster_fixtures import (
     docker_cluster_pk_ssh_den_auth,  # noqa: F401
     docker_cluster_pk_ssh_no_auth,  # noqa: F401
     docker_cluster_pk_ssh_telemetry,  # noqa: F401
-    docker_cluster_pk_ssh_test_account_logged_in,  # noqa: F401
     docker_cluster_pk_tls_den_auth,  # noqa: F401
     docker_cluster_pk_tls_exposed,  # noqa: F401
     docker_cluster_pwd_ssh_no_auth,  # noqa: F401
+    friend_account_logged_in_docker_cluster_pk_ssh,  # noqa: F401
     named_cluster,  # noqa: F401
     password_cluster,  # noqa: F401
     shared_cluster,  # noqa: F401

--- a/tests/test_resources/test_modules/test_functions/conftest.py
+++ b/tests/test_resources/test_modules/test_functions/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import runhouse as rh
 
 from tests.conftest import init_args
-from tests.utils import test_account
+from tests.utils import friend_account
 
 
 def summer(a: int, b: int):
@@ -61,7 +61,7 @@ def slow_func(ondemand_cpu_cluster):
 @pytest.fixture(scope="session")
 def shared_function(shared_cluster):
     username_to_share = rh.configs.username
-    with test_account():
+    with friend_account():
         # Create function on shared cluster with the same test account
         f = rh.function(summer).to(shared_cluster, env=["pytest"]).save()
 

--- a/tests/test_resources/test_modules/test_functions/test_aws_lambda/test_lambdas_with_fn.py
+++ b/tests/test_resources/test_modules/test_functions/test_aws_lambda/test_lambdas_with_fn.py
@@ -28,9 +28,9 @@ def test_from_runhouse_func():
 
 def test_share_lambda():
     user = rh.configs.username
-    from tests.utils import test_account
+    from tests.utils import friend_account
 
-    with test_account():
+    with friend_account():
         lambda_func = rh.aws_lambda_fn(fn=summer, name="summer_to_share")
         lambda_func.save()
         lambda_func.share(users=[user], notify_users=False, access_level="write")

--- a/tests/test_resources/test_modules/test_functions/test_function.py
+++ b/tests/test_resources/test_modules/test_functions/test_function.py
@@ -12,7 +12,7 @@ import requests
 import runhouse as rh
 from runhouse.resources.hardware.utils import LOCALHOST, ServerConnectionType
 
-from tests.utils import test_account
+from tests.utils import friend_account
 
 REMOTE_FUNC_NAME = "@/remote_function"
 
@@ -334,7 +334,7 @@ class TestFunction:
             access_level="read",
             notify_users=False,
         )
-        with test_account():
+        with friend_account():
             my_function = rh.function(name=my_function.rns_address)
             res = my_function(1, 2)
             assert res == 3
@@ -342,7 +342,7 @@ class TestFunction:
         my_function.revoke(users=["info@run.house"])
 
         with pytest.raises(Exception):
-            with test_account():
+            with friend_account():
                 my_function = rh.function(name=my_function.rns_address)
                 my_function(1, 2)
 

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -11,7 +11,7 @@ import pytest
 import runhouse as rh
 from runhouse import Package
 
-from tests.utils import test_account
+from tests.utils import friend_account
 
 logger = logging.getLogger(__name__)
 
@@ -654,7 +654,7 @@ class TestModule:
     def test_shared_readonly(
         self,
         ondemand_https_cluster_with_auth,
-        docker_cluster_pk_ssh_test_account_logged_in,
+        friend_account_logged_in_docker_cluster_pk_ssh,
     ):
         if ondemand_https_cluster_with_auth.address == "localhost":
             pytest.skip("Skipping sharing test on local cluster")
@@ -669,7 +669,7 @@ class TestModule:
             notify_users=False,
         )
 
-        with test_account():
+        with friend_account():
             test_load_and_use_readonly_module(
                 mod_name=remote_df.rns_address, cpu_count=2, size=size
             )
@@ -680,7 +680,7 @@ class TestModule:
             )[0][1]
         )
         test_fn = rh.fn(test_load_and_use_readonly_module).to(
-            docker_cluster_pk_ssh_test_account_logged_in
+            friend_account_logged_in_docker_cluster_pk_ssh
         )
         test_fn(mod_name=remote_df.rns_address, cpu_count=cpu_count, size=size)
 

--- a/tests/test_resources/test_resource_sharing.py
+++ b/tests/test_resources/test_resource_sharing.py
@@ -7,7 +7,7 @@ import requests
 import runhouse as rh
 from runhouse.globals import rns_client
 
-from tests.utils import test_account
+from tests.utils import friend_account
 
 
 def call_func_with_curl(ip_address, func_name, token, *args):
@@ -119,7 +119,7 @@ def test_running_func_with_cluster_read_access(shared_cluster, shared_function):
     current_username = rh.configs.username
     current_token = rh.configs.token
 
-    with test_account():
+    with friend_account():
         # Delete user access to the function
         resource_uri = rns_client.resource_uri(shared_function.rns_address)
 
@@ -152,7 +152,7 @@ def test_running_func_with_cluster_write_access(shared_cluster, shared_function)
 
     cluster_uri = rns_client.resource_uri(shared_cluster.rns_address)
 
-    with test_account():
+    with friend_account():
         # Give user write access to cluster from test account
         resp = requests.put(
             f"{rns_client.api_server_url}/resource/{cluster_uri}/users/access",
@@ -195,7 +195,7 @@ def test_running_func_with_no_cluster_access(shared_cluster, shared_function):
     current_username = rh.configs.username
     current_token = rh.configs.token
 
-    with test_account():
+    with friend_account():
         # Delete user access to cluster using the test account
         cluster_uri = rns_client.resource_uri(shared_cluster.rns_address)
         resp = requests.delete(

--- a/tests/test_resources/test_secrets/test_secret.py
+++ b/tests/test_resources/test_secrets/test_secret.py
@@ -10,7 +10,7 @@ from runhouse.globals import rns_client
 
 import tests.test_resources.test_resource
 
-from tests.utils import test_account
+from tests.utils import friend_account
 
 _provider_path_map = {
     "aws": "credentials",
@@ -154,19 +154,19 @@ class TestSecret(tests.test_resources.test_resource.TestResource):
             notify_users=False,
         )
 
-        with test_account():
+        with friend_account():
             reloaded_secret = rh.secret(name=vault_secret.rns_address)
             assert reloaded_secret.values == test_secret.values
 
         vault_secret.revoke(users=["info@run.house"])
         with pytest.raises(Exception):
-            with test_account():
+            with friend_account():
                 rh.secret(name=vault_secret.rns_address)
 
     @pytest.mark.level("local")
     def test_sharing_public_secret(self, test_secret):
         # Create & share
-        with test_account():
+        with friend_account():
             test_headers = rns_client.request_headers()
             vault_secret = rh.secret(name=test_secret.name, values=test_secret.values)
             vault_secret.save(headers=test_headers)

--- a/tests/test_servers/conftest.py
+++ b/tests/test_servers/conftest.py
@@ -11,7 +11,7 @@ import runhouse as rh
 from runhouse.globals import rns_client
 from runhouse.servers.http.http_server import app, HTTPServer
 
-from tests.utils import get_ray_servlet, get_test_obj_store, test_account
+from tests.utils import friend_account, get_ray_servlet, get_test_obj_store
 
 # Note: API Server will run on local docker container
 BASE_URL = "http://localhost:32300"
@@ -57,16 +57,13 @@ def local_client():
 
 
 @pytest.fixture(scope="function")
-def local_client_with_den_auth():
-    if not rh.configs.token:
-        pytest.skip("`TEST_TOKEN` or ~/.rh/config.yaml not set, skipping test.")
-
+def local_client_with_den_auth(logged_in_account):
     from fastapi.testclient import TestClient
 
     HTTPServer()
     HTTPServer.enable_den_auth()
     client = TestClient(app)
-    with test_account():
+    with friend_account():
         client.headers = rns_client.request_headers()
 
     yield client

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -13,7 +13,7 @@ from runhouse.constants import CLUSTER_CONFIG_PATH
 from runhouse.globals import rns_client
 from runhouse.servers.http.http_utils import b64_unpickle, pickle_b64
 
-from tests.utils import test_account
+from tests.utils import friend_account
 
 INVALID_HEADERS = {"Authorization": "Bearer InvalidToken"}
 
@@ -247,7 +247,7 @@ class TestHTTPServerDockerDenAuthOnly:
 
         import requests
 
-        with test_account():  # Test accounts with Den auth are created under test_account
+        with friend_account():  # Test accounts with Den auth are created under test_account
             res = requests.get(
                 f"{rns_client.api_server_url}/resource",
                 headers=rns_client.request_headers(),

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -3,7 +3,7 @@ import pytest
 from runhouse.servers.http.auth import hash_token
 
 from tests.test_servers.conftest import BASE_ENV_ACTOR_NAME
-from tests.utils import get_test_obj_store, test_account
+from tests.utils import friend_account, get_test_obj_store
 
 
 @pytest.mark.servertest
@@ -323,7 +323,7 @@ class TestAuthCacheObjStore:
 
     @pytest.mark.level("unit")
     def test_save_resources_to_obj_store_cache(self, obj_store):
-        with test_account() as test_account_dict:
+        with friend_account() as test_account_dict:
             token = test_account_dict["token"]
             hashed_token = hash_token(token)
 
@@ -345,7 +345,7 @@ class TestAuthCacheObjStore:
 
     @pytest.mark.level("unit")
     def test_no_resource_access_for_invalid_token(self, obj_store):
-        with test_account() as test_account_dict:
+        with friend_account() as test_account_dict:
             token = "abc"
             resource_uri = f"/{test_account_dict['username']}/summer"
             access_level = obj_store.resource_access_level(

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -9,7 +9,7 @@ from runhouse.servers.http.http_server import HTTPServer
 from runhouse.servers.http.http_utils import b64_unpickle, Message, pickle_b64
 
 from tests.test_servers.conftest import summer
-from tests.utils import test_account
+from tests.utils import friend_account
 
 
 @pytest.mark.servertest
@@ -177,7 +177,7 @@ class TestServlet:
     @pytest.mark.skip("Not implemented yet.")
     @pytest.mark.level("unit")
     def test_call_with_den_auth(self, base_servlet):
-        with test_account() as test_account_dict:
+        with friend_account() as test_account_dict:
             token_hash = hash_token(test_account_dict["token"])
             den_auth = True
             remote_func = rh.function(summer).save()
@@ -207,7 +207,7 @@ class TestServlet:
     @pytest.mark.skip("Not implemented yet.")
     @pytest.mark.level("unit")
     def test_call_module_method_(self, base_servlet):
-        with test_account():
+        with friend_account():
             token_hash = None
             den_auth = False
             remote_func = rh.function(summer).save()
@@ -229,7 +229,7 @@ class TestServlet:
     @pytest.mark.skip("Not implemented yet.")
     @pytest.mark.level("unit")
     def test_call_module_method_with_den_auth(self, base_servlet):
-        with test_account() as test_account_dict:
+        with friend_account() as test_account_dict:
             token_hash = hash_token(test_account_dict["token"])
             den_auth = True
             remote_func = rh.function(summer).save()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,7 +39,7 @@ def get_test_obj_store(env_servlet_name: str):
 
 
 @contextlib.contextmanager
-def test_account():
+def friend_account():
     """Used for the purposes of testing resource sharing among different accounts.
     When inside the context manager, use the test account credentials before reverting back to the original
     account when exiting."""
@@ -61,3 +61,28 @@ def test_account():
 
     finally:
         rns_client.load_account_from_file()
+
+
+@contextlib.contextmanager
+def logged_out():
+    """Used for the purposes of testing methods as if we're logged out.
+    When inside the context manager, token, username, and configs will all be None, as if logged out."""
+
+    rns_client._current_folder = None
+    rns_client._configs._simulate_logged_out = True
+
+    yield account
+
+    rns_client._configs._simulate_logged_out = False
+
+
+@contextlib.contextmanager
+def invalid_friend_account():
+    """Used for the purposes of testing methods as if we have invalid token.
+    When inside the context manager, the friend account role will be assumed, but the token will be set to junk."""
+
+    with friend_account() as friend_account_dict:
+        friend_account_dict["token"] = "junk"
+        rns_client._configs.token = "junk"
+
+        yield friend_account_dict


### PR DESCRIPTION
1. Rename test_account to friend_account to clarify that this account should always be
the sharee of resources in tests, not the primary sharer.
2. Add a logged_in_account fixture to make it easy to skip a test if not logged in, and also
ensure that the den_tester account is logged in as needed.
3. Add logged_out context manager for situations where we want to test behavior as if logged out.