### PR TITLE
Update _get_env_from to handle cases better

### DIFF
--- a/runhouse/resources/blobs/blob.py
+++ b/runhouse/resources/blobs/blob.py
@@ -187,7 +187,7 @@ def blob(
             pass
 
     system = _get_cluster_from(system or _current_cluster(key="config"), dryrun=dryrun)
-    env = env or _get_env_from(env)
+    env = env or _get_env_from(env, system)
 
     if (not system or isinstance(system, Cluster)) and not path and data_config is None:
         # Blobs must be named, or we don't have a key for the kv store

--- a/runhouse/resources/blobs/file.py
+++ b/runhouse/resources/blobs/file.py
@@ -119,7 +119,7 @@ class File(Blob):
                 system = "file"
 
         system = _get_cluster_from(system)
-        env = _get_env_from(env or self.env)
+        env = _get_env_from(env or self.env, system=system)
 
         if (not system or isinstance(system, Cluster)) and not path:
             name = self.name or _generate_default_name(prefix="blob")

--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -38,7 +38,7 @@ def _process_reqs(reqs):
 
 
 def _get_env_from(env):
-    if isinstance(env, Resource):
+    if isinstance(env, Resource) or env is None:
         return env
 
     from runhouse.resources.envs import Env
@@ -49,13 +49,12 @@ def _get_env_from(env):
         return Env(reqs=env, working_dir="./", name=Env.DEFAULT_NAME)
     elif isinstance(env, Dict):
         return Env.from_config(env)
-    elif (
-        isinstance(env, str)
-        and Env.DEFAULT_NAME not in env
-        and rns_client.exists(env, resource_type="env")
-    ):
+    elif isinstance(env, str) and rns_client.exists(env, resource_type="env"):
         return Env.from_name(env)
-    return env
+    elif env == Env.DEFAULT_NAME:
+        return Env(name=Env.DEFAULT_NAME)
+
+    raise ValueError("Could not locate Env from value: {env}")
 
 
 def _get_conda_yaml(conda_env=None):

--- a/runhouse/resources/functions/function.py
+++ b/runhouse/resources/functions/function.py
@@ -83,6 +83,10 @@ class Function(Module):
                 "Please pass in setup commands to the ``Env`` class corresponding to the function instead."
             )
 
+        new_fn_system = (
+            _get_cluster_from(system, dryrun=self.dryrun) if system else self.system
+        )
+
         # to retain backwards compatibility
         if reqs or setup_cmds:
             warnings.warn(
@@ -93,7 +97,7 @@ class Function(Module):
             env = Env(reqs=env, setup_cmds=setup_cmds, name=Env.DEFAULT_NAME)
         else:
             env = env or self.env or Env(name=Env.DEFAULT_NAME)
-            env = _get_env_from(env)
+            env = _get_env_from(env, system=new_fn_system)
 
         if isinstance(system, str) and system.lower() == "lambda_function":
             from runhouse.resources.functions.aws_lambda_factory import aws_lambda_fn
@@ -114,9 +118,7 @@ class Function(Module):
         new_function = copy.deepcopy(self)
         self.system = hw_backup
 
-        new_function.system = (
-            _get_cluster_from(system, dryrun=self.dryrun) if system else self.system
-        )
+        new_function.system = new_fn_system
 
         logging.info("Setting up Function on cluster.")
         # To up cluster in case it's not yet up

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -41,6 +41,7 @@ from runhouse.globals import obj_store, rns_client
 from runhouse.resources.envs.utils import _get_env_from
 from runhouse.resources.hardware.utils import (
     _current_cluster,
+    _get_cluster_from,
     ServerConnectionType,
     SkySSHRunner,
     ssh_tunnel,
@@ -317,7 +318,7 @@ class Cluster(Resource):
         from runhouse.resources.envs.env import Env
 
         self.check_server()
-        env = _get_env_from(env) or Env(name=env or Env.DEFAULT_NAME)
+        env = _get_env_from(env, system=self) or Env(name=env or Env.DEFAULT_NAME)
         env.reqs = env._reqs + reqs
         env.to(self)
 
@@ -379,7 +380,12 @@ class Cluster(Resource):
         )
 
         if env and not isinstance(env, str):
-            env = _get_env_from(env)
+            system = (
+                _get_cluster_from(resource.system)
+                if hasattr(resource, "system")
+                else None
+            )
+            env = _get_env_from(env, system=system)
             env_name = env.name or env.env_name
         else:
             env_name = env

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -199,7 +199,7 @@ class Module(Resource):
             config["system"] = _get_cluster_from(system)
         env = config.get("env")
         if isinstance(env, str):
-            config["env"] = _get_env_from(env)
+            config["env"] = _get_env_from(env, system=config.get("system"))
         return config
 
     @property
@@ -400,7 +400,7 @@ class Module(Resource):
             _get_cluster_from(system, dryrun=self.dryrun) if system else self.system
         )
         env = env or self.env
-        env = _get_env_from(env)
+        env = _get_env_from(env, system=system)
 
         if system:
             system.check_server()


### PR DESCRIPTION
improve 2 cases of _get_env_from, which is expected to return an `Env` type:
1. input env = "base_env" -- falls through all the if statements and returns the string "base_env" instead of the Env object
2. env is not saved in rns_client but exists on the cluster associated with the call. returns the env string instead of Env object