### PR TITLE
Simplify `rh.here` logic from what it was before.

### DIFF
--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -101,13 +101,22 @@ def load_cluster_config_from_file() -> Dict:
         return {}
 
 
-def _current_cluster(key="name"):
+def _current_cluster(key="config"):
     """Retrive key value from the current cluster config.
     If key is "config", returns entire config."""
     from runhouse.globals import obj_store
 
+    # Initialize obj_store if it hasn't been initialized yet
+    # So that we can call `get_cluster_config`
+
+    # If it's already initialized, we don't want to set the name
+    # to something else.
+    if not obj_store.is_initialized():
+        obj_store.initialize()
     cluster_config = obj_store.get_cluster_config()
     if cluster_config:
+        if (key == "cluster_name" or key == "name") and "name" not in cluster_config:
+            return None
         if key == "config":
             return cluster_config
         elif key == "cluster_name":

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -2,9 +2,6 @@ import logging
 import sys
 from typing import List
 
-import ray
-from ray.experimental.state.api import list_actors
-
 from runhouse.globals import configs, obj_store, rns_client
 
 from runhouse.logger import LOGGING_CONFIG
@@ -67,43 +64,23 @@ def load(name: str, instantiate: bool = True, dryrun: bool = False):
 
 
 def get_local_cluster_object():
-    # The cluster servlet is running if `runhouse start` has been run on this machine
-    # we check this using list_actors
-
     # This is likely being called from a different process than our HTTPServer
     # so we need to not initialize a new Ray instance, and rather connect
-    # to the existing one
+    # to the existing one.
 
-    # By specifying address, we attempt to connect to an existing Ray
-    # cluster instead of creating a new one
-    try:
-        ray.init(
-            address="auto",
-            ignore_reinit_error=True,
-            logging_level=logging.ERROR,
-            namespace="runhouse",
-        )
-    except ConnectionError:
-        logging.warning(
-            "Could not connect to Ray cluster. Make sure you have run `runhouse start`"
-        )
-        return "file"
+    # When we initialize the object store, it'll by default try to connect to
+    # a Ray cluster instead of starting one.
+    # If it was unable to connect to one and find a cluster servlet actor, then
+    # cluster config will be empty.
+    if not obj_store.is_initialized():
+        obj_store.initialize()
 
-    cluster_servlet_exists = any(
-        actor["class_name"] == "ClusterServlet" and actor["state"] == "ALIVE"
-        for actor in list_actors()
-    )
-
-    if cluster_servlet_exists:
-        # The base EnvServlet should have been created in the HTTPServer
-        obj_store.initialize("base")
-
-        # When HTTPServer is initialized, the cluster_config is set
-        # within the global state.
-        config = obj_store.get_cluster_config()
-        if config.get("resource_subtype") is not None:
-            system = _get_cluster_from(config, dryrun=True)
-            return system
+    # When HTTPServer is initialized, the cluster_config is set
+    # within the global state.
+    config = obj_store.get_cluster_config()
+    if config.get("resource_subtype") is not None:
+        system = _get_cluster_from(config, dryrun=True)
+        return system
 
     return "file"
 

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -46,7 +46,7 @@ from runhouse.servers.http.http_utils import (
     ServerSettings,
 )
 from runhouse.servers.nginx.config import NginxConfig
-from runhouse.servers.obj_store import initialize_ray_and_cluster_servlet, ObjStore
+from runhouse.servers.obj_store import ObjStore
 
 logger = logging.getLogger(__name__)
 
@@ -164,11 +164,8 @@ class HTTPServer:
         # This should already be initialized by the start script
         # But if the HTTPServer was started standalone in a test,
         # We still want to make sure the cluster servlet is initialized
-        if not ray.is_initialized():
-            initialize_ray_and_cluster_servlet(create_if_not_exists=True)
-
         # Puts without an env here will be sent to the base env.
-        obj_store.initialize("base")
+        obj_store.initialize("base", initialize_ray=True)
 
         # TODO disabling due to latency, figure out what to do with this
         # try:
@@ -898,9 +895,7 @@ if __name__ == "__main__":
     # The object store and the cluster servlet within it need to be
     # initiailzed in order to call `obj_store.get_cluster_config()`, which
     # uses the object store to load the cluster config from Ray.
-    initialize_ray_and_cluster_servlet(create_if_not_exists=True)
-
-    obj_store.initialize("base")
+    obj_store.initialize("base", initialize_ray=True)
 
     cluster_config = obj_store.get_cluster_config()
     if not cluster_config:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,14 +11,12 @@ from runhouse.servers.obj_store import ObjStore
 
 def get_ray_servlet(env_name):
     """Helper method for getting auth servlet and base env servlet"""
-    import ray
 
-    ray.init(
-        ignore_reinit_error=True,
-        runtime_env=None,
-        namespace="runhouse",
-    )
+    # We need to initialize the cluster_servlet before we can get the env servlet
+    fake_obj_store = ObjStore()
+    fake_obj_store.initialize(initialize_ray=True)
 
+    # Get the env servlet
     servlet = ObjStore.get_env_servlet(
         env_name=env_name,
         create=True,


### PR DESCRIPTION
Before, we were importing `rh.here` upon initialization of `import runhouse as
rh`. So, we had to do some specific work with `list_actors` in order to check
if the `ClusterServlet` was ready before calling Ray code. This is because we
could cause a circular dependency since Runhouse was imported within the
`EnvServlet` and `ClusterServlet`.

However, now since 
1. `rh.here` will only be called after these servlets are set
up, and
2. We attempt to connect to an existing Ray cluster instead of
creating a new one when we initialize the object store

We can simply initialize the object store and see if itw as able to set up
a cluster servlet to connect to. 
