### PR TITLE
Move `save()` back to before the env installation.

### DIFF
--- a/tests/fixtures/docker_cluster_fixtures.py
+++ b/tests/fixtures/docker_cluster_fixtures.py
@@ -369,6 +369,7 @@ def set_up_local_cluster(
     # the "owner's" token) to the container in many cases, so we're relying on authenticating the caller
     # to the server through Den. If the cluster isn't saved before coming up, the config in the cluster servlet
     # doesn't have the rns address, and the auth verification to Den fails.
+    rh_cluster.save()
 
     # Can't use the defaults_cache alone because we may need the token or username from the env variables
     config = rh.configs.defaults_cache
@@ -390,8 +391,6 @@ def set_up_local_cluster(
         else False,
         name="base_env",
     ).to(rh_cluster)
-
-    rh_cluster.save()
 
     def cleanup():
         docker_client.containers.get(container_name).stop()


### PR DESCRIPTION
@josh is passing the `rns_address` to `HTTPClient` in `connect_server_client`,
and this is not set properly unless the `cluster` is saved. Moving the save
back to unblock.
