### PR TITLE
Add `clusters` documentation page.

### DIFF
--- a/docs/notebooks/api/clusters.ipynb
+++ b/docs/notebooks/api/clusters.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c3aa5bf1-c65c-454a-af40-8b6b9264cd97",
+   "metadata": {},
+   "source": [
+    "# Clusters\n",
+    "\n",
+    "A cluster is the most basic form of compute in Runhouse, largely representing a group of instances or VMs connected with Ray. They largely fall in two categories:\n",
+    "\n",
+    "1. Static Clusters: Any machine you have SSH access to, set up with IP addresses and SSH credentials.\n",
+    "2. On-Demand Clusters: Any cloud instance spun up automatically for you with your cloud credentials.\n",
+    "\n",
+    "Runhouse provides various APIs for interacting with remote clusters, such as terminating an on-demand cloud cluster or running remote CLI or Python commands from your local dev environment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d01dd1c-8309-4fa6-91d3-9ca6efa6aa79",
+   "metadata": {},
+   "source": [
+    "Let's start with a simple example using AWS. After making sure your `~/.aws/credentials` file is set up with access to create instances in EC2, you can install Runhouse and create on-demand clusters in AWS. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "353a310c-9d05-4b49-af29-2ae372e03e9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install \"runhouse[aws]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "779febff-c940-4a55-bdf4-e94909777f05",
+   "metadata": {},
+   "source": [
+    "## On-Demand Clusters\n",
+    "\n",
+    "We can start by using the `rh.cluster` factory function to create our cluster. By specifying an `instance_type`, Runhouse sets up an On-Demand Cluster in AWS EC2 for us.\n",
+    "\n",
+    "Each cluster must be provided with a unique `name` identifier during construction. This `name` parameter is used for saving down or loading previous saved clusters, and also used for various CLI commands for the cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4778210a-1a30-4928-ac1d-ba81222d2668",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import runhouse as rh\n",
+    "\n",
+    "aws_cluster = rh.cluster(name=\"test-cluster\", instance_type=\"CPU:2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a45c01b-fdbc-40af-a4d2-fd35c7450bc2",
+   "metadata": {},
+   "source": [
+    "Next, we set up a basic function to throw up on our cluster. For more information about Functions & Modules that you can put up on a cluster, see [Functions & Modules](https://www.run.house/docs/tutorials/api/functions). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "29bc7bc3-bbe2-4d6e-9605-0f71c274bea6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_home(name: str):\n",
+    "    return f\"Run home {name}!\"\n",
+    "\n",
+    "remote_function = rh.function(run_home).to(aws_cluster)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2024df9-5735-4fa6-a56e-5d858be9dd90",
+   "metadata": {},
+   "source": [
+    "After running `.to`, your function is set up on the cluster to be called from anywhere. When you call `remote_function`, it executes remotely on your AWS instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bd0f621c-b7b8-4d96-b468-fb7604dfc58f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO | 2024-02-20 16:38:13.733518 | Calling run_home.call\n",
+      "INFO | 2024-02-20 16:38:14.807770 | Time to call run_home.call: 1.07 seconds\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Run home in cluster!!'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote_function(\"in cluster!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32cb4246-a772-4a35-a885-e066084e549a",
+   "metadata": {},
+   "source": [
+    "### On-Demand Clusters with TLS exposed\n",
+    "\n",
+    "In the previous example, the cluster that was brought up in EC2 is only accessible to the original user that has SSH credentials to the machine. However, you can set up a cluster with ports exposed to open Internet, and access objects and functions via `curl`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "fefb3c7b-2922-4700-b9a9-658e8f79274f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/rohinbhasin/work/runhouse/runhouse/resources/hardware/on_demand_cluster.py:317: UserWarning: Server is insecure and must be inside a VPC or have `den_auth` enabled to secure it.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "tls_cluster = rh.cluster(name=\"tls-cluster\",\n",
+    "                         instance_type=\"CPU:2\",\n",
+    "                         open_ports=[443], # expose HTTPS port to public\n",
+    "                         server_connection_type=\"tls\", # specify how runhouse communicates with this cluster\n",
+    "                         den_auth=False, # no authentication required to hit this cluster (NOT recommended)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59ac071b-875e-418e-86a1-12ccaa781580",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote_tls_function = rh.function(run_home).to(tls_cluster)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "bbc35b27-38ed-42ec-92a8-6d3ecf6accb8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO | 2024-02-20 17:09:03.605194 | Calling run_home.call\n",
+      "INFO | 2024-02-20 17:09:04.640570 | Time to call run_home.call: 1.04 seconds\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Run home Marvin!'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote_tls_function(\"Marvin\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "80cd254f-d29c-4d0f-b40d-779265404c34",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'3.86.210.191'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tls_cluster.address"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "fa9f3d90-d1e2-4630-9418-c788bff0606d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"data\":\"\\\"Run home Marvin!\\\"\",\"error\":null,\"traceback\":null,\"output_type\":\"result_serialized\",\"serialization\":\"json\"}"
+     ]
+    }
+   ],
+   "source": [
+    "! curl \"https://3.86.210.191/run_home/call?name=Marvin\" -k"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfe9ff82-066c-4211-bbab-40c9d3b85196",
+   "metadata": {},
+   "source": [
+    "## Static Clusters\n",
+    "\n",
+    "If you have existing machines within a VPC that you want to connect to, you can simply provide the IP addresses and path to SSH credentials to the machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "19d353a2-42c2-4c9d-b424-ae7f740d50e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster = rh.cluster(  # using private key\n",
+    "              name=\"cpu-cluster-existing\",\n",
+    "              ips=['<ip of the cluster>'],\n",
+    "              ssh_creds={'ssh_user': '<user>', 'ssh_private_key':'<path_to_key>'},\n",
+    "          )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d26b4fa5-620e-45ae-879e-30673968c124",
+   "metadata": {},
+   "source": [
+    "## Useful Cluster Functions "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d74f7f57-72c4-48d7-9479-e8dd63d4489b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: Permanently added '3.86.210.191' (ED25519) to the list of known hosts.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: numpy in /opt/conda/lib/python3.10/site-packages (1.26.4)\n",
+      "numpy==1.26.4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[(0,\n",
+       "  'Requirement already satisfied: numpy in /opt/conda/lib/python3.10/site-packages (1.26.4)\\nnumpy==1.26.4\\n',\n",
+       "  \"Warning: Permanently added '3.86.210.191' (ED25519) to the list of known hosts.\\r\\n\")]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tls_cluster.run(['pip install numpy && pip freeze | grep numpy'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "fa116b7c-9489-4d8f-b089-5ddcd10a7dc8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.26.4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[(0, '1.26.4\\n', '')]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tls_cluster.run_python(['import numpy', 'print(numpy.__version__)'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/api/clusters.rst
+++ b/docs/tutorials/api/clusters.rst
@@ -1,0 +1,222 @@
+Clusters
+========
+
+.. raw:: html
+
+    <p><a href="https://colab.research.google.com/github/run-house/runhouse/blob/stable/docs/notebooks/api/clusters.ipynb">
+    <img height="20px" width="117px" src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a></p>
+
+A cluster is the most basic form of compute in Runhouse, largely
+representing a group of instances or VMs connected with Ray. They
+largely fall in two categories:
+
+1. Static Clusters: Any machine you have SSH access to, set up with IP
+   addresses and SSH credentials.
+2. On-Demand Clusters: Any cloud instance spun up automatically for you
+   with your cloud credentials.
+
+Runhouse provides various APIs for interacting with remote clusters,
+such as terminating an on-demand cloud cluster or running remote CLI or
+Python commands from your local dev environment.
+
+Let’s start with a simple example using AWS. After making sure your
+``~/.aws/credentials`` file is set up with access to create instances in
+EC2, you can install Runhouse and create on-demand clusters in AWS.
+
+.. code:: ipython3
+
+    ! pip install "runhouse[aws]"
+
+On-Demand Clusters
+------------------
+
+We can start by using the ``rh.cluster`` factory function to create our
+cluster. By specifying an ``instance_type``, Runhouse sets up an
+On-Demand Cluster in AWS EC2 for us.
+
+Each cluster must be provided with a unique ``name`` identifier during
+construction. This ``name`` parameter is used for saving down or loading
+previous saved clusters, and also used for various CLI commands for the
+cluster.
+
+.. code:: ipython3
+
+    import runhouse as rh
+
+    aws_cluster = rh.cluster(name="test-cluster", instance_type="CPU:2")
+
+Next, we set up a basic function to throw up on our cluster. For more
+information about Functions & Modules that you can put up on a cluster,
+see `Functions &
+Modules <https://www.run.house/docs/tutorials/api/functions>`__.
+
+.. code:: ipython3
+
+    def run_home(name: str):
+        return f"Run home {name}!"
+
+    remote_function = rh.function(run_home).to(aws_cluster)
+
+After running ``.to``, your function is set up on the cluster to be
+called from anywhere. When you call ``remote_function``, it executes
+remotely on your AWS instance.
+
+.. code:: ipython3
+
+    remote_function("in cluster!")
+
+
+.. parsed-literal::
+    :class: code-output
+
+    INFO | 2024-02-20 16:38:13.733518 | Calling run_home.call
+    INFO | 2024-02-20 16:38:14.807770 | Time to call run_home.call: 1.07 seconds
+
+
+
+
+.. parsed-literal::
+    :class: code-output
+
+    'Run home in cluster!!'
+
+
+
+On-Demand Clusters with TLS exposed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the previous example, the cluster that was brought up in EC2 is only
+accessible to the original user that has SSH credentials to the machine.
+However, you can set up a cluster with ports exposed to open Internet,
+and access objects and functions via ``curl``.
+
+.. code:: ipython3
+
+    tls_cluster = rh.cluster(name="tls-cluster",
+                             instance_type="CPU:2",
+                             open_ports=[443], # expose HTTPS port to public
+                             server_connection_type="tls", # specify how runhouse communicates with this cluster
+                             den_auth=False, # no authentication required to hit this cluster (NOT recommended)
+    )
+
+
+.. parsed-literal::
+    :class: code-output
+
+    /Users/rohinbhasin/work/runhouse/runhouse/resources/hardware/on_demand_cluster.py:317: UserWarning: Server is insecure and must be inside a VPC or have `den_auth` enabled to secure it.
+      warnings.warn(
+
+
+.. code:: ipython3
+
+    remote_tls_function = rh.function(run_home).to(tls_cluster)
+
+.. code:: ipython3
+
+    remote_tls_function("Marvin")
+
+
+.. parsed-literal::
+    :class: code-output
+
+    INFO | 2024-02-20 17:09:03.605194 | Calling run_home.call
+    INFO | 2024-02-20 17:09:04.640570 | Time to call run_home.call: 1.04 seconds
+
+
+
+
+.. parsed-literal::
+    :class: code-output
+
+    'Run home Marvin!'
+
+
+
+.. code:: ipython3
+
+    tls_cluster.address
+
+
+
+
+.. parsed-literal::
+    :class: code-output
+
+    '3.86.210.191'
+
+
+
+.. code:: ipython3
+
+    ! curl "https://3.86.210.191/run_home/call?name=Marvin" -k
+
+
+.. parsed-literal::
+    :class: code-output
+
+    {"data":"\"Run home Marvin!\"","error":null,"traceback":null,"output_type":"result_serialized","serialization":"json"}
+
+Static Clusters
+---------------
+
+If you have existing machines within a VPC that you want to connect to,
+you can simply provide the IP addresses and path to SSH credentials to
+the machine.
+
+.. code:: ipython3
+
+    cluster = rh.cluster(  # using private key
+                  name="cpu-cluster-existing",
+                  ips=['<ip of the cluster>'],
+                  ssh_creds={'ssh_user': '<user>', 'ssh_private_key':'<path_to_key>'},
+              )
+
+Useful Cluster Functions
+------------------------
+
+.. code:: ipython3
+
+    tls_cluster.run(['pip install numpy && pip freeze | grep numpy'])
+
+
+.. parsed-literal::
+    :class: code-output
+
+    Warning: Permanently added '3.86.210.191' (ED25519) to the list of known hosts.
+
+
+.. parsed-literal::
+    :class: code-output
+
+    Requirement already satisfied: numpy in /opt/conda/lib/python3.10/site-packages (1.26.4)
+    numpy==1.26.4
+
+
+
+
+.. parsed-literal::
+    :class: code-output
+
+    [(0,
+      'Requirement already satisfied: numpy in /opt/conda/lib/python3.10/site-packages (1.26.4)\nnumpy==1.26.4\n',
+      "Warning: Permanently added '3.86.210.191' (ED25519) to the list of known hosts.\r\n")]
+
+
+
+.. code:: ipython3
+
+    tls_cluster.run_python(['import numpy', 'print(numpy.__version__)'])
+
+
+.. parsed-literal::
+    :class: code-output
+
+    1.26.4
+
+
+
+
+.. parsed-literal::
+    :class: code-output
+
+    [(0, '1.26.4\n', '')]

--- a/docs/tutorials/api/clusters.rst
+++ b/docs/tutorials/api/clusters.rst
@@ -43,7 +43,7 @@ cluster.
 
     import runhouse as rh
 
-    aws_cluster = rh.cluster(name="test-cluster", instance_type="CPU:2")
+    aws_cluster = rh.cluster(name="test-cluster", instance_type="CPU:2", provider="aws")
 
 Next, we set up a basic function to throw up on our cluster. For more
 information about Functions & Modules that you can put up on a cluster,


### PR DESCRIPTION
Add clusters doc page, not listed in the actual webpage yet; waiting for when
we deprecate the `compute` page.
