### PR TITLE
Add tls and HTTP docker fixture to LOCAL tests

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -119,10 +119,18 @@ class HTTPClient:
     @staticmethod
     def from_endpoint(endpoint: str, auth=None, cert_path=None):
         protocol, uri = endpoint.split("://")
-        host, port_and_route = uri.split(":", 1)
-        port, _ = port_and_route.split("/", 1)
+        if protocol not in ["http", "https"]:
+            raise ValueError(f"Invalid protocol: {protocol}")
+        port = None
+        if ":" in uri:
+            host, port_and_route = uri.split(":", 1)
+            port, _ = port_and_route.split("/", 1)
+        else:
+            host, _ = uri.split("/", 1)
         use_https = protocol == "https"
-        client = HTTPClient(host, int(port), auth, cert_path, use_https=False)
+        client = HTTPClient(
+            host, int(port) if port else None, auth, cert_path, use_https=False
+        )
         client.use_https = use_https
         return client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,8 +306,10 @@ default_fixtures[TestLevels.UNIT] = {
 }
 default_fixtures[TestLevels.LOCAL] = {
     "cluster": [
-        "docker_cluster_pk_ssh_no_auth",
-        "docker_cluster_pk_ssh_den_auth",
+        "docker_cluster_pk_ssh_no_auth",  # Represents private dev use case
+        # "docker_cluster_pk_ssh_den_auth",  # Helps isolate Auth issues
+        "docker_cluster_pk_tls_den_auth",  # Represents public app use case
+        "docker_cluster_pk_http_exposed",  # Represents within VPC use case
     ]
 }
 default_fixtures[TestLevels.MINIMAL] = {

--- a/tests/test_resources/test_modules/test_functions/test_function.py
+++ b/tests/test_resources/test_modules/test_functions/test_function.py
@@ -116,6 +116,7 @@ class TestFunction:
         assert not rh.exists(REMOTE_FUNC_NAME)
 
     @pytest.mark.level("local")
+    @pytest.mark.asyncio
     async def test_async_function(self, cluster):
         remote_sum = rh.function(async_summer).to(cluster)
         res = await remote_sum(1, 5)
@@ -151,6 +152,7 @@ class TestFunction:
         assert len(results) == 5
 
     @pytest.mark.level("local")
+    @pytest.mark.asyncio
     async def test_async_generator(self, cluster):
         remote_slow_generator = rh.function(async_slow_generator).to(cluster)
         results = []
@@ -271,7 +273,14 @@ class TestFunction:
     @pytest.mark.level("local")
     def test_share_and_revoke_function(self, cluster):
         # TODO: refactor in order to test the function.share() method.
-        my_function = rh.function(fn=summer).to(cluster).save(REMOTE_FUNC_NAME)
+        my_function = rh.function(fn=summer).to(cluster)
+        if cluster.server_connection_type in ["tls", "none"]:
+            my_function.set_endpoint(
+                f"{cluster.endpoint()}:{cluster.client_port}/{my_function.name}"
+            )
+        else:
+            my_function.set_endpoint(f"{cluster.endpoint()}/{my_function.name}")
+        my_function.save(REMOTE_FUNC_NAME)
 
         my_function.share(
             users=["info@run.house"],
@@ -333,10 +342,12 @@ class TestFunction:
 
     @pytest.mark.level("local")
     def test_http_url(self, cluster):
-        # TODO convert into something like function.request_args() and/or function.curl_command()
         remote_sum = rh.function(summer).to(cluster).save("@/remote_function")
         ssh_creds = cluster.ssh_creds
-        addr = remote_sum.endpoint(external=False)
+        if cluster.server_connection_type in ["tls", "none"]:
+            addr = f"{cluster.endpoint()}:{cluster.client_port}/{remote_sum.name}"
+        else:
+            addr = remote_sum.endpoint()
         auth = (
             (ssh_creds.get("ssh_user"), ssh_creds.get("password"))
             if ssh_creds.get("password")
@@ -359,20 +370,6 @@ class TestFunction:
             verify=verify,
         ).json()
         assert sum2 == 3
-
-    @pytest.mark.skip("Not yet implemented.")
-    @pytest.mark.level("local")
-    def test_http_url_with_curl(self):
-        # TODO: refactor needed, once the Function.http_url() is implemented.
-        # NOTE: Assumes the Function has already been created and deployed to running cluster
-        s = rh.function(name="test_function")
-        curl_cmd = s.http_url(a=1, b=2, curl_command=True)
-        print(curl_cmd)
-
-        # delete_configs the function data from the RNS
-        self.delete_function_from_rns(s)
-
-        assert True
 
     @pytest.mark.skip(
         "Clean up following local daemon refactor. Function probably doesn't need .get anymore."


### PR DESCRIPTION
Previously we had limited coverage of TLS and None connection types.