### PR TITLE
Add deleting env servlet functionality

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -115,3 +115,9 @@ class ClusterServlet:
 
     def clear_key_to_env_servlet_name_dict(self):
         self._key_to_env_servlet_name = {}
+
+    ##############################################
+    # Remove Env Servlet
+    ##############################################
+    def remove_env_servlet_name(self, env_servlet_name: str):
+        self._initialized_env_servlet_names.remove(env_servlet_name)

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -648,7 +648,6 @@ class ObjStore:
 
     def _delete_env_contents(self, env_name: Any):
         from runhouse.globals import env_servlets
-        from runhouse.resources.hardware.ray_utils import kill_actors
 
         # clear keys in the env servlet
         deleted_keys = self.keys_for_env_servlet_name(env_name)
@@ -656,7 +655,9 @@ class ObjStore:
 
         # delete the env servlet actor and remove its references
         if env_name in env_servlets:
-            kill_actors(env_name)
+            actor = env_servlets[env_name]
+            ray.kill(actor)
+
             del env_servlets[env_name]
         self.remove_env_servlet_name(env_name)
 

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -648,6 +648,7 @@ class ObjStore:
 
     def _delete_env_contents(self, env_name: Any):
         from runhouse.globals import env_servlets
+        from runhouse.resources.hardware.ray_utils import kill_actors
 
         # clear keys in the env servlet
         deleted_keys = self.keys_for_env_servlet_name(env_name)
@@ -655,9 +656,7 @@ class ObjStore:
 
         # delete the env servlet actor and remove its references
         if env_name in env_servlets:
-            actor = env_servlets[env_name]
-            ray.kill(actor)
-
+            kill_actors(env_name)
             del env_servlets[env_name]
         self.remove_env_servlet_name(env_name)
 

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -152,6 +152,32 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         assert cluster.get(k3) == "v3"
 
     @pytest.mark.level("local")
+    def test_cluster_delete_env(self, cluster):
+        env1 = rh.env(reqs=["numpy"], name="env1").to(cluster)
+        env2 = rh.env(reqs=["numpy"], name="env2").to(cluster)
+        env3 = rh.env(reqs=["numpy"], name="env3")
+
+        cluster.put("k1", "v1", env=env1.name)
+        cluster.put("k2", "v2", env=env2.name)
+        cluster.put_resource(env3, env=env1.name)
+
+        # test delete env2
+        assert cluster.get(env2.name)
+        assert cluster.get("k2")
+
+        cluster.delete(env2.name)
+        assert not cluster.get(env2.name)
+        assert not cluster.get("k2")
+
+        # test delete env3, which doesn't affect env1
+        assert cluster.get(env3.name)
+
+        cluster.delete(env3.name)
+        assert not cluster.get(env3.name)
+        assert cluster.get(env1.name)
+        assert cluster.get("k1")
+
+    @pytest.mark.level("local")
     @pytest.mark.skip(reason="TODO")
     def test_rh_here_objects(self, cluster):
         save_test_table_remote = rh.function(test_table_to_rh_here, system=cluster)

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from runhouse.servers.http.auth import hash_token
@@ -313,7 +315,7 @@ class TestObjStore:
 
     @pytest.mark.level("unit")
     def test_delete_env_servelet(self, obj_store):
-        obj_store_2 = get_test_obj_store("other")
+        _, obj_store_2 = get_ray_servlet_and_obj_store("obj_store_2")
 
         assert obj_store.keys() == []
         assert obj_store_2.keys() == []
@@ -342,6 +344,7 @@ class TestObjStore:
 
         # check that corresponding Ray actor is killed
         with pytest.raises(ObjStoreError):
+            time.sleep(0.5)  # ensure the actor has been fully killed
             ObjStore.get_env_servlet(env_name=env_to_delete, raise_ex_if_not_found=True)
 
 

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from runhouse.servers.http.auth import hash_token
@@ -314,7 +312,7 @@ class TestObjStore:
         assert obj_store_3.keys() == []
 
     @pytest.mark.level("unit")
-    def test_delete_env_servelet(self, obj_store):
+    def test_delete_env_servlet(self, obj_store):
         _, obj_store_2 = get_ray_servlet_and_obj_store("obj_store_2")
 
         assert obj_store.keys() == []
@@ -344,7 +342,6 @@ class TestObjStore:
 
         # check that corresponding Ray actor is killed
         with pytest.raises(ObjStoreError):
-            time.sleep(0.5)  # ensure the actor has been fully killed
             ObjStore.get_env_servlet(env_name=env_to_delete, raise_ex_if_not_found=True)
 
 


### PR DESCRIPTION
Duplicate of #401, accidentally merged into a branch instead of main

> Support deleting and killing and env servlet through cluster.delete(["env_key"]).

> Clears the keys existing within the env servlet, removes the env servlet from cluster servlet (and anywhere that keeps track of active env servlets), and kills the corresponding actor.
