### PR TITLE
deduplicates test code by assigning folder types to test level types

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyopenssl>=23.3.0
 ray[default] >= 2.2.0, <= 2.6.3, != 2.6.0
 rich
 sentry-sdk
-sshfs
+sshfs >= 2023.1.0, <= 2023.4.1
 sshtunnel>=0.3.0
 typer
 uvicorn

--- a/runhouse/resources/folders/folder.py
+++ b/runhouse/resources/folders/folder.py
@@ -77,7 +77,7 @@ class Folder(Resource):
             self.default_path(self.rns_address, system)
             if path is None
             else path
-            if isinstance(system, Resource)
+            if system is not self.DEFAULT_FS
             else path
             if Path(path).expanduser().is_absolute()
             else str(Path(rns_client.locate_working_dir()) / path)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
     "ray[default] >= 2.2.0, <= 2.6.3, != 2.6.0",
     "rich",
     "sentry-sdk",
-    "sshfs",
+    "sshfs >= 2023.1.0, <= 2023.4.1",
     "sshtunnel>=0.3.0",
     "typer",
     "uvicorn",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,9 +194,11 @@ from tests.fixtures.docker_cluster_fixtures import (
 
 from tests.fixtures.folder_fixtures import (
     cluster_folder,  # noqa: F401
+    dest,  # noqa: F401
     folder,  # noqa: F401
     gcs_folder,  # noqa: F401
     local_folder,  # noqa: F401
+    local_folder_docker,  # noqa: F401
     s3_folder,  # noqa: F401
 )
 

--- a/tests/fixtures/folder_fixtures.py
+++ b/tests/fixtures/folder_fixtures.py
@@ -8,6 +8,12 @@ from .utils import create_gcs_bucket, create_s3_bucket
 
 
 @pytest.fixture
+def dest(request):
+    """Parametrize over multiple folders - useful for running the same test on multiple storage types."""
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
 def folder(request):
     """Parametrize over multiple folders - useful for running the same test on multiple storage types."""
     return request.getfixturevalue(request.param)
@@ -23,13 +29,47 @@ def local_folder(tmp_path):
 
 
 @pytest.fixture
-def cluster_folder(ondemand_cpu_cluster, local_folder):
-    return local_folder.to(system=ondemand_cpu_cluster)
+def local_folder_docker(docker_cluster_pk_ssh_no_auth):
+    args = {
+        "name": "test_docker_folder",
+        "system": docker_cluster_pk_ssh_no_auth,
+        "path": "rh-folder",
+    }
+
+    local_folder_docker = rh.folder(**args)
+    init_args[id(local_folder_docker)] = args
+    local_folder_docker.put(
+        {f"sample_file_{i}.txt": f"file{i}".encode() for i in range(3)}
+    )
+    return local_folder_docker
 
 
 @pytest.fixture
-def s3_folder(local_folder):
-    s3_folder = local_folder.to(system="s3")
+def cluster_folder(ondemand_cpu_cluster):
+    args = {
+        "name": "test_cluster_folder",
+        "system": ondemand_cpu_cluster,
+        "path": "rh-folder",
+    }
+
+    cluster_folder = rh.folder(**args)
+    init_args[id(cluster_folder)] = args
+    cluster_folder.put({f"sample_file_{i}.txt": f"file{i}".encode() for i in range(3)})
+    return cluster_folder
+
+
+@pytest.fixture
+def s3_folder():
+    args = {
+        "name": "test_s3_folder",
+        "system": "s3",
+        "path": "rh-folder",
+    }
+
+    s3_folder = rh.folder(**args)
+    init_args[id(s3_folder)] = args
+    s3_folder.put({f"sample_file_{i}.txt": f"file{i}".encode() for i in range(3)})
+
     yield s3_folder
 
     # Delete files from S3
@@ -37,8 +77,17 @@ def s3_folder(local_folder):
 
 
 @pytest.fixture
-def gcs_folder(local_folder):
-    gcs_folder = local_folder.to(system="gs")
+def gcs_folder():
+    args = {
+        "name": "test_gcs_folder",
+        "system": "gs",
+        "path": "rh-folder",
+    }
+
+    gcs_folder = rh.folder(**args)
+    init_args[id(gcs_folder)] = args
+    gcs_folder.put({f"sample_file_{i}.txt": f"file{i}".encode() for i in range(3)})
+
     yield gcs_folder
 
     # Delete files from GCS


### PR DESCRIPTION
[WIP]

- deduplicates test code by assigning folder types to test level types
    - generalizes testing to be more cloud agnostic
- adds a `local_folder_docker` fixture
- expands folder to folder testing. Tests across 25 different folder transfer combinations for 
 `local_folder`, `local_folder_docker`, `cluster_folder`, `s3_folder`, and `gcs_folder`
- updates folder fixtures to use `init_args` 
- updates setting of `self._path` in `Folder` class, so that path is set properly even if the `system` passed in is of a `Cluster` type but was passed in the form of a `str`. 
- updates `sshfs` dependency to `sshfs >= 2023.1.0, <= 2023.4.1`