### PR TITLE
Disable Telemetry Correctly

### DIFF
--- a/runhouse/servers/env_servlet.py
+++ b/runhouse/servers/env_servlet.py
@@ -37,7 +37,7 @@ def error_handling_decorator(func):
         # the exception if there is one, instead of returning a Response object.
         try:
             output = func(*args, **kwargs)
-            if serialization is None:
+            if serialization is None or serialization == "none":
                 obj_store.unset_ctx(ctx_token) if ctx_token else None
                 return output
             if output is not None:

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -105,7 +105,7 @@ def deserialize_data(data: Any, serialization: Optional[str]):
         return json.loads(data)
     elif serialization == "pickle":
         return b64_unpickle(data)
-    elif serialization == "none" or serialization is None:
+    elif serialization is None or serialization == "none":
         return data
     else:
         raise ValueError(f"Invalid serialization type {serialization}")
@@ -122,7 +122,7 @@ def serialize_data(data: Any, serialization: Optional[str]):
             return json.dumps(str(e))
     elif serialization == "pickle":
         return pickle_b64(data)
-    elif serialization == "none" or serialization is None:
+    elif serialization is None or serialization == "none":
         return data
     else:
         raise ValueError(f"Invalid serialization type {serialization}")

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -603,7 +603,7 @@ class ObjStore:
         # package the config back into the remote object here before returning it.
         if (
             remote
-            and serialization is None
+            and (serialization is None or serialization == "none")
             and isinstance(res, dict)
             and "resource_type" in res
         ):


### PR DESCRIPTION
We should be disabling telemetry altogether if disable_usage_stats is True and
use_local_telemetry is False. Also, we should be returning bare results if serialization="none",
meaning no Response packaging, just as we do if serialization is None.