### PR TITLE
Change all `serialize_data` and `deserialize_data` spots to take lists instead of tuples.

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -799,7 +799,7 @@ class Cluster(Resource):
             module_name,
             method_name,
             stream_logs=stream_logs,
-            data=(args, kwargs),
+            data=[args, kwargs],
             run_name=run_name,
             remote=remote,
             run_async=run_async,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -586,7 +586,7 @@ class Module(Resource):
                 return client.call(
                     key=name,
                     method_name=key,
-                    data=([value], {}),
+                    data=[[value], {}],
                 )
 
             @classmethod
@@ -648,7 +648,7 @@ class Module(Resource):
         else:
             if not client or not name:
                 return self.resolved_state(**kwargs)
-            return client.call(name, "resolved_state", data=((), kwargs))
+            return client.call(name, "resolved_state", data=[(), kwargs])
 
     async def fetch_async(self, key: str, remote: bool = False):
         """Async version of fetch. Can't be a property like `fetch` because __getattr__ can't be awaited.

--- a/runhouse/servers/env_servlet.py
+++ b/runhouse/servers/env_servlet.py
@@ -95,7 +95,7 @@ class EnvServlet:
         data: Any,  # This first comes in a serialized format which the decorator re-populates after deserializing
         serialization: Optional[str] = None,
     ):
-        resource_config, state, dryrun = data
+        resource_config, state, dryrun = tuple(data)
         return obj_store.put_resource_local(resource_config, state, dryrun)
 
     @error_handling_decorator
@@ -114,7 +114,7 @@ class EnvServlet:
         remote: bool = False,
         ctx: Optional[dict] = None,
     ):
-        args, kwargs = data or ([], {})
+        args, kwargs = tuple(data) if data else ([], {})
         return obj_store.call_local(
             key,
             method_name,

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -396,7 +396,7 @@ class HTTPClient:
             req_type="post",
             # TODO wire up dryrun properly
             json_dict=PutResourceParams(
-                serialized_data=pickle_b64((config, state, dryrun)),
+                serialized_data=pickle_b64([config, state, dryrun]),
                 env_name=env_name,
                 serialization="pickle",
             ).dict(),

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -1067,7 +1067,9 @@ class ObjStore:
         ):
             from runhouse.servers.http.http_utils import deserialize_data
 
-            args, kwargs = deserialize_data(data, serialization) if data else ([], {})
+            args, kwargs = (
+                tuple(deserialize_data(data, serialization)) if data else ([], {})
+            )
 
             res = self.call_local(
                 key,
@@ -1138,15 +1140,15 @@ class ObjStore:
 
         env_name = env_name or self.servlet_name
         if self.has_local_storage and env_name == self.servlet_name:
-            resource_config, state, dryrun = deserialize_data(
-                serialized_data, serialization
+            resource_config, state, dryrun = tuple(
+                deserialize_data(serialized_data, serialization)
             )
             return self.put_resource_local(resource_config, state, dryrun)
 
         # Normally, serialization and deserialization happens within the servlet
         # However, if we're putting an env, we need to deserialize it here and
         # actually create the corresponding env servlet.
-        resource_config, _, _ = deserialize_data(serialized_data, serialization)
+        resource_config, _, _ = tuple(deserialize_data(serialized_data, serialization))
         if resource_config["resource_type"] == "env":
 
             # Note that the passed in `env_name` and the `env_name_to_create` here are

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -187,11 +187,11 @@ class TestHTTPClient:
         module_name = "module"
         method_name = "install"
 
-        self.client.call(module_name, method_name, data=(args, kwargs))
+        self.client.call(module_name, method_name, data=[args, kwargs])
 
         # Assert that the post request was called with the correct data
         expected_json_data = {
-            "data": pickle_b64((args, kwargs)),
+            "data": pickle_b64([args, kwargs]),
             "serialization": "pickle",
             "run_name": None,
             "stream_logs": True,


### PR DESCRIPTION
Tuples aren't json serializable. Therefore when we are passing arguments around that could be serialized as json (since we support None, json, pickle), we should have them packed as Lists. When we unpack these, we cast them to tuples and use normal tuple unwrapping methods; this allows us to still check the arguments are in the form we expect.