### PR TITLE
Avoid backgrounding by default when doing `runhouse start`.

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -100,6 +100,7 @@ def _start_server(
     restart,
     restart_ray,
     screen,
+    nohup,
     create_logfile=True,
     host=None,
     port=None,
@@ -118,6 +119,7 @@ def _start_server(
         restart=restart,
         restart_ray=restart_ray,
         screen=screen,
+        nohup=nohup,
         create_logfile=create_logfile,
         host=host,
         port=port,
@@ -182,6 +184,9 @@ def _start_server(
 def start(
     restart_ray: bool = typer.Option(False, help="Restart the Ray runtime"),
     screen: bool = typer.Option(False, help="Start the server in a screen"),
+    nohup: bool = typer.Option(
+        False, help="Start the server in a nohup if screen is not available"
+    ),
     host: Optional[str] = typer.Option(
         None, help="Custom server host address. Default is `0.0.0.0`."
     ),
@@ -212,6 +217,7 @@ def start(
         restart=False,
         restart_ray=restart_ray,
         screen=screen,
+        nohup=nohup,
         create_logfile=True,
         host=host,
         port=port,
@@ -230,6 +236,10 @@ def restart(
     screen: bool = typer.Option(
         True,
         help="Start the server in a screen. Only relevant when restarting locally.",
+    ),
+    nohup: bool = typer.Option(
+        True,
+        help="Start the server in a nohup if screen is not available. Only relevant when restarting locally.",
     ),
     resync_rh: bool = typer.Option(
         False,
@@ -280,6 +290,7 @@ def restart(
         restart=True,
         restart_ray=restart_ray,
         screen=screen,
+        nohup=nohup,
         create_logfile=True,
         host=host,
         port=port,

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -601,6 +601,7 @@ class Cluster(Resource):
         restart,
         restart_ray,
         screen,
+        nohup,
         create_logfile,
         host,
         port,
@@ -631,8 +632,7 @@ class Cluster(Resource):
             )
             screen = False
 
-        nohup = False
-        if not screen:
+        if not screen and nohup:
             nohup_check_cmd = "command -v nohup"
             nohup_check = subprocess.run(
                 nohup_check_cmd,
@@ -640,10 +640,9 @@ class Cluster(Resource):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            if nohup_check.returncode != 0:
+            nohup = nohup_check.returncode == 0
+            if not nohup:
                 logger.info("nohup is not available on the system.")
-            else:
-                nohup = True
 
         server_start_cmd = cls.SERVER_START_CMD
         start_screen_cmd = cls.START_SCREEN_CMD


### PR DESCRIPTION
With the addition of `nohup` if `screen` is not available, we were
backgrounding by default when running `runhouse start`. Now we should only do
it if `runhouse start --nohup` was passed.
