### PR TITLE
cluster from_name bugfix

### DIFF
--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -91,12 +91,10 @@ def cluster(
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,
             domain=domain,
-            kwargs=kwargs,
+            kwargs=kwargs if len(kwargs) > 0 else None,
         )
         # Filter out None/default values
-        alt_options = {
-            k: v for k, v in alt_options.items() if v is not None and len(v) > 0
-        }
+        alt_options = {k: v for k, v in alt_options.items() if v is not None}
         try:
             c = Cluster.from_name(name, dryrun, alt_options=alt_options)
             if c:

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -91,11 +91,12 @@ def cluster(
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,
             domain=domain,
-            den_auth=den_auth,
             kwargs=kwargs,
         )
         # Filter out None/default values
-        alt_options = {k: v for k, v in alt_options.items() if v is not None}
+        alt_options = {
+            k: v for k, v in alt_options.items() if v is not None and len(v) > 0
+        }
         try:
             c = Cluster.from_name(name, dryrun, alt_options=alt_options)
             if c:


### PR DESCRIPTION
When we were trying to load a cluster from den created a new cluster instance instead of loading the existing config from den. 