### PR TITLE
Set unique ssh control path per address:ssh_port

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -872,7 +872,12 @@ class Cluster(Resource):
         ssh_credentials.pop("ssh_host", node)
         pwd = ssh_credentials.pop("password", None)
 
-        runner = SkySSHRunner(node, **ssh_credentials, port=self.ssh_port)
+        runner = SkySSHRunner(
+            node,
+            **ssh_credentials,
+            ssh_control_name=f"{node}:{self.ssh_port}",
+            port=self.ssh_port,
+        )
         if not pwd:
             if up:
                 runner.run(["mkdir", "-p", dest], stream_logs=False)
@@ -1068,7 +1073,12 @@ class Cluster(Resource):
         host = ssh_credentials.pop("ssh_host", node or self.address)
         pwd = ssh_credentials.pop("password", None)
 
-        runner = SkySSHRunner(host, **ssh_credentials, port=self.ssh_port)
+        runner = SkySSHRunner(
+            host,
+            **ssh_credentials,
+            ssh_control_name=f"{host}:{self.ssh_port}",
+            port=self.ssh_port,
+        )
 
         if not pwd:
             for command in commands:

--- a/runhouse/resources/hardware/sagemaker/sagemaker_cluster.py
+++ b/runhouse/resources/hardware/sagemaker/sagemaker_cluster.py
@@ -668,6 +668,7 @@ class SageMakerCluster(Cluster):
                     port=self.ssh_port,
                     ssh_user=self.DEFAULT_USER,
                     ssh_private_key=self._abs_ssh_key_path,
+                    ssh_control_name=f"{self.name}:{self.ssh_port}",
                 )
                 command = f"{cmd_prefix} {command}" if cmd_prefix else command
                 logger.info(f"Running command on {self.name}: {command}")

--- a/runhouse/resources/hardware/sky_ssh_runner.py
+++ b/runhouse/resources/hardware/sky_ssh_runner.py
@@ -422,7 +422,12 @@ def ssh_tunnel(
                 # Host could be a proxy specified in credentials or is the provided address
                 host = ssh_credentials.pop("ssh_host", address)
 
-                runner = SkySSHRunner(host, **ssh_credentials, port=ssh_port)
+                runner = SkySSHRunner(
+                    host,
+                    **ssh_credentials,
+                    ssh_control_name=f"{address}:{ssh_port}",
+                    port=ssh_port,
+                )
                 runner.tunnel(local_port, remote_port)
                 ssh_tunnel = runner  # Just to keep the object in memory
             else:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -4,12 +4,13 @@ import requests
 
 @pytest.mark.level("local")
 def test_public_key_cluster_has_telemetry(docker_cluster_pk_ssh_telemetry):
-    cluster = docker_cluster_pk_ssh_telemetry
-    cluster.check_server()
-    assert cluster.is_up()  # Should be true for a Cluster object
+    docker_cluster_pk_ssh_telemetry.check_server()
+    assert (
+        docker_cluster_pk_ssh_telemetry.is_up()
+    )  # Should be true for a Cluster object
 
     # Make a GET request to the /spans endpoint
-    response = requests.get(f"http://{cluster.address}:{cluster.server_port}/spans")
+    response = requests.get(f"{docker_cluster_pk_ssh_telemetry.endpoint()}/spans")
 
     # Check the status code
     assert response.status_code == 200


### PR DESCRIPTION
We need to set unique control paths per cluster, and address:ssh_port is
the way we currently distinguish between clusters (including localhost:32322, etc.)