### PR TITLE
Split tests into multiple workflows for isolation.

### DIFF
--- a/.github/workflows/local_most_tests.yaml
+++ b/.github/workflows/local_most_tests.yaml
@@ -1,0 +1,29 @@
+name: pytest -v --level local -k "not secrettest and not servertest"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  most-tests-logged-in-level-local:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Setup Runhouse
+        uses: ./.github/workflows/setup_runhouse
+
+      - name: Setup ~/.rh/config.yaml
+        uses: ./.github/workflows/setup_rh_config
+        with:
+          username: ${{ secrets.CI_ACCOUNT_USERNAME }}
+          token: ${{ secrets.CI_ACCOUNT_TOKEN }}
+
+      - name: pytest -v --level local -k "not servertest and not secrettest"
+        env:
+          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+        run: pytest -v --level local -k "not servertest and not secrettest"
+        timeout-minutes: 60

--- a/.github/workflows/local_secret_tests.yaml
+++ b/.github/workflows/local_secret_tests.yaml
@@ -1,0 +1,29 @@
+name: pytest -v --level local -k "secrettest"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  secret-tests-logged-in-level-local:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Setup Runhouse
+        uses: ./.github/workflows/setup_runhouse
+
+      - name: Setup ~/.rh/config.yaml
+        uses: ./.github/workflows/setup_rh_config
+        with:
+          username: ${{ secrets.CI_ACCOUNT_USERNAME }}
+          token: ${{ secrets.CI_ACCOUNT_TOKEN }}
+
+      - name: pytest -v --level local -k "secrettest"
+        env:
+          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+        run: pytest -v --level local -k "secrettest"
+        timeout-minutes: 60

--- a/.github/workflows/local_server_tests.yaml
+++ b/.github/workflows/local_server_tests.yaml
@@ -1,0 +1,29 @@
+name: pytest -v --level local tests/test_servers/
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  server-tests-logged-in-level-local:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Setup Runhouse
+        uses: ./.github/workflows/setup_runhouse
+
+      - name: Setup ~/.rh/config.yaml
+        uses: ./.github/workflows/setup_rh_config
+        with:
+          username: ${{ secrets.CI_ACCOUNT_USERNAME }}
+          token: ${{ secrets.CI_ACCOUNT_TOKEN }}
+
+      - name: pytest -v --level local tests/test_servers/
+        env:
+          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+        run: pytest -v --level local tests/test_servers/
+        timeout-minutes: 60

--- a/.github/workflows/local_tests.yaml
+++ b/.github/workflows/local_tests.yaml
@@ -1,9 +1,6 @@
 name: Tests with level "local"
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
+on: workflow_dispatch
 
 jobs:
   # TODO: THESE ARE ONLY SEPARATE JOBS BECAUSE THERE ARE


### PR DESCRIPTION
When running jobs in the same workflow, Ray detects the existing running servers and cannot
decide which one to connect to. Separate these out for full Ray isolation.
