### PR TITLE
Fix loading port from endpoint to be `443` or `80` by default.

### DIFF
--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -130,9 +130,13 @@ class HTTPClient:
         else:
             host, _ = uri.split("/", 1)
         use_https = protocol == "https"
-        client = HTTPClient(
-            host, int(port) if port else None, auth, cert_path, use_https=False
-        )
+
+        if port is None:
+            port = 443 if use_https else 80
+        else:
+            port = int(port)
+
+        client = HTTPClient(host, port, auth, cert_path, use_https=False)
         client.use_https = use_https
         return client
 


### PR DESCRIPTION
Bug when doing:

```
import runhouse as rh

sg = rh.fn(name="/dongreenberg/get_stargazers")
for users in sg("run-house/runhouse"):
  print(users)
```
