### PR TITLE
Overhaul `delete_object` logic.

### DIFF
--- a/runhouse/servers/env_servlet.py
+++ b/runhouse/servers/env_servlet.py
@@ -7,7 +7,7 @@ import threading
 import time
 import traceback
 from functools import wraps
-from typing import Any, List, Optional, Union
+from typing import Any, Optional
 
 from sky.skylet.autostop_lib import set_last_active_time_to_now
 
@@ -453,29 +453,6 @@ class EnvServlet:
                 traceback=pickle_b64(traceback.format_exc())
                 if not serialization == "json"
                 else str(traceback.format_exc()),
-                output_type=OutputType.EXCEPTION,
-            )
-
-    def delete_obj(self, message: Union[Message, List], _intra_cluster=False):
-        self.register_activity()
-        keys = b64_unpickle(message.data) if not _intra_cluster else message
-        logger.info(f"Message received from client to delete keys: {keys or 'all'}")
-        try:
-            cleared = []
-            if keys:
-                for pin in keys:
-                    obj_store.delete(pin)
-                    cleared.append(pin)
-            else:
-                cleared = list(obj_store.keys())
-                obj_store.clear()
-            return Response(data=pickle_b64(cleared), output_type=OutputType.RESULT)
-        except Exception as e:
-            logger.exception(e)
-            self.register_activity()
-            return Response(
-                error=pickle_b64(e),
-                traceback=pickle_b64(traceback.format_exc()),
                 output_type=OutputType.EXCEPTION,
             )
 

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -13,6 +13,7 @@ from runhouse.resources.envs.utils import _get_env_from
 
 from runhouse.resources.resource import Resource
 from runhouse.servers.http.http_utils import (
+    DeleteObjectParams,
     handle_response,
     OutputType,
     pickle_b64,
@@ -403,11 +404,10 @@ class HTTPClient:
         return res
 
     def delete(self, keys=None, env=None):
-        return self.request(
-            "object",
-            req_type="delete",
-            data=pickle_b64((keys or [])),
-            env=env,
+        return self.request_json(
+            "delete_object",
+            req_type="post",
+            json_dict=DeleteObjectParams(keys=keys or []).dict(),
             err_str=f"Error deleting keys {keys}",
         )
 

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -45,6 +45,10 @@ class RenameObjectParams(BaseModel):
     new_key: str
 
 
+class DeleteObjectParams(BaseModel):
+    keys: List[str]
+
+
 class Args(BaseModel):
     args: Optional[List[Any]]
     kwargs: Optional[Dict[str, Any]]

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -9,7 +9,11 @@ import runhouse as rh
 from runhouse.globals import rns_client
 
 from runhouse.servers.http import HTTPClient
-from runhouse.servers.http.http_utils import pickle_b64, PutObjectParams
+from runhouse.servers.http.http_utils import (
+    DeleteObjectParams,
+    pickle_b64,
+    PutObjectParams,
+)
 
 
 @pytest.mark.servertest
@@ -298,23 +302,21 @@ class TestHTTPClient:
         mock_request.assert_called_with(f"keys/?env_name={test_env}", req_type="get")
 
     @pytest.mark.level("unit")
-    @patch("runhouse.servers.http.HTTPClient.request")
+    @patch("runhouse.servers.http.HTTPClient.request_json")
     def test_delete(self, mock_request):
         keys = ["key1", "key2"]
-        expected_data = pickle_b64(keys)
 
         self.client.delete(keys=keys)
 
         mock_request.assert_called_once_with(
-            "object",
-            req_type="delete",
-            data=ANY,
-            env=None,
+            "delete_object",
+            req_type="post",
+            json_dict=ANY,
             err_str=f"Error deleting keys {keys}",
         )
 
-        actual_data = mock_request.call_args[1]["data"]
-        assert actual_data == expected_data
+        actual_data = DeleteObjectParams(**mock_request.call_args[1]["json_dict"])
+        assert actual_data.keys == keys
 
 
 if __name__ == "__main__":

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -10,6 +10,7 @@ import runhouse as rh
 from runhouse.globals import rns_client
 from runhouse.servers.http.http_utils import (
     b64_unpickle,
+    DeleteObjectParams,
     pickle_b64,
     PutObjectParams,
     PutResourceParams,
@@ -107,11 +108,9 @@ class TestHTTPServerDocker:
     def test_delete_obj(self, http_client):
         # https://www.python-httpx.org/compatibility/#request-body-on-http-methods
         key = "key2"
-        data = pickle_b64([key])
-        response = http_client.request(
-            "delete",
-            url="/object",
-            json={"data": data},
+        response = http_client.post(
+            url="/delete_object",
+            json=DeleteObjectParams(keys=[key]).dict(),
             headers=rns_client.request_headers(),
         )
         assert response.status_code == 200
@@ -470,13 +469,10 @@ class TestHTTPServerNoDocker:
 
     @pytest.mark.level("unit")
     def test_delete_obj(self, client):
-        # https://www.python-httpx.org/compatibility/#request-body-on-http-methods
         key = "key"
-        data = pickle_b64([key])
-        response = client.request(
-            "delete",
-            url="/object",
-            json={"data": data},
+        response = client.post(
+            url="/delete_object",
+            json=DeleteObjectParams(keys=[key]).dict(),
             headers=rns_client.request_headers(),
         )
         assert response.status_code == 200

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -114,23 +114,6 @@ class TestServlet:
         assert resp.output_type == "exception"
         assert isinstance(b64_unpickle(resp.error), KeyError)
 
-    @pytest.mark.level("unit")
-    def test_delete_obj(self, test_servlet):
-        remote = False
-        keys = ["key1"]
-        message = Message(data=pickle_b64((keys)))
-        resp = HTTPServer.call_servlet_method(test_servlet, "delete_obj", [message])
-        assert resp.output_type == "result"
-        assert b64_unpickle(resp.data) == ["key1"]
-
-        resp = HTTPServer.call_servlet_method(
-            test_servlet,
-            "get",
-            ["key1", remote, True],
-        )
-        assert resp.output_type == "exception"
-        assert isinstance(b64_unpickle(resp.error), KeyError)
-
     @pytest.mark.skip("Not implemented yet.")
     @pytest.mark.level("unit")
     def test_call(self, test_servlet, docker_cluster_pk_ssh_no_auth):


### PR DESCRIPTION
Overhaul `delete_object` logic in similar way to others, no longer calling into
servlet.
