### PR TITLE
Remove use of `pickle_b64` and `b64_unpickle` directly.

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -20,7 +20,6 @@ from runhouse.servers.http.http_utils import (
     GetObjectParams,
     handle_response,
     OutputType,
-    pickle_b64,
     PutObjectParams,
     PutResourceParams,
     RenameObjectParams,
@@ -308,7 +307,7 @@ class HTTPClient:
             self._formatted_url(f"{key}/{method_name}"),
             json=CallParams(
                 data=serialize_data(data, serialization),
-                serialization="pickle",
+                serialization=serialization,
                 run_name=run_name,
                 stream_logs=stream_logs,
                 save=save,
@@ -380,7 +379,7 @@ class HTTPClient:
             req_type="post",
             json_dict=PutObjectParams(
                 key=key,
-                serialized_data=pickle_b64(value),
+                serialized_data=serialize_data(value, "pickle"),
                 env_name=env,
                 serialization="pickle",
             ).dict(),
@@ -396,7 +395,7 @@ class HTTPClient:
             req_type="post",
             # TODO wire up dryrun properly
             json_dict=PutResourceParams(
-                serialized_data=pickle_b64([config, state, dryrun]),
+                serialized_data=serialize_data([config, state, dryrun], "pickle"),
                 env_name=env_name,
                 serialization="pickle",
             ).dict(),

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -36,7 +36,6 @@ from runhouse.servers.http.http_utils import (
     get_token_from_request,
     handle_exception_response,
     OutputType,
-    pickle_b64,
     PutObjectParams,
     PutResourceParams,
     RenameObjectParams,
@@ -238,14 +237,16 @@ class HTTPServer:
                 cert = cert_file.read()
 
             return Response(
-                data=pickle_b64(cert), output_type=OutputType.RESULT_SERIALIZED
+                data=serialize_data(cert, "pickle"),
+                output_type=OutputType.RESULT_SERIALIZED,
+                serialization="pickle",
             )
 
         except Exception as e:
             logger.exception(e)
             return Response(
-                error=pickle_b64(e),
-                traceback=pickle_b64(traceback.format_exc()),
+                error=serialize_data(e, "pickle"),
+                traceback=serialize_data(traceback.format_exc(), "pickle"),
                 output_type=OutputType.EXCEPTION,
             )
 
@@ -265,8 +266,8 @@ class HTTPServer:
             logger.exception(e)
             HTTPServer.register_activity()
             return Response(
-                error=pickle_b64(e),
-                traceback=pickle_b64(traceback.format_exc()),
+                error=serialize_data(e, "pickle"),
+                traceback=serialize_data(traceback.format_exc(), "pickle"),
                 output_type=OutputType.EXCEPTION,
             )
 
@@ -301,8 +302,8 @@ class HTTPServer:
             logger.exception(e)
             HTTPServer.register_activity()
             return Response(
-                error=pickle_b64(e),
-                traceback=pickle_b64(traceback.format_exc()),
+                error=serialize_data(e, "pickle"),
+                traceback=serialize_data(traceback.format_exc(), "pickle"),
                 output_type=OutputType.EXCEPTION,
             )
 

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -194,8 +194,8 @@ def handle_response(
     elif output_type == OutputType.SUCCESS:
         return
     elif output_type == OutputType.EXCEPTION:
-        fn_exception = b64_unpickle(response_data["error"])
-        fn_traceback = b64_unpickle(response_data["traceback"])
+        fn_exception = deserialize_data(response_data["error"], "pickle")
+        fn_traceback = deserialize_data(response_data["traceback"], "pickle")
         if not (
             isinstance(fn_exception, StopIteration)
             or isinstance(fn_exception, GeneratorExit)

--- a/tests/test_servers/test_caddy.py
+++ b/tests/test_servers/test_caddy.py
@@ -8,7 +8,7 @@ import requests
 
 from runhouse.globals import rns_client
 from runhouse.servers.caddy.config import CaddyConfig
-from runhouse.servers.http.http_utils import pickle_b64, PutObjectParams
+from runhouse.servers.http.http_utils import PutObjectParams, serialize_data
 
 
 @pytest.mark.servertest
@@ -361,7 +361,9 @@ class TestCaddyServerLocally:
         response = requests.post(
             f"{protocol}://{cluster.server_address}:{cluster.client_port}/object",
             json=PutObjectParams(
-                serialized_data=pickle_b64(test_list), key=key, serialization="pickle"
+                serialized_data=serialize_data(test_list, "pickle"),
+                key=key,
+                serialization="pickle",
             ).dict(),
             headers=rns_client.request_headers(),
             verify=verify,

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -10,8 +10,8 @@ from runhouse.globals import rns_client
 from runhouse.servers.http import HTTPClient
 from runhouse.servers.http.http_utils import (
     DeleteObjectParams,
-    pickle_b64,
     PutObjectParams,
+    serialize_data,
 )
 
 
@@ -128,7 +128,7 @@ class TestHTTPClient:
             json.dumps(
                 {
                     "output_type": "result_serialized",
-                    "data": pickle_b64("final_result"),
+                    "data": serialize_data("final_result", "pickle"),
                     "serialization": "pickle",
                 }
             ),
@@ -191,7 +191,7 @@ class TestHTTPClient:
 
         # Assert that the post request was called with the correct data
         expected_json_data = {
-            "data": pickle_b64([args, kwargs]),
+            "data": serialize_data([args, kwargs], "pickle"),
             "serialization": "pickle",
             "run_name": None,
             "stream_logs": True,
@@ -244,7 +244,7 @@ class TestHTTPClient:
 
         key = "my_list"
         value = list(range(5, 50, 2)) + ["a string"]
-        expected_data = pickle_b64(value)
+        expected_data = serialize_data(value, "pickle")
 
         self.client.put_object(key, value)
 


### PR DESCRIPTION
Everywhere we can, use `serialize_data` and `deserialize_data`, especially in tests. This allows us to later parameterize our tests to work with other serialization types (e.g. `json`) and make sure they still work correctly :).

A few spots change the tests to use the response serialization type.

Update the `/cert` method to work correctly.