### PR TITLE
Fix `runhouse restart` to correctly check for exsiting Ray cluster.

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -18,12 +18,14 @@ import runhouse.rns.login
 from runhouse import __version__, cluster, configs
 from runhouse.constants import (
     RAY_KILL_CMD,
+    RAY_START_CMD,
     SERVER_LOGFILE,
     SERVER_START_CMD,
     SERVER_STOP_CMD,
     START_NOHUP_CMD,
     START_SCREEN_CMD,
 )
+from runhouse.resources.hardware.ray_utils import check_for_existing_ray_instance
 
 
 # create an explicit Typer application
@@ -279,12 +281,14 @@ def _start_server(
     if restart:
         cmds.append(SERVER_STOP_CMD)
 
+    # We have to `ray start` not within screen/nohup
+    existing_ray_instance = check_for_existing_ray_instance()
+    if not existing_ray_instance or restart_ray:
+        cmds.append(RAY_KILL_CMD)
+        cmds.append(RAY_START_CMD)
+
     # Collect flags
     flags = []
-    restart_ray_flag = " --restart-ray" if restart_ray else ""
-    if restart_ray_flag:
-        logger.info("Restarting a Ray instance on the remote machine.")
-        flags.append(restart_ray_flag)
 
     den_auth_flag = " --use-den-auth" if den_auth else ""
     if den_auth_flag:
@@ -524,13 +528,10 @@ def restart(
 
 @app.command()
 def stop(stop_ray: bool = typer.Option(True, help="Stop the Ray runtime")):
-    try:
-        subprocess.run(SERVER_STOP_CMD, shell=True, check=True)
-    except subprocess.CalledProcessError:
-        pass
+    subprocess.run(SERVER_STOP_CMD, shell=True)
 
     if stop_ray:
-        subprocess.run(RAY_KILL_CMD, shell=True, check=True)
+        subprocess.run(RAY_KILL_CMD, shell=True)
 
 
 @app.callback()

--- a/runhouse/resources/hardware/ray_utils.py
+++ b/runhouse/resources/hardware/ray_utils.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 from typing import Optional
 
 import ray
@@ -7,22 +8,11 @@ from ray.experimental.state.api import list_actors
 logger = logging.getLogger(__name__)
 
 
-def check_for_existing_ray_instance(address: str, remain_connected: bool = False):
-    try:
-        ray.init(
-            address=address,
-            ignore_reinit_error=True,
-            logging_level=logging.ERROR,
-        )
-
-        # Note that this is _technically_ just to check if there is an existing
-        # cluster. We want to shutdown() which doesn't actually kill the cluster,
-        # but cleans up the state of Ray within this Python process.
-        if not remain_connected:
-            ray.shutdown()
-        return True
-    except ConnectionError:
-        return False
+def check_for_existing_ray_instance():
+    ray_status_check = subprocess.run(
+        ["ray", "status"],  # stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    return ray_status_check.returncode == 0
 
 
 def list_actor_states(

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -6,7 +6,7 @@ from runhouse.globals import configs, obj_store, rns_client
 
 from runhouse.logger import LOGGING_CONFIG
 
-from runhouse.servers.obj_store import ClusterServletSetupOption, RaySetupOption
+from runhouse.servers.obj_store import ClusterServletSetupOption
 
 # Configure the logger once
 logging.config.dictConfig(LOGGING_CONFIG)
@@ -74,7 +74,6 @@ def get_local_cluster_object():
     try:
         obj_store.initialize(
             servlet_name=obj_store.servlet_name or "base",
-            setup_ray=RaySetupOption.GET_OR_FAIL,
             setup_cluster_servlet=ClusterServletSetupOption.GET_OR_FAIL,
         )
     except ConnectionError:

--- a/runhouse/servers/env_servlet.py
+++ b/runhouse/servers/env_servlet.py
@@ -28,7 +28,7 @@ from runhouse.servers.http.http_utils import (
     Response,
     serialize_data,
 )
-from runhouse.servers.obj_store import ClusterServletSetupOption, RaySetupOption
+from runhouse.servers.obj_store import ClusterServletSetupOption
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,6 @@ class EnvServlet:
         obj_store.initialize(
             self.env_name,
             has_local_storage=True,
-            setup_ray=RaySetupOption.GET_OR_FAIL,
             setup_cluster_servlet=ClusterServletSetupOption.GET_OR_FAIL,
         )
 

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -868,12 +868,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--restart-ray",
-        action="store_true",
-        default=False,
-        help="Whether to kill and restart our own Ray instance. Defaults to False.",
-    )
-    parser.add_argument(
         "--host",
         type=str,
         default=None,
@@ -947,18 +941,10 @@ if __name__ == "__main__":
     # We only want to forcibly start a Ray cluster if asked.
     # We connect this to the "base" env, which we'll initialize later,
     # so writes to the obj_store within the server get proxied to the "base" env.
-    if parse_args.restart_ray:
-        obj_store.initialize(
-            "base",
-            setup_ray=RaySetupOption.FORCE_CREATE,
-            setup_cluster_servlet=ClusterServletSetupOption.FORCE_CREATE,
-        )
-    else:
-        obj_store.initialize(
-            "base",
-            setup_ray=RaySetupOption.GET_OR_CREATE,
-            setup_cluster_servlet=ClusterServletSetupOption.FORCE_CREATE,
-        )
+    obj_store.initialize(
+        "base",
+        setup_cluster_servlet=ClusterServletSetupOption.FORCE_CREATE,
+    )
 
     cluster_config = obj_store.get_cluster_config()
     if not cluster_config:


### PR DESCRIPTION
As @dongreenberg , `runhouse restart` would hang for existing Ray clusters and `runhouse stop` would leave things in a broken state. This does its best to handle this new case.