### PR TITLE
Improve `_current_cluster` to initialize object store and handle a local cluster.

### DIFF
--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -101,13 +101,22 @@ def load_cluster_config_from_file() -> Dict:
         return {}
 
 
-def _current_cluster(key="name"):
+def _current_cluster(key="config"):
     """Retrive key value from the current cluster config.
     If key is "config", returns entire config."""
     from runhouse.globals import obj_store
 
+    # Initialize obj_store if it hasn't been initialized yet
+    # So that we can call `get_cluster_config`
+
+    # If it's already initialized, we don't want to set the name
+    # to something else.
+    if not obj_store.is_initialized():
+        obj_store.initialize()
     cluster_config = obj_store.get_cluster_config()
     if cluster_config:
+        if (key == "cluster_name" or key == "name") and "name" not in cluster_config:
+            return None
         if key == "config":
             return cluster_config
         elif key == "cluster_name":

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -46,7 +46,7 @@ from runhouse.servers.http.http_utils import (
     ServerSettings,
 )
 from runhouse.servers.nginx.config import NginxConfig
-from runhouse.servers.obj_store import initialize_ray_and_cluster_servlet, ObjStore
+from runhouse.servers.obj_store import ObjStore
 
 logger = logging.getLogger(__name__)
 
@@ -164,11 +164,8 @@ class HTTPServer:
         # This should already be initialized by the start script
         # But if the HTTPServer was started standalone in a test,
         # We still want to make sure the cluster servlet is initialized
-        if not ray.is_initialized():
-            initialize_ray_and_cluster_servlet(create_if_not_exists=True)
-
         # Puts without an env here will be sent to the base env.
-        obj_store.initialize("base")
+        obj_store.initialize("base", initialize_ray=True)
 
         # TODO disabling due to latency, figure out what to do with this
         # try:
@@ -898,9 +895,7 @@ if __name__ == "__main__":
     # The object store and the cluster servlet within it need to be
     # initiailzed in order to call `obj_store.get_cluster_config()`, which
     # uses the object store to load the cluster config from Ray.
-    initialize_ray_and_cluster_servlet(create_if_not_exists=True)
-
-    obj_store.initialize("base")
+    obj_store.initialize("base", initialize_ray=True)
 
     cluster_config = obj_store.get_cluster_config()
     if not cluster_config:

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, List, Optional, Set, Union
 
 import ray
+from ray.experimental.state.api import list_actors
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,32 @@ class NoLocalObjStoreError(ObjStoreError):
 def initialize_ray_and_cluster_servlet(create_if_not_exists: bool = False):
     from runhouse.servers.cluster_servlet import ClusterServlet
 
-    if create_if_not_exists:
+    try:
+        if not ray.is_initialized():
+            ray.init(
+                address="auto",
+                ignore_reinit_error=True,
+                logging_level=logging.ERROR,
+                namespace="runhouse",
+            )
+    except ConnectionError:
+        logging.warning(
+            "Could not connect to Ray cluster. Make sure you have run `runhouse start`"
+        )
+        pass
+
+    cluster_servlet_exists = (
+        any(
+            actor["class_name"] == "ClusterServlet" and actor["state"] == "ALIVE"
+            for actor in list_actors()
+        )
+        if ray.is_initialized()
+        else False
+    )
+
+    if cluster_servlet_exists:
+        return ray.get_actor("cluster_servlet", namespace="runhouse")
+    elif create_if_not_exists:
         ray.init(
             ignore_reinit_error=True,
             logging_level=logging.ERROR,
@@ -38,15 +64,10 @@ def initialize_ray_and_cluster_servlet(create_if_not_exists: bool = False):
 
         # Make sure cluster servlet is actually initialized
         ray.get(cluster_servlet.get_cluster_config.remote())
+        return cluster_servlet
+
     else:
-        ray.init(
-            address="auto",
-            ignore_reinit_error=True,
-            logging_level=logging.ERROR,
-            namespace="runhouse",
-        )
-        cluster_servlet = ray.get_actor("cluster_servlet", namespace="runhouse")
-    return cluster_servlet
+        return None
 
 
 class ObjStore:
@@ -80,10 +101,14 @@ class ObjStore:
 
         self._kv_store: Dict[Any, Any] = None
 
+    def is_initialized(self):
+        return ray.is_initialized() and self.cluster_servlet is not None
+
     def initialize(
         self,
         servlet_name: Optional[str] = None,
         has_local_storage: bool = False,
+        initialize_ray: bool = False,
     ):
         # The initialization of the obj_store needs to be in a separate method
         # so the HTTPServer actually initalizes the obj_store,
@@ -92,41 +117,51 @@ class ObjStore:
 
         # ClusterServlet essentially functions as a global state/metadata store
         # for all nodes connected to this Ray cluster.
-        try:
-            self.cluster_servlet = initialize_ray_and_cluster_servlet()
 
-        except ConnectionError:
-            # If ray.init fails, we're not on a cluster, so we don't need to do anything
-            pass
-
-        # There are 3 operating modes of the KV store:
-        # servlet_name is set, has_local_storage is True: This is an EnvServlet with a local KV store.
-        # servlet_name is set, has_local_storage is False: This is an ObjStore class that is not an EnvServlet,
-        #   but wants to proxy its writes to a running EnvServlet.
-        # servlet_name is unset, has_local_storage is False: This is an ObjStore class that by default only looks at
-        #   the global KV store and other servlets.
-        if not servlet_name and has_local_storage:
-            raise ValueError(
-                "Must provide a servlet name if the servlet has local storage."
-            )
-
-        # There can only be one initialized EnvServlet with a given name AND with local storage.
-        if has_local_storage and servlet_name:
-            if self.is_env_servlet_name_initialized(servlet_name):
-                raise ValueError(
-                    f"There already exists an EnvServlet with name {servlet_name}."
+        # We need to
+        if not self.is_initialized():
+            try:
+                self.cluster_servlet = initialize_ray_and_cluster_servlet(
+                    create_if_not_exists=initialize_ray
                 )
-            else:
-                self.mark_env_servlet_name_as_initialized(servlet_name)
 
-        self.servlet_name = servlet_name
-        self.has_local_storage = has_local_storage
-        if self.has_local_storage:
-            self._kv_store = {}
+            except ConnectionError:
+                # If ray.init fails, we're not on a cluster, so we don't need to do anything
+                pass
 
-        num_gpus = ray.cluster_resources().get("GPU", 0)
-        cuda_visible_devices = list(range(int(num_gpus)))
-        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, cuda_visible_devices))
+        # We only want to actually proceed with "initializing" the object store if
+        # we are on a cluster where the Runhouse daemon is running.
+        if self.is_initialized():
+            # There are 3 operating modes of the KV store:
+            # servlet_name is set, has_local_storage is True: This is an EnvServlet with a local KV store.
+            # servlet_name is set, has_local_storage is False: This is an ObjStore class that is not an EnvServlet,
+            #   but wants to proxy its writes to a running EnvServlet.
+            # servlet_name is unset, has_local_storage is False: This is an ObjStore class that by default only looks at
+            #   the global KV store and other servlets.
+            if not servlet_name and has_local_storage:
+                raise ValueError(
+                    "Must provide a servlet name if the servlet has local storage."
+                )
+
+            # There can only be one initialized EnvServlet with a given name AND with local storage.
+            if has_local_storage and servlet_name:
+                if self.is_env_servlet_name_initialized(servlet_name):
+                    raise ValueError(
+                        f"There already exists an EnvServlet with name {servlet_name}."
+                    )
+                else:
+                    self.mark_env_servlet_name_as_initialized(servlet_name)
+
+            self.servlet_name = servlet_name
+            self.has_local_storage = has_local_storage
+            if self.has_local_storage:
+                self._kv_store = {}
+
+            num_gpus = ray.cluster_resources().get("GPU", 0)
+            cuda_visible_devices = list(range(int(num_gpus)))
+            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(
+                map(str, cuda_visible_devices)
+            )
 
     ##############################################
     # Generic helpers

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,14 +11,12 @@ from runhouse.servers.obj_store import ObjStore
 
 def get_ray_servlet(env_name):
     """Helper method for getting auth servlet and base env servlet"""
-    import ray
 
-    ray.init(
-        ignore_reinit_error=True,
-        runtime_env=None,
-        namespace="runhouse",
-    )
+    # We need to initialize the cluster_servlet before we can get the env servlet
+    fake_obj_store = ObjStore()
+    fake_obj_store.initialize(initialize_ray=True)
 
+    # Get the env servlet
     servlet = ObjStore.get_env_servlet(
         env_name=env_name,
         create=True,


### PR DESCRIPTION
If we are running a Python script on a cluster, the object store may not be
initialized. We used to initialize the object store within `__init__.py`, but
that is now removed to prevent circular dependency issues. 

So now, if a user requests the `_current_cluster` as a part of their script/flow and the object store isn't already initialized, then make sure to initialize it.
Note that in a server or a servlet, `cluster_servlet` would already not be
`None`, so we wouldn't re-initialize it and set the name to `None`.

Also change `_current_cluster` to return `config` by default, and check if `name` is `None`.
