### PR TITLE
removes kubernetestest marker

### DIFF
--- a/tests/test_resources/test_clusters/test_kubernetes_cluster.py
+++ b/tests/test_resources/test_clusters/test_kubernetes_cluster.py
@@ -11,7 +11,6 @@ def num_cpus():
     return f"Num cpus: {multiprocessing.cpu_count()}"
 
 
-@pytest.mark.kubernetestest
 class TestKubernetesCluster(
     tests.test_resources.test_clusters.test_cluster.TestCluster
 ):


### PR DESCRIPTION
removes kubernetestest marker. This was showing up in the warnings summary on CI, so I got rid of the marker. 