### PR TITLE
Get rh.here to work.

### DIFF
--- a/runhouse/__init__.py
+++ b/runhouse/__init__.py
@@ -8,7 +8,6 @@ from runhouse.resources.functions.aws_lambda_factory import aws_lambda_fn
 from runhouse.resources.functions.function import Function
 from runhouse.resources.functions.function_factory import function
 from runhouse.resources.hardware import (
-    _current_cluster,
     cluster,
     Cluster,
     kubernetes_cluster,
@@ -33,7 +32,7 @@ from runhouse.rns.secrets import Secrets  # Deprecated
 from runhouse.rns.top_level_rns_fns import (
     current_folder,
     exists,
-    here,
+    get_local_cluster_object,
     ipython,
     load,
     locate,
@@ -51,5 +50,18 @@ send = function
 
 # Syntactic sugar
 fn = function
+
+_rh_here_stored = None
+
+
+def __getattr__(name):
+    global _rh_here_stored
+    if name == "here":
+        if _rh_here_stored is None:
+            _rh_here_stored = get_local_cluster_object()
+        return _rh_here_stored
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __version__ = "0.0.16"

--- a/runhouse/resources/folders/folder.py
+++ b/runhouse/resources/folders/folder.py
@@ -463,7 +463,9 @@ class Folder(Resource):
         dest_folder.path = dest_path
         dest_folder.system = dest_cluster
 
-        if self._fs_str == "file":  # Includes case where we're on the cluster
+        if self._fs_str == "file" and dest_cluster.name is not None:
+            # Includes case where we're on the cluster itself
+            # And the destination is a cluster, not rh.here
             dest_cluster._rsync(
                 source=self.path, dest=dest_path, up=True, contents=True
             )

--- a/runhouse/resources/hardware/__init__.py
+++ b/runhouse/resources/hardware/__init__.py
@@ -7,4 +7,9 @@ from .cluster_factory import (
 )
 from .on_demand_cluster import OnDemandCluster
 from .sagemaker_cluster import SageMakerCluster
-from .utils import _current_cluster, _get_cluster_from, _load_cluster_config_from_file
+from .utils import (
+    _current_cluster,
+    _get_cluster_from,
+    cluster_config_file_exists,
+    load_cluster_config_from_file,
+)

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -69,7 +69,8 @@ class Cluster(Resource):
 
     def __init__(
         self,
-        name,
+        # Name will almost always be provided unless a "local" cluster is created
+        name: Optional[str] = None,
         ips: List[str] = None,
         ssh_creds: Dict = None,
         server_host: str = None,
@@ -432,7 +433,8 @@ class Cluster(Resource):
 
     def on_this_cluster(self):
         """Whether this function is being called on the same cluster."""
-        return _current_cluster("name") == self.rns_address
+        config = _current_cluster("config")
+        return config is not None and config.get("name") == self.rns_address
 
     # ----------------- RPC Methods ----------------- #
 

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -88,8 +88,12 @@ class ServerConnectionType(str, Enum):
     AWS_SSM = "aws_ssm"
 
 
-def _load_cluster_config_from_file() -> Dict:
-    if Path(CLUSTER_CONFIG_PATH).expanduser().exists():
+def cluster_config_file_exists() -> bool:
+    return Path(CLUSTER_CONFIG_PATH).expanduser().exists()
+
+
+def load_cluster_config_from_file() -> Dict:
+    if cluster_config_file_exists():
         with open(Path(CLUSTER_CONFIG_PATH).expanduser()) as f:
             cluster_config = json.load(f)
         return cluster_config

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -2,9 +2,14 @@ import logging
 import sys
 from typing import List
 
-from runhouse.globals import configs, rns_client
+import ray
+from ray.experimental.state.api import list_actors
+
+from runhouse.globals import configs, obj_store, rns_client
 
 from runhouse.logger import LOGGING_CONFIG
+
+from runhouse.resources.hardware.utils import _get_cluster_from
 
 # Configure the logger once
 logging.config.dictConfig(LOGGING_CONFIG)
@@ -61,20 +66,46 @@ def load(name: str, instantiate: bool = True, dryrun: bool = False):
         )
 
 
-# This funny structure lets us use `rh.here` to get the current cluster
-def __getattr__(name):
-    if name == "here":
-        from runhouse.resources.hardware.utils import (
-            _current_cluster,
-            _get_cluster_from,
-        )
+def get_local_cluster_object():
+    # The cluster servlet is running if `runhouse start` has been run on this machine
+    # we check this using list_actors
 
-        config = _current_cluster(key="config")
-        if not config:
-            return "file"
-        system = _get_cluster_from(config, dryrun=True)
-        return system
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+    # This is likely being called from a different process than our HTTPServer
+    # so we need to not initialize a new Ray instance, and rather connect
+    # to the existing one
+
+    # By specifying address, we attempt to connect to an existing Ray
+    # cluster instead of creating a new one
+    try:
+        ray.init(
+            address="auto",
+            ignore_reinit_error=True,
+            logging_level=logging.ERROR,
+            namespace="runhouse",
+        )
+    except ConnectionError:
+        logging.warning(
+            "Could not connect to Ray cluster. Make sure you have run `runhouse start`"
+        )
+        return "file"
+
+    cluster_servlet_exists = any(
+        actor["class_name"] == "ClusterServlet" and actor["state"] == "ALIVE"
+        for actor in list_actors()
+    )
+
+    if cluster_servlet_exists:
+        # The base EnvServlet should have been created in the HTTPServer
+        obj_store.initialize("base")
+
+        # When HTTPServer is initialized, the cluster_config is set
+        # within the global state.
+        config = obj_store.get_cluster_config()
+        if config.get("resource_subtype") is not None:
+            system = _get_cluster_from(config, dryrun=True)
+            return system
+
+    return "file"
 
 
 def set_save_to(save_to: List[str]):

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -1,8 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Set, Union
 
-from runhouse.resources.hardware import _load_cluster_config_from_file
-
+from runhouse.resources.hardware import load_cluster_config_from_file
 from runhouse.servers.http.auth import AuthCache
 
 logger = logging.getLogger(__name__)
@@ -12,13 +11,16 @@ class ClusterServlet:
     def __init__(
         self, cluster_config: Optional[Dict[str, Any]] = None, *args, **kwargs
     ):
-        self.cluster_config: Optional[Dict[str, Any]] = cluster_config
-        local_cluster_config = _load_cluster_config_from_file()
-        if local_cluster_config:
-            self.cluster_config = local_cluster_config
-        else:
-            self.cluster_config = {}
 
+        # We do this here instead of at the start of the HTTP Server startup
+        # because someone can be running `HTTPServer()` standalone in a test
+        # and still want an initialized cluster config in the servlet.
+        if not cluster_config:
+            cluster_config = load_cluster_config_from_file()
+
+        self.cluster_config: Optional[Dict[str, Any]] = (
+            cluster_config if cluster_config else {}
+        )
         self._initialized_env_servlet_names: Set[str] = set()
         self._key_to_env_servlet_name: Dict[Any, str] = {}
         self._auth_cache: AuthCache = AuthCache()

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -81,7 +81,9 @@ class ObjStore:
         self._kv_store: Dict[Any, Any] = None
 
     def initialize(
-        self, servlet_name: Optional[str] = None, has_local_storage: bool = False
+        self,
+        servlet_name: Optional[str] = None,
+        has_local_storage: bool = False,
     ):
         # The initialization of the obj_store needs to be in a separate method
         # so the HTTPServer actually initalizes the obj_store,


### PR DESCRIPTION
Interacting with `rh.here` is important, like the following example
```
import runhouse as rh
rh.here.get(...)
# Other things interacting with `rh.here`
```

 This should work in the following cases:
1. `runhouse start` was run locally, and from a different Python process a user runs the code
2. On a cluster that was started remotely via `rh.cluster` or `rh.ondemand_cluster`


Working to include tests for interacting with it as well.