### PR TITLE
Introduce proper env-var based token behavior

### DIFF
--- a/runhouse/rns/defaults.py
+++ b/runhouse/rns/defaults.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+import os
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -35,7 +36,61 @@ class Defaults:
     }
 
     def __init__(self):
+        self._token = None
+        self._username = None
+        self._default_folder = None
         self._defaults_cache = defaultdict(dict)
+
+    @property
+    def token(self):
+        # This is not to "cache" the token, but rather to allow us to manually override it in python
+        if self._token:
+            return self._token
+        if os.environ.get("RH_TOKEN"):
+            self._token = os.environ.get("RH_TOKEN")
+            return self._token
+        if "token" in self.defaults_cache:
+            self._token = self.defaults_cache["token"]
+            return self._token
+        return None
+
+    @token.setter
+    def token(self, value):
+        self._token = value
+
+    @property
+    def username(self):
+        # This is not to "cache" the username, but rather to allow us to manually override it in python
+        if self._username:
+            return self._username
+        if os.environ.get("RH_USERNAME"):
+            self._username = os.environ.get("RH_USERNAME")
+            return self._username
+        if "username" in self.defaults_cache:
+            self._username = self.defaults_cache["username"]
+            return self._username
+        return None
+
+    @username.setter
+    def username(self, value):
+        self._username = value
+
+    @property
+    def default_folder(self):
+        # This is not to "cache" the default_folder, but rather to allow us to manually override it in python
+        if self._default_folder:
+            return self._default_folder
+        if "default_folder" in self.defaults_cache:
+            self._default_folder = self.defaults_cache["default_folder"]
+            return self._default_folder
+        if self.username:
+            self._default_folder = "/" + self.username
+            return self._default_folder
+        return self.BASE_DEFAULTS["default_folder"]
+
+    @default_folder.setter
+    def default_folder(self, value):
+        self._default_folder = value
 
     @property
     def defaults_cache(self):

--- a/runhouse/rns/login.py
+++ b/runhouse/rns/login.py
@@ -112,6 +112,8 @@ def login(
         )
 
     if token:
+        # Note, this is to explicitly add it to the config file, as opposed to setting in python
+        # via configs.token = token
         configs.set("token", token)
 
     if download_config:
@@ -311,6 +313,15 @@ def logout(
     configs.delete(key="token")
     configs.delete(key="username")
     configs.delete(key="default_folder")
+
+    # Delete values in configs object
+    configs.token = None
+    configs.username = None
+    configs.default_folder = None
+
+    # Wipe env vars
+    os.environ.pop("RH_TOKEN", None)
+    os.environ.pop("RH_USERNAME", None)
 
     rh_config_path = configs.CONFIG_PATH
     if not delete_rh_config_file and interactive_session:

--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -130,17 +130,11 @@ class RNSClient:
 
     @property
     def default_folder(self):
-        folder = self._configs.get("default_folder")
-        if folder in [None, "~"] and self._configs.get("username"):
-            folder = "/" + self._configs.get("username")
-            self._configs.set("default_folder", folder)
-        return folder
+        return self._configs.default_folder
 
     @property
     def current_folder(self):
-        if not self._current_folder:
-            self._current_folder = self.default_folder
-        return self._current_folder
+        return self._current_folder if self._current_folder else self.default_folder
 
     @current_folder.setter
     def current_folder(self, value):
@@ -148,7 +142,7 @@ class RNSClient:
 
     @property
     def token(self):
-        return self._configs.get("token", None)
+        return self._configs.token
 
     @property
     def api_server_url(self):
@@ -198,28 +192,28 @@ class RNSClient:
         payload["data"] = data
         return payload
 
-    def load_account_from_env(self) -> Dict[str, str]:
+    def load_account_from_env(
+        self, token_env_var="RH_TOKEN", usr_env_var="RH_USERNAME"
+    ) -> Dict[str, str]:
         dotenv.load_dotenv()
 
-        test_token = os.getenv("TEST_TOKEN")
-        test_username = os.getenv("TEST_USERNAME")
+        test_token = os.getenv(token_env_var)
+        test_username = os.getenv(usr_env_var)
         if not (test_token and test_username):
             return None
 
-        # Hack to avoid actually writing down these values, in case the user stops mid-test and we don't reach the
-        # finally block
-        self._configs.defaults_cache["token"] = test_token
-        self._configs.defaults_cache["username"] = test_username
-        self._configs.defaults_cache["default_folder"] = f"/{test_username}"
+        self._configs.token = test_token
+        self._configs.username = test_username
+        self._configs.default_folder = f"/{test_username}"
 
         # The client caches the folder that is used as the current folder variable, we clear this so it loads the new
         # folder when we switch accounts
         self._current_folder = None
 
         return {
-            "token": self._configs.defaults_cache["token"],
-            "username": self._configs.defaults_cache["username"],
-            "default_folder": self._configs.defaults_cache["default_folder"],
+            "token": self._configs.token,
+            "username": self._configs.username,
+            "default_folder": self._configs.default_folder,
         }
 
     def load_account_from_file(self) -> None:

--- a/tests/test_servers/conftest.py
+++ b/tests/test_servers/conftest.py
@@ -58,7 +58,7 @@ def local_client():
 
 @pytest.fixture(scope="function")
 def local_client_with_den_auth():
-    if not rh.configs.get("token"):
+    if not rh.configs.token:
         pytest.skip("`TEST_TOKEN` or ~/.rh/config.yaml not set, skipping test.")
 
     from fastapi.testclient import TestClient

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,7 +43,9 @@ def test_account():
     account when exiting."""
 
     try:
-        account = rns_client.load_account_from_env()
+        account = rns_client.load_account_from_env(
+            token_env_var="TEST_TOKEN", usr_env_var="TEST_USERNAME"
+        )
         if account is None:
             pytest.skip("`TEST_TOKEN` or `TEST_USERNAME` not set, skipping test.")
         yield account


### PR DESCRIPTION
1. Allow token and username to be set in RH_TOKEN and RH_USERNAME env vars
2. Fix bug where tokens being set in env vars or directly in python are being written to config file
3. Fix TEST_ACCOUNT token setting behavior to flow through new rh.configs.token flow

Reattempting to merge https://github.com/run-house/runhouse/pull/318