### PR TITLE
Use unique temp resource name when saving to Den in tests

### DIFF
--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -82,7 +82,7 @@ class ProviderSecret(Secret):
     def save(
         self, name: str = None, save_values: bool = True, headers: Optional[Dict] = None
     ):
-        name = name or self.name or self.provider
+        name = name or self.rns_address or self.provider
         return super().save(name=name, save_values=save_values, headers=headers)
 
     def delete(self, headers: Optional[Dict] = None, contents: bool = False):

--- a/runhouse/resources/secrets/provider_secrets/sky_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/sky_secret.py
@@ -29,5 +29,6 @@ class SkySecret(SSHSecret):
             name=name, provider=provider, values=values, path=path, dryrun=dryrun
         )
 
+    @staticmethod
     def from_config(config: dict, dryrun: bool = False):
         return SkySecret(**config, dryrun=dryrun)

--- a/runhouse/resources/secrets/provider_secrets/ssh_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/ssh_secret.py
@@ -54,7 +54,7 @@ class SSHSecret(ProviderSecret):
             self.name = name
         elif not self.name:
             self.name = f"ssh-{self.key}"
-        super().save(
+        return super().save(
             save_values=save_values, headers=headers or rns_client.request_headers()
         )
 

--- a/runhouse/servers/http/auth.py
+++ b/runhouse/servers/http/auth.py
@@ -67,7 +67,12 @@ def verify_cluster_access(
 ) -> bool:
     """Checks whether the user has access to the cluster.
     Note: If user has write access to the cluster, will have access to all other resources on the cluster by default."""
-    from runhouse.globals import obj_store
+    from runhouse.globals import configs, obj_store
+
+    # The logged-in user always has full access to the cluster. This is especially important if they flip on
+    # Den Auth without saving the cluster.
+    if configs.token == token:
+        return True
 
     token_hash = hash_token(token)
 

--- a/tests/test_resources/conftest.py
+++ b/tests/test_resources/conftest.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from runhouse.resources.resource import Resource
@@ -14,6 +16,46 @@ RESOURCE_NAME = "my_resource"
 @pytest.fixture(scope="function")
 def resource(request):
     return request.getfixturevalue(request.param)
+
+
+@pytest.fixture(scope="session")
+def saved_resource_pool():
+    try:
+        pool = {}
+        yield pool
+    finally:
+        for res in pool.values():
+            # Wrap in another try/except block so we can clean up as much as possible
+            try:
+                res.delete_configs()
+            except Exception:
+                pass
+
+
+@pytest.fixture(scope="session")
+def test_rns_folder():
+    return f"testing-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+
+
+@pytest.fixture(scope="function")
+def saved_resource(resource, saved_resource_pool, test_rns_folder):
+    if not resource.name:
+        pytest.skip("Resource must have a name to be saved")
+
+    if resource.name not in saved_resource_pool:
+        # Create a variant of the resource under a different name so we don't conflict with other tests or
+        # or other runs of the test.
+        resource_copy = resource.from_config(
+            config=resource.config_for_rns, dryrun=True
+        )
+        if resource.rns_address[:2] != "~/":
+            # No need to vary the name for local resources
+            # Put resource copies in a folder together so it's easier to clean up
+            resource_copy.name = (
+                f"{resource._rns_folder}/{test_rns_folder}/{resource.name}"
+            )
+        saved_resource_pool[resource.name] = resource_copy.save()
+    return saved_resource_pool[resource.name]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_resources/test_envs/conftest.py
+++ b/tests/test_resources/test_envs/conftest.py
@@ -65,10 +65,11 @@ def conda_env_from_path():
 @pytest.fixture(scope="session")
 def _local_conda_env():
     env_name = "test_conda_local_env"
-    os.system(f"conda create -n {env_name} -y python==3.10.9")
-    yield
-
-    os.system(f"conda env remove -n {env_name} -y")
+    try:
+        os.system(f"conda create -n {env_name} -y python==3.10.9")
+        yield
+    finally:
+        os.system(f"conda env remove -n {env_name} -y")
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -469,7 +469,7 @@ class TestModule:
         # TODO: ask Josh for advice how to share it with a new user each time.
         users = ["josh@run.house"]
         remote_calc = rh.module(Calculator).to(cluster).save(name="rh_remote_calc")
-        added_users, new_users = remote_calc.share(
+        added_users, new_users, _ = remote_calc.share(
             users=users, notify_users=False, access_level="write"
         )
         assert remote_calc.name == "rh_remote_calc"


### PR DESCRIPTION
Various tests were becoming flaky due to CI running them in parallel and global Den saving/deleting behavior
colliding. This change gives each test run a unique folder in RNS for a "saved_resource" fixture, which also
cleans up the saved configs after testing completes. It also speeds up tests by not recreating
and deleting resources over and over.