### PR TITLE
Fix Server defaulting and use certs in HTTPClient

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -90,7 +90,7 @@ class Cluster(Resource):
         self.ssl_certfile = ssl_certfile
         self.ssl_keyfile = ssl_keyfile
         self.server_connection_type = server_connection_type
-        self.server_port = server_port or DEFAULT_SERVER_PORT
+        self.server_port = server_port
         self.client_port = client_port
         self.ssh_port = ssh_port or self.DEFAULT_SSH_PORT
         self.server_host = server_host

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -50,7 +50,7 @@ class HTTPClient:
         self.system = system
         self.client = requests.Session()
         self.client.auth = self.auth
-        self.client.verify = self.verify
+        self.client.verify = self.cert_path if self.verify else False
         self.client.timeout = None
 
     def _use_cert_verification(self):
@@ -70,9 +70,8 @@ class HTTPClient:
 
         if cert.issuer == cert.subject:
             warnings.warn(
-                f"Cert in use ({cert_path}) is self-signed, cannot verify in requests to server."
+                f"Cert in use ({cert_path}) is self-signed, cannot independently verify it."
             )
-            return False
 
         return True
 

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -107,7 +107,7 @@ class TestHTTPClient:
             use_https=True,
             cert_path="/self-signed/path",
         )
-        assert not client.verify
+        assert client.verify
 
         # Test with HTTPS enabled and an invalid cert path
         mock_exists.return_value = False


### PR DESCRIPTION
We were overriding the daemon settings when starting the HTTP server and applying incorrect settings,
and also not using the certs in the HTTPClient to verify requests. This fixes both.