### PR TITLE
Recognize workdir based on setup.cfg

### DIFF
--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -119,6 +119,7 @@ class RNSClient:
         for search_target in [
             ".git",
             "setup.py",
+            "setup.cfg",
             "pyproject.toml",
             "rh",
             "requirements.txt",


### PR DESCRIPTION
We recognize a workdir based on setup.py, pyproject.toml, .git, etc., but we're missing
setup.cfg as a packaging specifier.