### PR TITLE
Add deleting env servlet functionality

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -115,3 +115,9 @@ class ClusterServlet:
 
     def clear_key_to_env_servlet_name_dict(self):
         self._key_to_env_servlet_name = {}
+
+    ##############################################
+    # Remove Env Servlet
+    ##############################################
+    def remove_env_servlet_name(self, env_servlet_name: str):
+        self._initialized_env_servlet_names.remove(env_servlet_name)

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -594,10 +594,6 @@ class ObjStore:
 
             del env_servlets[env_name]
 
-        # delete the local key
-        if self.contains_local(env_name):
-            self.delete_local(env_name)
-
         self.remove_env_servlet_name(env_name)
         return env_servlet_keys
 

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -580,25 +580,25 @@ class ObjStore:
     def delete_local(self, key: Any):
         self.pop_local(key)
 
-    def delete_env(self, key: Any):
+    def delete_env(self, env_name: Any):
         from runhouse.globals import env_servlets
 
         # clear keys in the env servlet
-        env_servlet_keys = list(self._kv_store.keys()) if self.has_local_storage else []
-        self.clear_for_env_servlet_name(key)
+        env_servlet_keys = self.keys_for_env_servlet_name(env_name)
+        self.clear_for_env_servlet_name(env_name)
 
         # delete the env servlet actor
-        if key in env_servlets:
-            actor = env_servlets[key]
+        if env_name in env_servlets:
+            actor = env_servlets[env_name]
             ray.kill(actor)
 
-            del env_servlets[key]
+            del env_servlets[env_name]
 
         # delete the local key
-        if self.contains_local(key):
-            self.delete_local(key)
+        if self.contains_local(env_name):
+            self.delete_local(env_name)
 
-        self.remove_env_servlet_name(key)
+        self.remove_env_servlet_name(env_name)
         return env_servlet_keys
 
     def delete(self, key: Union[Any, List[Any]]):

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -155,10 +155,13 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     def test_cluster_delete_env(self, cluster):
         env1 = rh.env(reqs=["numpy"], name="env1").to(cluster)
         env2 = rh.env(reqs=["numpy"], name="env2").to(cluster)
+        env3 = rh.env(reqs=["numpy"], name="env3")
 
         cluster.put("k1", "v1", env=env1.name)
         cluster.put("k2", "v2", env=env2.name)
+        cluster.put_resource(env3, env=env1.name)
 
+        # test delete env2
         assert cluster.get(env2.name)
         assert cluster.get("k2")
 
@@ -166,6 +169,11 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         assert not cluster.get(env2.name)
         assert not cluster.get("k2")
 
+        # test delete env3, which doesn't affect env1
+        assert cluster.get(env3.name)
+
+        cluster.delete(env3.name)
+        assert not cluster.get(env3.name)
         assert cluster.get(env1.name)
         assert cluster.get("k1")
 

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -152,6 +152,24 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         assert cluster.get(k3) == "v3"
 
     @pytest.mark.level("local")
+    def test_cluster_delete_env(self, cluster):
+        env1 = rh.env(reqs=["numpy"], name="env1").to(cluster)
+        env2 = rh.env(reqs=["numpy"], name="env2").to(cluster)
+
+        cluster.put("k1", "v1", env=env1.name)
+        cluster.put("k2", "v2", env=env2.name)
+
+        assert cluster.get(env2.name)
+        assert cluster.get("k2")
+
+        cluster.delete(env2.name)
+        assert not cluster.get(env2.name)
+        assert not cluster.get("k2")
+
+        assert cluster.get(env1.name)
+        assert cluster.get("k1")
+
+    @pytest.mark.level("local")
     @pytest.mark.skip(reason="TODO")
     def test_rh_here_objects(self, cluster):
         save_test_table_remote = rh.function(test_table_to_rh_here, system=cluster)

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -331,10 +331,14 @@ class TestObjStore:
 
         obj_store.delete(env_to_delete)
 
-        # check obj_store_2 servlet and nested keys are deleted
+        # check obj_store_2 servlet and nested keys are deleted but obj_store_1 unaffected
         assert env_to_delete not in obj_store.get_all_initialized_env_servlet_names()
         for key in obj_store_2_keys:
             assert not obj_store.get(key)
+        assert (
+            obj_store.servlet_name in obj_store.get_all_initialized_env_servlet_names()
+        )
+        assert obj_store.get("k1")
 
         # check that corresponding Ray actor is killed
         with pytest.raises(ObjStoreError):

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -329,7 +329,7 @@ class TestObjStore:
         for key in obj_store_2_keys:
             assert obj_store.get(key)
 
-        obj_store.delete(env_to_delete)
+        obj_store._delete_env_contents(env_to_delete)
 
         # check obj_store_2 servlet and nested keys are deleted but obj_store_1 unaffected
         assert env_to_delete not in obj_store.get_all_initialized_env_servlet_names()

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -1,6 +1,7 @@
 import pytest
 
 from runhouse.servers.http.auth import hash_token
+from runhouse.servers.obj_store import ObjStore, ObjStoreError
 
 from tests.utils import friend_account, get_test_obj_store
 
@@ -309,6 +310,35 @@ class TestObjStore:
         )
         obj_store_2.clear()
         assert obj_store_3.keys() == []
+
+    @pytest.mark.level("unit")
+    def test_delete_env_servelet(self, obj_store):
+        obj_store_2 = get_test_obj_store("other")
+
+        assert obj_store.keys() == []
+        assert obj_store_2.keys() == []
+
+        obj_store.put("k1", "v1")
+        obj_store_2.put("k2", "v2")
+        obj_store_2.put("k3", "v3")
+
+        env_to_delete = obj_store_2.servlet_name
+        obj_store_2_keys = obj_store_2.keys_for_env_servlet_name(env_to_delete)
+
+        assert env_to_delete in obj_store.get_all_initialized_env_servlet_names()
+        for key in obj_store_2_keys:
+            assert obj_store.get(key)
+
+        obj_store.delete(env_to_delete)
+
+        # check obj_store_2 servlet and nested keys are deleted
+        assert env_to_delete not in obj_store.get_all_initialized_env_servlet_names()
+        for key in obj_store_2_keys:
+            assert not obj_store.get(key)
+
+        # check that corresponding Ray actor is killed
+        with pytest.raises(ObjStoreError):
+            ObjStore.get_env_servlet(env_name=env_to_delete, raise_ex_if_not_found=True)
 
 
 @pytest.mark.servertest


### PR DESCRIPTION
Support deleting and killing and env servlet through `cluster.delete(["env_key"])`.

Clears the keys existing within the env servlet, removes the env servlet from cluster servlet (and anywhere that keeps track of active env servlets), and kills the corresponding actor. 
