### PR TITLE
reuse certs across clusters

### DIFF
--- a/runhouse/servers/caddy/config.py
+++ b/runhouse/servers/caddy/config.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 from runhouse.constants import DEFAULT_SERVER_PORT
 
+SYSTEMCTL_ERROR = "systemctl: command not found"
+
 
 class CaddyConfig:
     BASE_CONFIG_PATH = "/etc/caddy/Caddyfile"
@@ -114,7 +116,7 @@ class CaddyConfig:
         )
 
         if result.returncode != 0:
-            if "systemctl: command not found" in result.stderr:
+            if SYSTEMCTL_ERROR in result.stderr:
                 # If running in a docker container or distro without systemctl, reload caddy as a background process
                 reload_cmd = f"caddy reload --config {str(self.caddyfile)}"
                 try:
@@ -157,6 +159,7 @@ class CaddyConfig:
                         check=True,
                         text=True,
                         stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
                     )
                 except subprocess.CalledProcessError as e:
                     raise RuntimeError(f"Failed to run Caddy install command: {e}")
@@ -255,7 +258,7 @@ class CaddyConfig:
             text=True,
         )
         if result.returncode != 0:
-            if "systemctl: command not found" in result.stderr:
+            if SYSTEMCTL_ERROR in result.stderr:
                 # If running in a docker container or distro without systemctl, check whether Caddy has been configured
                 run_cmd = f"caddy validate --config {str(self.caddyfile)}"
                 try:
@@ -265,6 +268,7 @@ class CaddyConfig:
                         check=True,
                         text=True,
                         stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
                     )
                 except subprocess.CalledProcessError as e:
                     logger.warning(e)
@@ -305,7 +309,7 @@ class CaddyConfig:
             text=True,
         )
         if result.returncode != 0:
-            if "systemctl: command not found" in result.stderr:
+            if SYSTEMCTL_ERROR in result.stderr:
                 # If running in a docker container or distro without systemctl, we need to start Caddy manually
                 # as a background process
                 run_cmd = "caddy start"
@@ -316,6 +320,7 @@ class CaddyConfig:
                         check=True,
                         text=True,
                         stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
                     )
                 except subprocess.CalledProcessError as e:
                     raise RuntimeError(

--- a/runhouse/servers/http/certs.py
+++ b/runhouse/servers/http/certs.py
@@ -15,16 +15,14 @@ logger = logging.getLogger(__name__)
 
 
 class TLSCertConfig:
-    """Handler for creating and managing the TLS certs needed to enable HTTPS on the Runhouse API server.
-    Note that this class can be initialized both locally and on the cluster, which affects the default file
-    paths for storing the generated certs."""
+    """Handler for creating and managing the TLS certs needed to enable HTTPS on the Runhouse API server."""
 
     CERT_NAME = "rh_server.crt"
     PRIVATE_KEY_NAME = "rh_server.key"
     TOKEN_VALIDITY_DAYS = 365
 
     # Base directory for certs stored locally
-    LOCAL_PRIVATE_KEY_DIR = "~/.rh/certs/private"
+    # Note: Each user will have their own set of certs, to be reused on for each cluster
     LOCAL_CERT_DIR = "~/.rh/certs"
 
     # https://caddy.community/t/permission-denied-error-when-caddy-try-to-save-the-certificate/15026
@@ -34,32 +32,16 @@ class TLSCertConfig:
     CADDY_CLUSTER_DIR = "/var/lib/caddy"
     DEFAULT_CLUSTER_DIR = "~/certs"
 
-    def __init__(
-        self, cert_path: str = None, key_path: str = None, dir_name: str = None
-    ):
+    def __init__(self, cert_path: str = None, key_path: str = None):
         self._cert_path = cert_path
         self._key_path = key_path
-
-        # Useful for initializing locally, where the user may have multiple certs stored for different clusters
-        # Each cluster will have its own directory for storing the cert / private key files
-        self.dir_name = dir_name
 
     @property
     def cert_path(self):
         if self._cert_path is not None:
             return resolve_absolute_path(self._cert_path)
 
-        if not self.dir_name:
-            # Default cert path when initializing on a cluster
-            return str(Path(f"{self.LOCAL_CERT_DIR}/{self.CERT_NAME}").expanduser())
-        else:
-            # Default cert path when initializing locally - certs to be saved locally in a folder dedicated to the
-            # relevant cluster
-            return str(
-                Path(
-                    f"{self.LOCAL_CERT_DIR}/{self.dir_name}/{self.CERT_NAME}"
-                ).expanduser()
-            )
+        return str(Path(f"{self.LOCAL_CERT_DIR}/{self.CERT_NAME}").expanduser())
 
     @cert_path.setter
     def cert_path(self, cert_path):
@@ -70,20 +52,7 @@ class TLSCertConfig:
         if self._key_path is not None:
             return resolve_absolute_path(self._key_path)
 
-        if not self.dir_name:
-            # Default cert path when initializing on a cluster
-            return str(
-                Path(
-                    f"{self.LOCAL_PRIVATE_KEY_DIR}/{self.PRIVATE_KEY_NAME}"
-                ).expanduser()
-            )
-        else:
-            # Default cert path when initializing locally
-            return str(
-                Path(
-                    f"{self.LOCAL_PRIVATE_KEY_DIR}/{self.dir_name}/{self.PRIVATE_KEY_NAME}"
-                ).expanduser()
-            )
+        return str(Path(f"{self.LOCAL_CERT_DIR}/{self.PRIVATE_KEY_NAME}").expanduser())
 
     @key_path.setter
     def key_path(self, key_path):

--- a/tests/test_resources/test_clusters/cluster_tests.py
+++ b/tests/test_resources/test_clusters/cluster_tests.py
@@ -177,7 +177,6 @@ def test_start_server_with_custom_certs(
     TLSCertConfig(
         key_path=ssl_keyfile,
         cert_path=ssl_certfile,
-        dir_name=ondemand_https_cluster_with_auth.name,
     ).generate_certs(address=ondemand_https_cluster_with_auth.address)
 
     # # Restart the server using the custom certs

--- a/tests/test_servers/test_caddy.py
+++ b/tests/test_servers/test_caddy.py
@@ -349,7 +349,12 @@ class TestCaddyServerLocally:
 
     @pytest.mark.level("local")
     def test_using_caddy_on_local_cluster(self, cluster):
-        protocol = "https" if cluster._use_https else "http"
+        if cluster._use_https:
+            protocol = "https"
+            # Ensure cluster has certs copied over
+            cluster.restart_server()
+        else:
+            protocol = "http"
 
         cluster.check_server()
 


### PR DESCRIPTION
Instead of generating separate certs for each cluster, have a single set of certs per user to be re-used across clusters