### PR TITLE
Only write out execution logs if we need them

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -801,6 +801,7 @@ class Cluster(Resource):
                 data=(args, kwargs),
                 stream_logs=stream_logs,
                 run_name=run_name,
+                # remote=remote,
                 run_async=run_async,
                 serialization=None,
             )

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -338,8 +338,10 @@ class HTTPServer:
                     key=key,
                     method_name=method_name,
                     data=params.data,
+                    stream_logs=params.stream_logs,
                     serialization=params.serialization,
                     run_name=params.run_name,
+                    # remote=params.remote,
                     run_async=True,
                 )
             )

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -883,12 +883,15 @@ class ObjStore:
 
         from runhouse.resources.provenance import run
 
-        log_ctx = run(
-            name=run_name,
-            log_dest="file" if run_name else None,
-            load=False,
-        )
-        log_ctx.__enter__()
+        log_ctx = None
+        if stream_logs:
+            # When we start collecting logs for telemetry, we'll enter here too
+            log_ctx = run(
+                name=run_name,
+                log_dest="file" if run_name else None,
+                load=False,
+            )
+            log_ctx.__enter__()
 
         obj = self.get_local(key, default=KeyError)
 
@@ -998,7 +1001,8 @@ class ObjStore:
             )
             fut = self.construct_call_retrievable(res, run_name, laziness_type)
             self.put_local(run_name, fut)
-            log_ctx.__exit__(None, None, None)
+            if log_ctx:
+                log_ctx.__exit__(None, None, None)
             return fut
 
         from runhouse.resources.resource import Resource
@@ -1020,7 +1024,8 @@ class ObjStore:
                 # If remote is True and the result is a resource, we return just the config
                 res = res.config_for_rns
 
-        log_ctx.__exit__(None, None, None)
+        if log_ctx:
+            log_ctx.__exit__(None, None, None)
 
         return res
 


### PR DESCRIPTION
Right now we're always writing out function call logs, which has a performance implication.
When I ran a server benchmark it introduced a few thousand nearly empty logfiles, even
though I wasn't streaming logs. For now, we can only write them out if stream_logs=True,
as the log info is also available in server.log if needed. When we collect logs in telemetry,
we can write them out then too as needed.