### PR TITLE
Introduce Asgi module and support calling route functions directly

### DIFF
--- a/runhouse/__init__.py
+++ b/runhouse/__init__.py
@@ -1,3 +1,4 @@
+from runhouse.resources.asgi import Asgi, asgi
 from runhouse.resources.blobs import blob, Blob, file, File
 from runhouse.resources.envs import conda_env, CondaEnv, env, Env
 from runhouse.resources.folders import Folder, folder, GCSFolder, S3Folder

--- a/runhouse/resources/asgi.py
+++ b/runhouse/resources/asgi.py
@@ -1,0 +1,116 @@
+import inspect
+import logging
+from typing import Any, Optional, Tuple, Union
+
+from runhouse.resources.envs import _get_env_from, Env
+from runhouse.resources.module import LOCAL_METHODS, Module
+
+logger = logging.getLogger(__name__)
+
+
+class Asgi(Module):
+    def __init__(self, app_pointers: Optional[Tuple] = None, **kwargs):
+        """
+        Runhouse Asgi Module. Allows you to deploy an ASGI app to a cluster.
+
+        .. note::
+                To create an Asgi, please use the factory method :func:`asgi`.
+        """
+        super().__init__(**kwargs)
+        self.app_pointers = app_pointers
+        self._app = None
+
+    async def asgi_call(self, scope, receive, send) -> None:
+        if not self._app:
+            self._app = self._get_obj_from_pointers(*self.app_pointers)
+        await self._app(scope, receive, send)
+
+    def __call__(self, *args, **kwargs):
+        return self.asgi_call(*args, **kwargs)
+
+    def _route_names_and_endpoints(self):
+        if not self._app:
+            self.local._app = Module._get_obj_from_pointers(*self.local.app_pointers)
+
+        return {route.name: route.endpoint for route in self.local._app.routes[4:]}
+
+    @property
+    def signature(self):
+        sig = super().signature
+
+        route_attrs = {
+            name: self.method_signature(endpoint)
+            for name, endpoint in self._route_names_and_endpoints().items()
+            if not name[0] == "_" and name not in LOCAL_METHODS
+        }
+        sig.update(route_attrs)
+        return sig
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_app"] = None
+        return state
+
+    def _signature_extensions(self, item):
+        if item == "_app":
+            # Object hasn't been remotely initialized yet
+            return None
+
+        # If the item is a route name, return the endpoint. This allows us to call the route name directly
+        # as a method, which is nice for debugging.
+        return self._route_names_and_endpoints().get(item)
+
+
+def asgi(
+    app: Any,
+    env: Optional[Union[str, "Env"]] = None,
+    name: Optional[str] = None,
+    dryrun: bool = False,
+    **kwargs
+) -> Asgi:
+    """
+    A factory method for creating ASGI modules, such as a FastAPI or Starlette app.
+
+    Args:
+        app (Any): The ASGI app to deploy.
+        **kwargs: Keyword arguments for the :class:`Asgi` constructor.
+
+    Returns:
+        Asgi: The resulting Asgi object.
+
+    Example:
+        >>> from fastapi import FastAPI
+        >>> import runhouse as rh
+        >>> app = FastAPI()
+        >>> @app.get("/summer/{a}")
+        >>> def summer(a: int, b: int = 2):
+        >>>     return a + b
+        >>>
+        >>> fast_api_module = rh.asgi(app).to(rh.here, name="fast_api_module")
+        >>> fast_api_module.summer(1, 2)
+        >>> # output: 3
+    """
+    if name and not any([app, kwargs, env]):
+        # Try reloading existing module
+        return Asgi.from_name(name, dryrun)
+
+    if not isinstance(env, Env):
+        env = _get_env_from(env) or Env(name=Env.DEFAULT_NAME)
+        env.working_dir = env.working_dir or "./"
+
+    callers_global_vars = inspect.currentframe().f_back.f_globals.items()
+    app_name = [
+        var_name for var_name, var_val in callers_global_vars if var_val is app
+    ][0]
+
+    app_file, app_module, _ = Module._extract_pointers(
+        app.routes[4].endpoint, reqs=env.reqs
+    )
+
+    return Asgi(
+        app_pointers=(app_file, app_module, app_name),
+        env=env,
+        name=name,
+        dryrun=dryrun,
+        **kwargs
+    )

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -266,6 +266,11 @@ class Module(Resource):
 
         return signature_metadata
 
+    def _signature_extensions(self, item):
+        """A way to manually extend the methods behind names in the signature. We can't use __getattr__
+        because it gets too crazy and circular with the overloaded __getattribute__ below."""
+        return None
+
     def endpoint(self, external: bool = False):
         """The endpoint of the module on the cluster. Returns an endpoint if one was manually set (e.g. if loaded
         down from a config). If not, request the endpoint from the Module's system.
@@ -505,6 +510,16 @@ class Module(Resource):
             if is_prop:
                 return attr
         except (ModuleNotFoundError, AttributeError) as e:
+            # If there's no client, we can't call this method remotely, so ur last shot is if it's in
+            # the _signature_extensions
+            if not client:
+                if self._signature_extensions(item):
+                    return self._signature_extensions(item)
+                else:
+                    raise e
+
+            # If there is a client, we can try calling this method remotely, and load the required properties
+            # down from the signature
             if item in self.signature:
                 _, is_prop, is_async, is_gen, local_default = list(
                     self.signature.get(item).values()

--- a/tests/test_resources/test_modules/test_server_modules/assets/sample_fastapi_app.py
+++ b/tests/test_resources/test_modules/test_server_modules/assets/sample_fastapi_app.py
@@ -9,7 +9,7 @@ def summer(a: int, b: int):
 
 
 @app.post("/my/deeply/{arg1}/nested/endpoint/{arg2}")
-async def my_deeply_nested_saync_endpoint(arg1: str, arg2: int, arg3: float):
+async def my_deeply_nested_async_endpoint(arg1: str, arg2: int, arg3: float):
     return arg1, arg2, arg3
 
 

--- a/tests/test_resources/test_modules/test_server_modules/dont_test_server_module.py
+++ b/tests/test_resources/test_modules/test_server_modules/dont_test_server_module.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import unittest
 
@@ -22,57 +21,47 @@ TODO test with Den Auth and HTTPS enabled
 """
 
 
-def test_asgi_server(cluster):
-    # If we detect that this is a FastAPI app / ASGIApp, we can automatically attach the functions to the  __getattr__
-    # of the app object, so that we can call them directly from the app object. We can also deploy it with uvicorn.
-    # We can find the app name and module via the functions in the app object's routes:
-    # app.routes[4].endpoint.__module__
-    # or maybe app.routes[4].dependant.cache_key[0]
-    # We can find the app name by extracting the decorator from the function source:
-    # inspect.getsource(app.routes[4].endpoint)
-    fast_api_module = rh.server(app).to(
+@pytest.mark.asyncio
+@pytest.mark.level("local")
+async def test_asgi_server(cluster):
+    fast_api_module = rh.asgi(app).to(
         cluster, env=["pytest", "requests"], name="fast_api_module"
     )
-    assert isinstance(fast_api_module, rh.ASGIApp)
+    assert isinstance(fast_api_module, rh.Asgi)
     assert fast_api_module.summer(1, 2) == 3
+
     # Call an async method
-    assert asyncio.run(
-        fast_api_module.my_deeply_nested_saync_endpoint("hello", 1, 2.0)
-        == ("hello", 1, 2.0)
+    assert await fast_api_module.my_deeply_nested_async_endpoint("hello", 1, 2.0) == (
+        "hello",
+        1,
+        2.0,
     )
 
-    assert fast_api_module.my_streaming_endpoint() == list(range(10))
+    assert list(fast_api_module.my_streaming_endpoint()) == list(range(10))
     assert fast_api_module.my_endpoint_with_optional_body_params_and_header(
         a=1, b=2, c=3
     ) == (1, 2, 3)
 
-    res = requests.get(
-        "http://localhost:8000/fast_api_module/summer/1", params={"b": 2}
-    )
+    endpoint = fast_api_module.endpoint(external=False)
+    res = requests.get(f"{endpoint}/summer/1", params={"b": 2})
     assert res.json() == 3
     res = requests.post(
-        "http://localhost:8000/fast_api_module/my/deeply/hello/nested/endpoint/1",
+        f"{endpoint}/my/deeply/hello/nested/endpoint/1",
         json={"arg3": 2.0},
     )
     assert res.json() == ["hello", 1, 2.0]
-    res = requests.get("http://localhost:8000/fast_api_module/my/streaming/endpoint")
+    res = requests.get(f"{endpoint}/my/streaming/endpoint")
     assert res.json() == list(range(10))
     res = requests.get(
-        "http://localhost:8000/fast_api_module/my/endpoint/with/optional/body/params/and/header",
+        f"{endpoint}/my/endpoint/with/optional/body/params/and/header",
         json={"a": 1, "b": 2},
         headers={"c": 3},
     )
     assert res.json() == [1, 2, 3]
 
     # Test UI page pulls properly
-    res = requests.get("http://localhost:8000/fast_api_module/docs")
+    res = requests.get(f"{endpoint}/docs")
     assert res.status_code == 200
-
-    fast_api_module.stop()
-
-    # Test that the server is stopped
-    with pytest.raises(requests.exceptions.ConnectionError):
-        requests.get("http://localhost:8000/fast_api_module/summer/1", params={"b": 2})
 
 
 def test_python_script_start(cluster):


### PR DESCRIPTION
Introduces Asgi modulei, including logic for incorporating routes as part of signature,
 and asgi factory including logic to find and reload asgi app by pointers.
Successfully calls route endpoint by method directly. Next needs to support calling via requests/curl.