### PR TITLE
Refactor function notebook

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -1229,6 +1229,10 @@ class Cluster(Resource):
         Example:
             >>> rh.cluster("test-cluster").notebook()
         """
+        # Roughly trying to follow:
+        # https://towardsdatascience.com/using-jupyter-notebook-running-on-a-remote-docker-container-via-ssh-ea2c3ebb9055
+        # https://docs.ray.io/en/latest/ray-core/using-ray-with-jupyter.html
+
         tunnel = self.ssh_tunnel(
             local_port=port_forward,
             num_ports_to_try=10,


### PR DESCRIPTION
small bug in function's .notebook() following ssh_tunnel return type refactor. also duplicate code with system.notebook() so just use it directly

