### PR TITLE
Fix `name` not being updated in cluster servlet and breaking `on_this_cluster`.

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -475,6 +475,9 @@ class HTTPClient:
             )
         return res
 
+    def set_cluster_name(self, name: str):
+        return self.set_settings({"cluster_name": name})
+
     def delete(self, keys=None, env=None):
         return self.request_json(
             "delete_object",

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -310,6 +310,9 @@ class HTTPServer:
     @app.post("/settings")
     @validate_cluster_access
     def update_settings(request: Request, message: ServerSettings) -> Response:
+        if message.cluster_name:
+            obj_store.set_cluster_config_value("name", message.cluster_name)
+
         if message.den_auth:
             HTTPServer.enable_den_auth(flush=message.flush_auth_cache)
         elif message.den_auth is not None and not message.den_auth:

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -33,6 +33,7 @@ class RequestContext(BaseModel):
 
 
 class ServerSettings(BaseModel):
+    cluster_name: Optional[str] = None
     den_auth: Optional[bool] = None
     flush_auth_cache: Optional[bool] = None
 

--- a/tests/fixtures/docker_cluster_fixtures.py
+++ b/tests/fixtures/docker_cluster_fixtures.py
@@ -369,7 +369,6 @@ def set_up_local_cluster(
     # the "owner's" token) to the container in many cases, so we're relying on authenticating the caller
     # to the server through Den. If the cluster isn't saved before coming up, the config in the cluster servlet
     # doesn't have the rns address, and the auth verification to Den fails.
-    rh_cluster.save()
 
     # Can't use the defaults_cache alone because we may need the token or username from the env variables
     config = rh.configs.defaults_cache
@@ -391,6 +390,8 @@ def set_up_local_cluster(
         else False,
         name="base_env",
     ).to(rh_cluster)
+
+    rh_cluster.save()
 
     def cleanup():
         docker_client.containers.get(container_name).stop()


### PR DESCRIPTION
In [this PR](https://app.graphite.dev/github/pr/run-house/runhouse/434/Only-set-rns_address-upon-save), @dongreenberg sets it up so RNS address is only set on save.

However, we set the cluster name within the cluster servlet remotely once, and then if the RNS address was updated, on_this_cluster would fail since it checked _current_cluster("name") == self.rns_address. So, when RNS address is updated, I now also send a request to the daemon and set the cluster name in the config