### PR TITLE
Undeprecate ips argument to cluster

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -725,7 +725,7 @@ class Cluster(Resource):
         logger.info(f"Restarting Runhouse API server on {self.name}.")
 
         if resync_rh:
-            self._sync_runhouse_to_cluster(_install_url=_rh_install_url, node="all")
+            self._sync_runhouse_to_cluster(_install_url=_rh_install_url)
             logger.info("Finished syncing Runhouse to cluster.")
 
         # Update the cluster config on the cluster

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -70,10 +70,9 @@ def cluster(
         >>> # Load cluster from above
         >>> reloaded_cluster = rh.cluster(name="rh-a10x")
     """
-    if "ips" in kwargs:
-        host = kwargs["ips"]
-        warnings.warn(
-            "``ips`` argument has been deprecated. Please use ``host`` to refer to the cluster IPs or host instead."
+    if host and kwargs.get("ips"):
+        raise ValueError(
+            "Cluster factory method can only accept one of `host` or `ips` as an argument."
         )
 
     if name and all(
@@ -172,7 +171,7 @@ def cluster(
         host = [host]
 
     c = Cluster(
-        ips=host,
+        ips=kwargs.pop("ips", None) or host,
         ssh_creds=ssh_creds,
         name=name,
         server_host=server_host,


### PR DESCRIPTION
Now that we restart the ray nodes, we can support passing ips. Our tutorials were breaking because ips wasn't supported. Also, we no longer need to rsync runhouse to each node, because rsync sends to all nodes by default, so remove that too.