### PR TITLE
Change Module's endpoint from propery to function

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -176,7 +176,7 @@ class Cluster(Resource):
         return config
 
     def endpoint(self, external=False):
-        """Endpoint for the cluster's RPC server. If external is True, will only return the external url,
+        """Endpoint for the cluster's Daemon server. If external is True, will only return the external url,
         and will return None otherwise (e.g. if a tunnel is required). If external is False, will either return
         the external url if it exists, or will set up the connection (based on connection_type) and return
         the internal url (including the local connected port rather than the sever port). If cluster is not up,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -26,6 +26,7 @@ LOCAL_METHODS = dir(Resource) + [
     "_pointers",
     "_endpoint",
     "endpoint",
+    "set_endpoint",
     "_client",
     "access_level",
     "visibility",
@@ -126,7 +127,8 @@ class Module(Resource):
         # modules change across Runhouse versions.
         config["signature"] = self.signature
 
-        config["endpoint"] = self.endpoint
+        # Only save the endpoint if it's present in _endpoint or externally accessible
+        config["endpoint"] = self.endpoint(external=True)
         return config
 
     @classmethod
@@ -264,20 +266,28 @@ class Module(Resource):
 
         return signature_metadata
 
-    @property
-    def endpoint(self):
-        """The endpoint of the module on the cluster. If the module is local, this will be None."""
-        # Only return an endpoint if it's external, local endpoints are not useful
+    def endpoint(self, external: bool = False):
+        """The endpoint of the module on the cluster. Returns an endpoint if one was manually set (e.g. if loaded
+        down from a config). If not, request the endpoint from the Module's system.
+
+        Args:
+            external: If True and getting the endpoint from the system, only return an endpoint if it's externally
+                accessible (i.e. not on localhost, not connected through as ssh tunnel). If False, return the endpoint
+                even if it's not externally accessible.
+        """
+        if self._endpoint:
+            return self._endpoint
+
         if (
             self._system
             and hasattr(self._system, "endpoint")
-            and self._system.endpoint(external=True)
+            and self._system.endpoint(external=external)
         ):
-            return f"{self._system.endpoint(external=True)}/{self.name}"
-        return self._endpoint
+            return f"{self._system.endpoint(external=external)}/{self.name}"
 
-    @endpoint.setter
-    def endpoint(self, new_endpoint: str):
+        return None
+
+    def set_endpoint(self, new_endpoint: str):
         self._endpoint = new_endpoint
 
     def _client(self):


### PR DESCRIPTION
This allows us to set external=True or False, in case we want a locally-callable
endpoint. Previously if the endpoint was only locally callable, we would only return
None. This is now also consistent with Cluster's endpoint().