### PR TITLE
Overhaul `rename_object` logic to new format.

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -18,6 +18,7 @@ from runhouse.servers.http.http_utils import (
     pickle_b64,
     PutObjectParams,
     PutResourceParams,
+    RenameObjectParams,
 )
 
 logger = logging.getLogger(__name__)
@@ -381,11 +382,10 @@ class HTTPClient:
         return self.rename_object(old_key, new_key)
 
     def rename_object(self, old_key, new_key):
-        self.request(
-            "object",
-            req_type="put",
-            data=pickle_b64((old_key, new_key)),
-            key=old_key,
+        self.request_json(
+            "rename",
+            req_type="post",
+            json_dict=RenameObjectParams(key=old_key, new_key=new_key).dict(),
             err_str=f"Error renaming object {old_key}",
         )
 

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -32,6 +32,7 @@ from runhouse.servers.http.http_utils import (
     pickle_b64,
     PutObjectParams,
     PutResourceParams,
+    RenameObjectParams,
     Response,
     ServerSettings,
 )
@@ -535,12 +536,17 @@ class HTTPServer:
             return handle_exception_response(e, traceback.format_exc())
 
     @staticmethod
-    @app.put("/object")
+    @app.post("/rename")
     @validate_cluster_access
-    def rename_object(request: Request, message: Message):
-        return HTTPServer.call_in_env_servlet(
-            "rename_object", [message], env=message.env, lookup_env_for_name=message.key
-        )
+    def rename_object(request: Request, params: RenameObjectParams):
+        try:
+            obj_store.rename(
+                old_key=params.key,
+                new_key=params.new_key,
+            )
+            return Response(output_type=OutputType.SUCCESS)
+        except Exception as e:
+            return handle_exception_response(e, traceback.format_exc())
 
     @staticmethod
     @app.delete("/object")

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -40,6 +40,11 @@ class PutObjectParams(BaseModel):
     env_name: Optional[str] = None
 
 
+class RenameObjectParams(BaseModel):
+    key: str
+    new_key: str
+
+
 class Args(BaseModel):
     args: Optional[List[Any]]
     kwargs: Optional[Dict[str, Any]]

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -13,6 +13,7 @@ from runhouse.servers.http.http_utils import (
     pickle_b64,
     PutObjectParams,
     PutResourceParams,
+    RenameObjectParams,
 )
 
 from tests.utils import friend_account
@@ -92,9 +93,10 @@ class TestHTTPServerDocker:
     def test_rename_object(self, http_client):
         old_key = "key1"
         new_key = "key2"
-        data = pickle_b64((old_key, new_key))
-        response = http_client.put(
-            "/object", json={"data": data}, headers=rns_client.request_headers()
+        response = http_client.post(
+            "/rename",
+            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            headers=rns_client.request_headers(),
         )
         assert response.status_code == 200
 
@@ -328,9 +330,10 @@ class TestHTTPServerDockerDenAuthOnly:
     def test_rename_object_with_invalid_token(self, http_client):
         old_key = "key1"
         new_key = "key2"
-        data = pickle_b64((old_key, new_key))
-        response = http_client.put(
-            "/object", json={"data": data}, headers=INVALID_HEADERS
+        response = http_client.post(
+            "/rename",
+            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            headers=INVALID_HEADERS,
         )
         assert response.status_code == 403
         assert "Cluster access is required for API" in response.text
@@ -443,10 +446,9 @@ class TestHTTPServerNoDocker:
     def test_rename_object(self, client):
         old_key = "key1"
         new_key = "key2"
-        data = pickle_b64((old_key, new_key))
-        response = client.put(
-            "/object",
-            json={"data": data},
+        response = client.post(
+            "/rename",
+            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
             headers=rns_client.request_headers(),
         )
         assert response.status_code == 200
@@ -557,9 +559,10 @@ class TestHTTPServerNoDockerDenAuthOnly:
     def test_rename_object_with_invalid_token(self, local_client_with_den_auth):
         old_key = "key1"
         new_key = "key2"
-        data = pickle_b64((old_key, new_key))
-        resp = local_client_with_den_auth.put(
-            "/object", json={"data": data}, headers=INVALID_HEADERS
+        resp = local_client_with_den_auth.post(
+            "/rename",
+            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            headers=INVALID_HEADERS,
         )
         assert resp.status_code == 403
 

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -115,27 +115,18 @@ class TestServlet:
         assert isinstance(b64_unpickle(resp.error), KeyError)
 
     @pytest.mark.level("unit")
-    def test_rename_object(self, test_servlet):
-        message = Message(data=pickle_b64(("key1", "key2")))
-        resp = HTTPServer.call_servlet_method(test_servlet, "rename_object", [message])
-        assert resp.output_type == "success"
-
-        keys = ObjStore.call_actor_method(test_servlet, "keys_local")
-        assert "key2" in keys
-
-    @pytest.mark.level("unit")
     def test_delete_obj(self, test_servlet):
         remote = False
-        keys = ["key2"]
+        keys = ["key1"]
         message = Message(data=pickle_b64((keys)))
         resp = HTTPServer.call_servlet_method(test_servlet, "delete_obj", [message])
         assert resp.output_type == "result"
-        assert b64_unpickle(resp.data) == ["key2"]
+        assert b64_unpickle(resp.data) == ["key1"]
 
         resp = HTTPServer.call_servlet_method(
             test_servlet,
             "get",
-            ["key2", remote, True],
+            ["key1", remote, True],
         )
         assert resp.output_type == "exception"
         assert isinstance(b64_unpickle(resp.error), KeyError)


### PR DESCRIPTION
Change rename_object to new format, turns out for this one we don't even need
to have any logic in the servlet. The obj store abstracts this all away. 

I get rid of the only `put` request and instead make this a `post` to `/rename`
for more consistency.
