### PR TITLE
Speed Up HTTPClient with requests.Session

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -48,6 +48,10 @@ class HTTPClient:
         self.use_https = use_https
         self.verify = self._use_cert_verification()
         self.system = system
+        self.client = requests.Session()
+        self.client.auth = self.auth
+        self.client.verify = self.verify
+        self.client.timeout = None
 
     def _use_cert_verification(self):
         if not self.use_https:
@@ -127,13 +131,13 @@ class HTTPClient:
         # Support use case where we explicitly do not want to provide headers (e.g. requesting a cert)
         headers = rns_client.request_headers() if headers != {} else headers
         req_fn = (
-            requests.get
+            self.client.get
             if req_type == "get"
-            else requests.put
+            else self.client.put
             if req_type == "put"
-            else requests.delete
+            else self.client.delete
             if req_type == "delete"
-            else requests.post
+            else self.client.post
         )
         # Note: For localhost (e.g. docker) do not add trailing slash (will lead to connection errors)
         endpoint = endpoint.strip("/")
@@ -146,10 +150,7 @@ class HTTPClient:
         response = req_fn(
             self._formatted_url(endpoint),
             json=json_dict,
-            timeout=timeout,
-            auth=self.auth,
             headers=headers,
-            verify=self.verify,
         )
         if response.status_code != 200:
             raise ValueError(
@@ -161,10 +162,9 @@ class HTTPClient:
         return resp_json
 
     def check_server(self):
-        resp = requests.get(
+        resp = self.client.get(
             self._formatted_url("check"),
             timeout=self.CHECK_TIMEOUT_SEC,
-            verify=self.verify,
         )
 
         if resp.status_code != 200:
@@ -244,7 +244,7 @@ class HTTPClient:
             f"{'Calling' if method_name else 'Getting'} {module_name}"
             + (f".{method_name}" if method_name else "")
         )
-        res = requests.post(
+        res = self.client.post(
             self._formatted_url(f"{module_name}/{method_name}"),
             json={
                 "data": pickle_b64([args, kwargs]),
@@ -257,7 +257,6 @@ class HTTPClient:
             },
             stream=not run_async,
             headers=rns_client.request_headers(),
-            verify=self.verify,
         )
         if res.status_code != 200:
             raise ValueError(
@@ -331,6 +330,7 @@ class HTTPClient:
         else:
             log_str = f"Time to get {module_name}: {round(end - start, 2)} seconds"
         logging.info(log_str)
+        res.close()
         return non_generator_result
 
     def put_object(self, key: str, value: Any, env=None):
@@ -393,11 +393,10 @@ class HTTPClient:
         )
 
     def set_settings(self, new_settings: Dict[str, Any]):
-        res = requests.post(
+        res = self.client.post(
             self._formatted_url("settings"),
             json=new_settings,
             headers=rns_client.request_headers(),
-            verify=self.verify,
         )
         if res.status_code != 200:
             raise ValueError(

--- a/tests/test_servers/conftest.py
+++ b/tests/test_servers/conftest.py
@@ -27,13 +27,13 @@ def summer(a, b):
 # -------- FIXTURES ----------- #
 @pytest.fixture(scope="module")
 def http_client():
-    with httpx.Client(base_url=BASE_URL, timeout=60.0) as client:
+    with httpx.Client(base_url=BASE_URL, timeout=None) as client:
         yield client
 
 
 @pytest_asyncio.fixture(scope="function")
 async def async_http_client():
-    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+    async with httpx.AsyncClient(base_url=BASE_URL, timeout=None) as client:
         yield client
 
 

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -27,7 +27,7 @@ class TestHTTPClient:
         self.client = HTTPClient("localhost", DEFAULT_SERVER_PORT)
 
     @pytest.mark.level("unit")
-    @patch("requests.get")
+    @patch("requests.Session.get")
     def test_check_server(self, mock_get):
         mock_response = Mock()
         mock_response.status_code = 200
@@ -40,7 +40,6 @@ class TestHTTPClient:
         mock_get.assert_called_once_with(
             f"http://localhost:{DEFAULT_SERVER_PORT}/check",
             timeout=HTTPClient.CHECK_TIMEOUT_SEC,
-            verify=False,
         )
 
     @pytest.mark.level("unit")
@@ -108,7 +107,7 @@ class TestHTTPClient:
         assert not client.verify
 
     @pytest.mark.level("unit")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_call_module_method(self, mock_post):
         response_sequence = [
             json.dumps({"output_type": "log", "data": "Log message"}),
@@ -152,18 +151,16 @@ class TestHTTPClient:
             "run_async": False,
         }
         expected_headers = rns_client.request_headers()
-        expected_verify = self.client.verify
 
         mock_post.assert_called_once_with(
             expected_url,
             json=expected_json_data,
             stream=True,
             headers=expected_headers,
-            verify=expected_verify,
         )
 
     @pytest.mark.level("unit")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_call_module_method_with_args_kwargs(self, mock_post):
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -196,18 +193,16 @@ class TestHTTPClient:
         }
         expected_url = f"http://localhost:32300/{module_name}/{method_name}"
         expected_headers = rns_client.request_headers()
-        expected_verify = False
 
         mock_post.assert_called_with(
             expected_url,
             json=expected_json_data,
             stream=True,
             headers=expected_headers,
-            verify=expected_verify,
         )
 
     @pytest.mark.level("unit")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_call_module_method_error_handling(self, mock_post):
         mock_response = Mock()
         mock_response.status_code = 500
@@ -218,7 +213,7 @@ class TestHTTPClient:
             self.client.call_module_method("module", "method")
 
     @pytest.mark.level("unit")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_call_module_method_stream_logs(self, mock_post):
         # Setup the mock response with a log in the stream
         response_sequence = [
@@ -237,7 +232,7 @@ class TestHTTPClient:
         assert next(res) == "Log message"
 
     @pytest.mark.level("unit")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_call_module_method_config(self, mock_post):
         test_data = self.local_cluster.config_for_rns
         mock_response = Mock()
@@ -253,7 +248,7 @@ class TestHTTPClient:
         assert cluster.config_for_rns == test_data
 
     @pytest.mark.level("unit")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_call_module_method_not_found_error(self, mock_post):
         mock_response = Mock()
         mock_response.status_code = 200

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -121,7 +121,7 @@ class TestHTTPServerDocker:
     @pytest.mark.level("local")
     def test_call_module_method(self, http_client, cluster):
         # Create new func on the cluster, then call it
-        remote_func = rh.function(summer, system=cluster)
+        remote_func = rh.function(summer).to(cluster)
 
         method_name = "call"
         module_name = remote_func.name
@@ -156,7 +156,7 @@ class TestHTTPServerDocker:
     @pytest.mark.level("local")
     @pytest.mark.asyncio
     async def test_async_call(self, async_http_client, cluster):
-        remote_func = rh.function(summer, system=cluster)
+        remote_func = rh.function(summer).to(cluster)
         method = "call"
 
         response = await async_http_client.post(


### PR DESCRIPTION
We should pool tcp connections open to the same cluster, otherwise the mapper
fails with exhausted resources.