### PR TITLE
Add local quick start guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Table of Contents
    :maxdepth: 1
    :caption: Getting Started
 
-   tutorials/api/quick_start
+   tutorials/start/quick_start
    architecture
    api_tutorials
 

--- a/docs/notebooks/start/quick_start.ipynb
+++ b/docs/notebooks/start/quick_start.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f444cfb2-8392-4aa4-b405-4e48837028da",
+   "metadata": {},
+   "source": [
+    "# Getting Started\n",
+    "\n",
+    "In this basic example, we demonstrate how to use Runhouse to set up a local server and deploy your own Python application to it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0562c9bb-2407-488a-b48a-938988994854",
+   "metadata": {},
+   "source": [
+    "## Runhouse Server Setup\n",
+    "\n",
+    "First install runhouse with `pip install runhouse`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "915bb87d-b343-4c79-b7a5-b2e6cae982ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install runhouse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0011e5f3-337f-4e3f-97a7-0fd3c24eb2d9",
+   "metadata": {},
+   "source": [
+    "Next, start the runhouse server locally on CLI with `runhouse restart`, and use `runhouse status` to print the status and details of the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0f2150c-4623-4bc8-b2db-1e6742068ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!runhouse restart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6e40f748-29fc-4afb-b597-a84663b403cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1;38;5;63m😈 Runhouse Daemon is running 🏃\u001b[0m\n",
+      "• server_port: \u001b[1;36m32300\u001b[0m\n",
+      "• den_auth: \u001b[3;91mFalse\u001b[0m\n",
+      "• server_connection_type: none\n",
+      "• backend config:\n",
+      "        • use_local_telemetry: \u001b[3;91mFalse\u001b[0m\n",
+      "        • domain: \u001b[3;35mNone\u001b[0m\n",
+      "        • server_host: \u001b[1;92m0.0.0.0\u001b[0m\n",
+      "        • ips: \u001b[1m[\u001b[0m\u001b[32m'0.0.0.0'\u001b[0m\u001b[1m]\u001b[0m\n",
+      "        • resource_subtype: Cluster\n",
+      "\u001b[1mServing 🍦 :\u001b[0m\n",
+      "\u001b[3;4mbase \u001b[0m\u001b[1;3;4m(\u001b[0m\u001b[3;4mEnv\u001b[0m\u001b[1;3;4m)\u001b[0m\u001b[3;4m:\u001b[0m\n",
+      "This environment has no resources.\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!runhouse status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "726b1918-8823-47af-bf8a-fe9bb332bd8f",
+   "metadata": {},
+   "source": [
+    "## Run your Local Service\n",
+    "Standing up your Python code on the server is simple with the Runhouse API. Simply wrap it with `rh.function` or `rh.module` for a Python function or class, respectively, and then sync it to the server using `.to(rh.here)`.\n",
+    "\n",
+    "For more specifics on the Runhouse API, please refer to the API tutorials or API reference on [Runhouse docs](https://www.run.house/docs)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02a081c4-2292-46bb-a14a-51ede255e4e8",
+   "metadata": {},
+   "source": [
+    "### Sample Function: `get_pid`\n",
+    "\n",
+    "For our example, we use a simple Python function that returns the process ID. It optionally takes in a parameter, which it adds to the process ID prior to returning it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fb2dca52-4532-4a56-9840-b70e89d0c59d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import runhouse as rh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6bd2aa51-17cd-41af-8569-f0471f3bad78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_pid(a=0):\n",
+    "    import os\n",
+    "    return os.getpid() + int(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89c356d1-4439-4f24-b5b1-82e21d7aa9a4",
+   "metadata": {},
+   "source": [
+    "### Sync `get_pid` to the server\n",
+    "\n",
+    "The following code sends our Python function, `get_pid` to "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "479cc113-486b-4c63-a4d0-342698e50887",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO | 2024-02-21 19:12:40.047825 | Writing out function to /Users/caroline/Documents/runhouse/runhouse/docs/notebooks/start/get_pid_fn.py. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).\n",
+      "INFO | 2024-02-21 19:12:40.083022 | Sending module get_pid to local Runhouse daemon\n"
+     ]
+    }
+   ],
+   "source": [
+    "server_get_pid = rh.function(get_pid).to(rh.here)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bef56094-829f-4b51-83e6-1e1285c2b12e",
+   "metadata": {},
+   "source": [
+    "### Remote Function Call\n",
+    "\n",
+    "We can call the function from the server just as you would a regular Python function. As you can see in the following code, the regular Python function `get_pid()` returns a different process ID than the server `server_get_pid()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4efe228b-bdf0-46cd-8f6b-49fdf142091c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Local PID 3295\n",
+      "Daemon PID 3391\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Local PID {get_pid()}\")\n",
+    "print(f\"Server PID {server_get_pid()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35cace93-6a01-4983-9f24-3ba0ab0ffe02",
+   "metadata": {},
+   "source": [
+    "### HTTP Endpoint and Curl\n",
+    "\n",
+    "Here, we extract the function endpoint, and use it in a curl call. You can also pass in variables to the curl call, or paste the http link in your browser and see the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a9051025-519b-4d7d-978d-9c7a9ad90c23",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'http://0.0.0.0:32300/get_pid'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "server_get_pid.endpoint()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c48e608b-26e9-454d-8eab-1c0ea455a061",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"data\":\"3391\",\"error\":null,\"traceback\":null,\"output_type\":\"result_serialized\",\"serialization\":\"json\"}"
+     ]
+    }
+   ],
+   "source": [
+    "!curl \"http://0.0.0.0:32300/get_pid/call\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "de5880f8-1723-4131-ad20-25797669822f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"data\":\"3392\",\"error\":null,\"traceback\":null,\"output_type\":\"result_serialized\",\"serialization\":\"json\"}"
+     ]
+    }
+   ],
+   "source": [
+    "!curl \"http://0.0.0.0:32300/get_pid/call?a=1\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/start/quick_start.rst
+++ b/docs/tutorials/start/quick_start.rst
@@ -1,0 +1,156 @@
+Getting Started
+===============
+
+.. raw:: html
+
+    <p><a href="https://colab.research.google.com/github/run-house/runhouse/blob/stable/docs/notebooks/start/quick_start.ipynb">
+    <img height="20px" width="117px" src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a></p>
+
+In this basic example, we demonstrate how to use Runhouse to set up a
+local server and deploy your own Python application to it.
+
+Runhouse Server Setup
+---------------------
+
+First install runhouse with ``pip install runhouse``.
+
+.. code:: ipython3
+
+    !pip install runhouse
+
+Next, start the runhouse server locally on CLI with
+``runhouse restart``, and use ``runhouse status`` to print the status
+and details of the server.
+
+.. code:: ipython3
+
+    !runhouse restart
+
+.. code:: ipython3
+
+    !runhouse status
+
+
+.. parsed-literal::
+    :class: code-output
+
+    [1;38;5;63m😈 Runhouse Daemon is running 🏃[0m
+    • server_port: [1;36m32300[0m
+    • den_auth: [3;91mFalse[0m
+    • server_connection_type: none
+    • backend config:
+            • use_local_telemetry: [3;91mFalse[0m
+            • domain: [3;35mNone[0m
+            • server_host: [1;92m0.0.0.0[0m
+            • ips: [1m[[0m[32m'0.0.0.0'[0m[1m][0m
+            • resource_subtype: Cluster
+    [1mServing 🍦 :[0m
+    [3;4mbase [0m[1;3;4m([0m[3;4mEnv[0m[1;3;4m)[0m[3;4m:[0m
+    This environment has no resources.
+    [0m
+
+Run your Local Service
+----------------------
+
+Standing up your Python code on the server is simple with the Runhouse
+API. Simply wrap it with ``rh.function`` or ``rh.module`` for a Python
+function or class, respectively, and then sync it to the server using
+``.to(rh.here)``.
+
+For more specifics on the Runhouse API, please refer to the API
+tutorials or API reference on `Runhouse
+docs <https://www.run.house/docs>`__.
+
+Sample Function: ``get_pid``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For our example, we use a simple Python function that returns the
+process ID. It optionally takes in a parameter, which it adds to the
+process ID prior to returning it.
+
+.. code:: ipython3
+
+    import runhouse as rh
+
+.. code:: ipython3
+
+    def get_pid(a=0):
+        import os
+        return os.getpid() + int(a)
+
+Sync ``get_pid`` to the server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following code sends our Python function, ``get_pid`` to
+
+.. code:: ipython3
+
+    server_get_pid = rh.function(get_pid).to(rh.here)
+
+
+.. parsed-literal::
+    :class: code-output
+
+    INFO | 2024-02-21 19:12:40.047825 | Writing out function to /Users/caroline/Documents/runhouse/runhouse/docs/notebooks/start/get_pid_fn.py. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body).
+    INFO | 2024-02-21 19:12:40.083022 | Sending module get_pid to local Runhouse daemon
+
+
+Remote Function Call
+~~~~~~~~~~~~~~~~~~~~
+
+We can call the function from the server just as you would a regular
+Python function. As you can see in the following code, the regular
+Python function ``get_pid()`` returns a different process ID than the
+server ``server_get_pid()``.
+
+.. code:: ipython3
+
+    print(f"Local PID {get_pid()}")
+    print(f"Server PID {server_get_pid()}")
+
+
+.. parsed-literal::
+    :class: code-output
+
+    Local PID 3295
+    Daemon PID 3391
+
+
+HTTP Endpoint and Curl
+~~~~~~~~~~~~~~~~~~~~~~
+
+Here, we extract the function endpoint, and use it in a curl call. You
+can also pass in variables to the curl call, or paste the http link in
+your browser and see the result.
+
+.. code:: ipython3
+
+    server_get_pid.endpoint()
+
+
+.. parsed-literal::
+    :class: code-output
+
+    'http://0.0.0.0:32300/get_pid'
+
+
+
+.. code:: ipython3
+
+    !curl "http://0.0.0.0:32300/get_pid/call"
+
+
+.. parsed-literal::
+    :class: code-output
+
+    {"data":"3391","error":null,"traceback":null,"output_type":"result_serialized","serialization":"json"}
+
+.. code:: ipython3
+
+    !curl "http://0.0.0.0:32300/get_pid/call?a=1"
+
+
+.. parsed-literal::
+    :class: code-output
+
+    {"data":"3392","error":null,"traceback":null,"output_type":"result_serialized","serialization":"json"}


### PR DESCRIPTION
Replace quick start with local daemon / web server approach. Thinking of having the extension (to a remote cluster) as a second followup tutorial under getting started rather than included in this.

Note: Previous quick start removed from runhouse table of contents but files still left for now. Could be useful for compute basic or some other tututorial, to update/remove in a later PR.
