### PR TITLE
Only set rns_address upon save

### DIFF
--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -198,7 +198,6 @@ class Env(Resource):
         """
         system = _get_cluster_from(system)
         new_env = copy.deepcopy(self)
-        # new_env.name = new_env.name or "base"
         new_env.reqs, new_env.working_dir = self._reqs_to(system, path, mount)
         new_env.secrets = self._secrets_to(system)
 

--- a/runhouse/resources/folders/folder.py
+++ b/runhouse/resources/folders/folder.py
@@ -471,7 +471,9 @@ class Folder(Resource):
             )
 
         elif isinstance(self.system, Resource):
-            if self.system.rns_address == dest_cluster.rns_address:
+            if self.system.endpoint(external=False) == dest_cluster.endpoint(
+                external=False
+            ):
                 # We're on the same cluster, so we can just move the files
                 if not path:
                     # If user didn't specify a path, we can just return self

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -424,7 +424,9 @@ class Cluster(Resource):
     def on_this_cluster(self):
         """Whether this function is being called on the same cluster."""
         config = _current_cluster("config")
-        return config is not None and config.get("name") == self.rns_address
+        return config is not None and config.get("name") == (
+            self.rns_address or self.name
+        )
 
     # ----------------- RPC Methods ----------------- #
 
@@ -678,7 +680,7 @@ class Cluster(Resource):
             raise ValueError(f"Failed to restart server {self.name}.")
 
         if https_flag:
-            rns_address = self.rns_address
+            rns_address = self.rns_address or self.name
             if not rns_address:
                 raise ValueError("Cluster must have a name in order to enable HTTPS.")
 

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -514,8 +514,6 @@ class OnDemandCluster(Cluster):
                         "~/.rh": "~/.rh",
                     }
                 )
-            # If we choose to reduce collisions of cluster names:
-            # cluster_name = self.rns_address.strip('~/').replace("/", "-")
             sky.launch(
                 task,
                 cluster_name=self.name,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -919,7 +919,7 @@ class Module(Resource):
 
     def rename(self, name: str):
         """Rename the module."""
-        if self.name == name:
+        if self.name == name or self.rns_address == name:
             return
         old_name = self.name
         self.name = name  # Goes through Resource setter to parse name properly (e.g. if rns path)
@@ -928,9 +928,13 @@ class Module(Resource):
             and isinstance(self.system, Cluster)
             and self.system.on_this_cluster()
         ):
-            obj_store.rename(old_key=old_name, new_key=self.rns_address)
+            # We rename the object with the full rns_address here because if it's a resource, we want the
+            # object stored in the obj store to have the updated rns_address, not just the updated key.
+            obj_store.rename(old_key=old_name, new_key=self.rns_address or self.name)
         elif self._client():
-            self._client().rename(old_key=old_name, new_key=self.rns_address)
+            self._client().rename(
+                old_key=old_name, new_key=self.rns_address or self.name
+            )
 
     def save(
         self,

--- a/runhouse/resources/secrets/secret.py
+++ b/runhouse/resources/secrets/secret.py
@@ -184,6 +184,8 @@ class Secret(Resource):
         elif not self.name:
             raise ValueError("A resource must have a name to be saved.")
 
+        self._rns_folder = self._rns_folder or rns_client.current_folder
+
         config = self.config_for_rns
         config["name"] = self.rns_address
         if "values" in config:
@@ -244,7 +246,7 @@ class Secret(Resource):
             )
 
         else:
-            if self.rns_address.startswith("/"):
+            if self.rns_address and self.rns_address.startswith("/"):
                 self._delete_secret_configs(headers)
             else:
                 self._delete_local_config()

--- a/runhouse/resources/secrets/utils.py
+++ b/runhouse/resources/secrets/utils.py
@@ -13,6 +13,8 @@ USER_ENDPOINT = "user/secret"
 
 
 def load_config(name: str, endpoint: str = USER_ENDPOINT):
+    if "/" not in name:
+        name = f"{rns_client.current_folder}/{name}"
     rns_address = rns_client.resolve_rns_path(name)
     if rns_address.startswith("/"):
         # Load via Resource API

--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -300,6 +300,9 @@ class RNSClient:
 
         from runhouse.resources.hardware.utils import _current_cluster
 
+        if "/" not in name:
+            name = f"{self.current_folder}/{name}"
+
         rns_address = self.resolve_rns_path(name)
 
         if rns_address == _current_cluster("name"):
@@ -494,12 +497,12 @@ class RNSClient:
         #     return self.RH_BUILTINS_FOLDER
         # if path.startswith('^'):
         #     return self.RH_BUILTINS_FOLDER + '/' + path[1:]
-        if path[0] not in ["/", "~", "^"]:
-            return self.current_folder + "/" + path
         return path
 
     @staticmethod
     def split_rns_name_and_path(path: str):
+        if "/" not in path:
+            return path, None
         return Path(path).name, str(Path(path).parent)
 
     def exists(

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -109,13 +109,15 @@ def save(
 
     # TODO handle self.access == 'read' instead of this weird overwrite argument
     if name:
-        if "/" in name[1:] or resource._rns_folder is None:
+        if "/" in name[1:]:
             (
                 resource._name,
                 resource._rns_folder,
             ) = split_rns_name_and_path(resolve_rns_path(name))
         else:
             resource._name = name
+    if not resource.rns_address:
+        resource._rns_folder = rns_client.current_folder
     rns_client.save_config(resource=resource, overwrite=overwrite)
 
 

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -33,7 +33,7 @@ from runhouse.servers.http.http_utils import (
     DeleteObjectParams,
     get_token_from_request,
     handle_exception_response,
-    load_current_cluster,
+    load_current_cluster_rns_address,
     Message,
     OutputType,
     pickle_b64,
@@ -72,8 +72,10 @@ def validate_cluster_access(func):
         if func_call and token:
             obj_store.add_user_to_auth_cache(token, refresh_cache=False)
 
-        if not den_auth_enabled or func_call:
-            # If this is a func call, we'll handle the auth in the object store
+        # The logged-in user always has full access to the cluster. This is especially important if they flip on
+        # Den Auth without saving the cluster.
+        # If this is a func call, we'll handle the auth in the object store.
+        if not den_auth_enabled or func_call or (token and configs.token == token):
             if is_coro:
                 return await func(*args, **kwargs)
 
@@ -86,14 +88,14 @@ def validate_cluster_access(func):
                 f"format: {json.dumps({'Authorization': 'Bearer <token>'})}",
             )
 
-        cluster_uri = load_current_cluster()
+        cluster_uri = load_current_cluster_rns_address()
         if cluster_uri is None:
             logger.error(
                 f"Failed to load cluster RNS address. Make sure cluster config YAML has been saved "
                 f"on the cluster in path: {CLUSTER_CONFIG_PATH}"
             )
             raise HTTPException(
-                status_code=404,
+                status_code=403,
                 detail="Failed to load current cluster. Make sure cluster config YAML exists on the cluster.",
             )
 

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -123,7 +123,7 @@ def get_token_from_request(request):
     return auth_headers.split("Bearer ")[-1] if auth_headers else None
 
 
-def load_current_cluster():
+def load_current_cluster_rns_address():
     from runhouse.resources.hardware import _current_cluster, _get_cluster_from
 
     current_cluster = _get_cluster_from(_current_cluster("config"))

--- a/tests/test_resources/conftest.py
+++ b/tests/test_resources/conftest.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 
+from runhouse.globals import rns_client
 from runhouse.resources.resource import Resource
 
 from tests.conftest import init_args
@@ -48,11 +49,11 @@ def saved_resource(resource, saved_resource_pool, test_rns_folder):
         resource_copy = resource.from_config(
             config=resource.config_for_rns, dryrun=True
         )
-        if resource.rns_address[:2] != "~/":
+        if not resource.rns_address or resource.rns_address[:2] != "~/":
             # No need to vary the name for local resources
             # Put resource copies in a folder together so it's easier to clean up
             resource_copy.name = (
-                f"{resource._rns_folder}/{test_rns_folder}/{resource.name}"
+                f"{rns_client.current_folder}/{test_rns_folder}/{resource.name}"
             )
         saved_resource_pool[resource.name] = resource_copy.save()
     return saved_resource_pool[resource.name]

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -97,7 +97,9 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         saved_config_on_cluster = save_resource_and_return_config_cluster()
         # This cluster was created without any logged in Runhouse config. Make sure that the simple resource
         # created on the cluster starts with "~", which is the prefix that local Runhouse configs are saved with.
-        assert saved_config_on_cluster["name"].startswith("~")
+        assert ("/" not in saved_config_on_cluster["name"]) or (
+            saved_config_on_cluster["name"].startswith("~")
+        )
 
     @pytest.mark.level("local")
     def test_cluster_recreate(self, cluster):

--- a/tests/test_resources/test_resource.py
+++ b/tests/test_resources/test_resource.py
@@ -42,7 +42,8 @@ class TestResource:
                 assert resource.rns_address == args["name"]
             else:
                 assert resource.name == args["name"]
-                assert resource.rns_address.split("/")[-1] == args["name"]
+                if resource.rns_address:
+                    assert resource.rns_address.split("/")[-1] == args["name"]
 
         if "dryrun" in args:
             assert args["dryrun"] == resource.dryrun
@@ -54,7 +55,10 @@ class TestResource:
         args = init_args.get(id(resource))
         config = resource.config_for_rns
         assert isinstance(config, dict)
-        assert config["name"] == resource.rns_address
+        if resource.rns_address:
+            assert config["name"] == resource.rns_address
+        else:
+            assert config["name"] == resource.name
         assert config["resource_type"] == resource.RESOURCE_TYPE
         assert config["resource_subtype"] == resource.__class__.__name__
         if "dryrun" in args:


### PR DESCRIPTION
Until now we've been setting the _rns_folder of a resource implicitly to
rns_client.current_folder, whether the resource has been saved or not,
so the address is really meaningless. This is a relic from a time when
we tried to save resources constantly as they were created and changed.
Now, it would be much easier to have a reasonable assumption of whether
a resource has been saved and therefore whether its rns_address is
meaningful if passed to another environment. For example, when saving
a resource config as a sub-config of another resource, we need to know
whether we can just save a string because the resource has been saved
or if we need to return the full sub-resource config. This bug in particular
was breaking some things.

This change changes the behavior of `rns_address` to return None if there
is no _rns_folder or no _name, and saves the _rns_folder to the current_folder
only upon save. If a user gives a resource a full rns_address that's their own
business, we will not check if the address is actually pointing to something
when we return the property.