### PR TITLE
Don't expose Ray ports in Testing Clusters

### DIFF
--- a/docker/cuda/Dockerfile
+++ b/docker/cuda/Dockerfile
@@ -41,12 +41,8 @@ RUN echo "[supervisord]" > /etc/supervisor/conf.d/supervisord.conf && \
     echo "stdout_logfile=/var/log/runhouse.log" >> /etc/supervisor/conf.d/supervisord.conf && \
     echo "stderr_logfile=/var/log/runhouse.err" >> /etc/supervisor/conf.d/supervisord.conf
 
-# Ray dashboard port
-EXPOSE 52365
 # Runhouse server port
 EXPOSE 32300
-# Ray Redis cache port
-EXPOSE 6379
 # HTTPS port
 EXPOSE 443
 # HTTP port

--- a/docker/slim/password-file-auth/Dockerfile
+++ b/docker/slim/password-file-auth/Dockerfile
@@ -43,12 +43,8 @@ RUN echo "[supervisord]" > /etc/supervisor/conf.d/supervisord.conf && \
     echo "stdout_logfile=/var/log/sshd.log" >> /etc/supervisor/conf.d/supervisord.conf && \
     echo "stderr_logfile=/var/log/sshd.err" >> /etc/supervisor/conf.d/supervisord.conf
 
-# Ray dashboard port
-EXPOSE 52365
 # Runhouse server port
 EXPOSE 32300
-# Ray Redis cache port
-EXPOSE 6379
 # HTTPS port
 EXPOSE 443
 # HTTP port

--- a/docker/slim/public-key-auth/Dockerfile
+++ b/docker/slim/public-key-auth/Dockerfile
@@ -51,13 +51,8 @@ RUN echo "[supervisord]" > /etc/supervisor/conf.d/supervisord.conf && \
     echo "stdout_logfile=/var/log/sshd.log" >> /etc/supervisor/conf.d/supervisord.conf && \
     echo "stderr_logfile=/var/log/sshd.err" >> /etc/supervisor/conf.d/supervisord.conf
 
-
-# Ray dashboard port
-EXPOSE 52365
 # Runhouse server port
 EXPOSE 32300
-# Ray Redis cache port
-EXPOSE 6379
 # HTTPS port
 EXPOSE 443
 # HTTP port

--- a/tests/test_resources/test_resource.py
+++ b/tests/test_resources/test_resource.py
@@ -172,18 +172,13 @@ class TestResource:
                 == config
             )
 
+        # TODO: If we are testing with an ondemand_cluster we to
+        # sync sky key so loading ondemand_cluster from config works
+        # Also need aws secret to load availability zones
+        # secrets=["sky", "aws"],
         load_shared_resource_config_cluster = rh.function(
             load_shared_resource_config
-        ).to(
-            system=friend_account_logged_in_docker_cluster_pk_ssh,
-            env=rh.env(
-                working_dir=None,
-                # TODO: If we are testing with an ondemand_cluster we need these secrets
-                # Sync sky key so loading ondemand_cluster from config works
-                # Also need aws secret to load availability zones
-                # secrets=["sky", "aws"],
-            ),
-        )
+        ).to(friend_account_logged_in_docker_cluster_pk_ssh)
         assert (
             load_shared_resource_config_cluster(
                 resource_class_name, saved_resource.rns_address


### PR DESCRIPTION
We were running into an issue where the local_daemon fixture was connecting to the docker cluster ports by default.