### PR TITLE
Change requests.Session scope to be global

### DIFF
--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -37,6 +37,7 @@ class TestHTTPClient:
         mocked_get.assert_called_once_with(
             f"http://localhost:{DEFAULT_SERVER_PORT}/check",
             timeout=HTTPClient.CHECK_TIMEOUT_SEC,
+            verify=False,
         )
 
     @pytest.mark.level("unit")
@@ -170,6 +171,8 @@ class TestHTTPClient:
             json=expected_json_data,
             stream=True,
             headers=expected_headers,
+            auth=None,
+            verify=False,
         )
 
     @pytest.mark.level("unit")
@@ -209,6 +212,8 @@ class TestHTTPClient:
             json=expected_json_data,
             stream=True,
             headers=expected_headers,
+            auth=None,
+            verify=False,
         )
 
     @pytest.mark.level("unit")


### PR DESCRIPTION
Turns out requests.Session only pools HTTP connections within a session:
https://github.com/psf/requests/issues/3445#issuecomment-263820399

We were creating new connections to the same cluster for no reason. Now we use
a global pool for the process. It would be nice to pool across processes, but
not sure that's straightforward, as requests is barely even threadsafe.