### PR TITLE
Change default `autostop_mins` to 60.

### DIFF
--- a/runhouse/rns/defaults.py
+++ b/runhouse/rns/defaults.py
@@ -24,7 +24,7 @@ class Defaults:
     BASE_DEFAULTS = {
         "default_folder": "~",
         "default_provider": "cheapest",
-        "default_autostop": -1,
+        "default_autostop": 60,
         "use_spot": False,
         "use_local_configs": True,
         "disable_data_collection": False,


### PR DESCRIPTION
I've been leaving clusters up on accident. Let's resolve this
