### PR TITLE
Avoid returning `Response` objects via the obj_store when called directly.

### DIFF
--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -719,7 +719,7 @@ class ObjStore:
         resource_config: Dict[str, Any],
         state: Dict[Any, Any],
         dryrun: bool,
-    ) -> None:
+    ) -> str:
         from runhouse.resources.module import Module
         from runhouse.resources.resource import Resource
         from runhouse.rns.utils.names import _generate_default_name


### PR DESCRIPTION
Return directly if we aren't serializing!