### PR TITLE
Overhaul put_resource logic.

### DIFF
--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -1,4 +1,5 @@
 import codecs
+import json
 import logging
 import re
 import sys
@@ -26,6 +27,12 @@ class ServerSettings(BaseModel):
     flush_auth_cache: Optional[bool] = None
 
 
+class PutResourceParams(BaseModel):
+    serialized_data: Any
+    serialization: Optional[str] = None
+    env_name: Optional[str] = None
+
+
 class Args(BaseModel):
     args: Optional[List[Any]]
     kwargs: Optional[Dict[str, Any]]
@@ -36,6 +43,7 @@ class Response(BaseModel):
     error: Optional[str] = None
     traceback: Optional[str] = None
     output_type: str
+    serialization: Optional[str] = None
 
 
 class OutputType:
@@ -48,6 +56,7 @@ class OutputType:
     RESULT = "result"
     RESULT_LIST = "result_list"
     RESULT_STREAM = "result_stream"
+    RESULT_SERIALIZED = "result_serialized"
     SUCCESS_STREAM = "success_stream"  # No output, but with generators
     CONFIG = "config"
 
@@ -58,6 +67,30 @@ def pickle_b64(picklable):
 
 def b64_unpickle(b64_pickled):
     return pickle.loads(codecs.decode(b64_pickled.encode(), "base64"))
+
+
+def deserialize_data(data: Any, serialization: Optional[str]):
+    if data is None:
+        return None
+
+    if serialization == "json":
+        return json.loads(data)
+    elif serialization == "pickle":
+        return b64_unpickle(data)
+    else:
+        return data
+
+
+def serialize_data(data: Any, serialization: Optional[str]):
+    if data is None:
+        return None
+
+    if serialization == "json":
+        return json.dumps(data)
+    elif serialization == "pickle":
+        return pickle_b64(data)
+    else:
+        return data
 
 
 def get_token_from_request(request):
@@ -73,6 +106,8 @@ def load_current_cluster():
 
 
 def handle_response(response_data, output_type, err_str):
+    if output_type == OutputType.RESULT_SERIALIZED:
+        return deserialize_data(response_data["data"], response_data["serialization"])
     if output_type in [OutputType.RESULT, OutputType.RESULT_STREAM]:
         return b64_unpickle(response_data["data"])
     elif output_type == OutputType.CONFIG:

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -7,6 +7,7 @@ import runhouse as rh
 from runhouse.servers.http.auth import hash_token
 from runhouse.servers.http.http_server import HTTPServer
 from runhouse.servers.http.http_utils import b64_unpickle, Message, pickle_b64
+from runhouse.servers.obj_store import ObjStore
 
 from tests.test_servers.conftest import summer
 from tests.utils import friend_account
@@ -22,14 +23,14 @@ class TestServlet:
             resource = local_blob.to(system="file", path=resource_path)
 
             state = {}
-            message = Message(
+            resp = ObjStore.call_actor_method(
+                test_servlet,
+                "put_resource_local",
                 data=pickle_b64((resource.config_for_rns, state, resource.dryrun)),
-            )
-            resp = HTTPServer.call_servlet_method(
-                test_servlet, "put_resource", [message]
+                serialization="pickle",
             )
 
-            assert resp.output_type == "result"
+            assert resp.output_type == "result_serialized"
             assert b64_unpickle(resp.data).startswith("file_")
 
     @pytest.mark.level("unit")


### PR DESCRIPTION
Introduce a generic format and precedence for calls into `EnvServlet`.

All functions will take in `data` and `serialization`. They can put whatever
they want in the `data` field and unpack them as tuples before and after, as
done in this PR. This will support pickle and json serialization.

The other parameters to `EnvServlet` functions will be explicit.

The `EnvServlet` should also only call `local` ObjStore functions, and the
ObjStore should deal with all the outside-of-env logic and call the right Env.
