### PR TITLE
RNS client error should match the new modified log string.

### DIFF
--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -317,8 +317,9 @@ class RNSClient:
             request_headers = self.request_headers()
             if not request_headers:
                 raise PermissionError(
-                    "No Runhouse token found. Please log in using `rh.login()` or `runhouse login`. "
-                    "If you do not have an account, you can create one at https://run.house/login."
+                    "No Runhouse token provided. Try running `$ runhouse login` or visiting "
+                    "https://run.house/login to retrieve a token. If calling via HTTP, please "
+                    "provide a valid token in the Authorization header."
                 )
 
             resource_uri = self.resource_uri(name)


### PR DESCRIPTION
We now catch in `handle_exception_response` a `PermissionError` and check if
the text is `No Runhouse Token Provided.` in order to raise the appropriate
HTTPException error. This was not being caught because the log string wasn't
updated, so therefore the error was getting raised on the server and causing
a 500.
