### PR TITLE
Change some logging to go to `sys.stdout`.

### DIFF
--- a/runhouse/resources/envs/conda_env.py
+++ b/runhouse/resources/envs/conda_env.py
@@ -8,9 +8,9 @@ from typing import Dict, List, Optional, Union
 from runhouse.globals import obj_store
 
 from runhouse.resources.packages import Package
+from runhouse.utils import install_conda
 
 from .env import Env
-from .utils import _install_conda
 
 
 logger = logging.getLogger(__name__)
@@ -103,8 +103,7 @@ class CondaEnv(Env):
                 .split()[1]
             )
             self.conda_yaml["dependencies"].append(f"python=={base_python_version}")
-        if subprocess.run(shlex.split("conda --version")) != 0:
-            _install_conda()
+        install_conda()
         local_env_exists = f"\n{self.env_name} " in subprocess.check_output(
             shlex.split("conda info --envs"), shell=False
         ).decode("utf-8")

--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -1,8 +1,6 @@
 import copy
 import logging
 import os
-import shlex
-import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -11,6 +9,8 @@ from runhouse.resources.folders import Folder
 from runhouse.resources.hardware import _get_cluster_from, Cluster
 from runhouse.resources.packages import Package
 from runhouse.resources.resource import Resource
+
+from runhouse.utils import run_with_logs
 
 from .utils import _env_vars_from_file
 
@@ -161,7 +161,7 @@ class Env(Resource):
             pkg._install(self)
         return self.run(self.setup_cmds) if self.setup_cmds else None
 
-    def run(self, cmds: List[str]):
+    def run(self, cmds: Union[List[str], str]):
         """Run command locally inside the environment"""
         ret_codes = []
         for cmd in cmds:
@@ -171,17 +171,10 @@ class Env(Resource):
             use_shell = any(shell_feat in cmd for shell_feat in [">", "|", "&&", "||"])
             if use_shell:
                 # Example: "echo '<TOKEN>' > ~/.rh/config.yaml"
-                ret_code = subprocess.run(
-                    cmd,
-                    shell=True,
-                )
+                retcode = run_with_logs(cmd, shell=True)
             else:
-                ret_code = subprocess.run(
-                    shlex.split(cmd),
-                    # cwd=self.working_dir,  # Should we do this?
-                    shell=False,
-                )
-            ret_codes.append(ret_code)
+                retcode = run_with_logs(cmd, shell=False)
+            ret_codes.append(retcode)
         return ret_codes
 
     def to(

--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -1,5 +1,3 @@
-import logging
-import shlex
 import subprocess
 
 from pathlib import Path
@@ -113,16 +111,3 @@ def _env_vars_from_file(env_file):
     dotenv_path = find_dotenv(str(env_file), usecwd=True)
     env_vars = dotenv_values(dotenv_path)
     return dict(env_vars)
-
-
-def _install_conda():
-    if subprocess.run(shlex.split("conda --version")) != 0:
-        logging.info("Conda is not installed")
-        subprocess.run(
-            "wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh",
-            shell=True,
-        )
-        subprocess.run("bash ~/miniconda.sh -b -p ~/miniconda", shell=True)
-        subprocess.run("source $HOME/miniconda3/bin/activate", shell=True)
-        if subprocess.run(shlex.split("conda --version")) != 0:
-            raise RuntimeError("Could not install Conda.")

--- a/runhouse/utils.py
+++ b/runhouse/utils.py
@@ -1,0 +1,40 @@
+import logging
+import shlex
+import subprocess
+from typing import List, Union
+
+
+def run_with_logs(cmd: Union[List[str], str], **kwargs) -> int:
+    """Runs a command and prints the output to sys.stdout.
+    We can't just pipe to sys.stdout, and when in a `call` method
+    we overwrite sys.stdout with a multi-logger to a file and stdout.
+
+    Args:
+        cmd: The command to run.
+        kwargs: Keyword arguments to pass to subprocess.Popen.
+
+    Returns:
+        The returncode of the command.
+    """
+    if isinstance(cmd, str) and not kwargs.get("shell", False):
+        cmd = shlex.split(cmd)
+    logging.info(f"Running command: {cmd} with kwargs: {kwargs}")
+    p = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs
+    )
+    for line in p.stdout:
+        print(line.decode("utf-8").strip())
+    return p.wait()
+
+
+def install_conda():
+    if run_with_logs("conda --version") != 0:
+        logging.info("Conda is not installed")
+        run_with_logs(
+            "wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh",
+            shell=True,
+        )
+        run_with_logs("bash ~/miniconda.sh -b -p ~/miniconda", shell=True)
+        run_with_logs("source $HOME/miniconda3/bin/activate", shell=True)
+        if run_with_logs("conda --version") != 0:
+            raise RuntimeError("Could not install Conda.")


### PR DESCRIPTION
When calling a method, we use the `StreamTee` in `provenance.py` to log to a file _and_ stdout at the same time, which is how we stream logs from `call`.

However, when we call `env.install`, we call things via subprocess, and these logs aren't propagated. Unfortunately there's no neat way to pipe this (I scoured the entirety of StackOverflow) so we just need to set up a pipe, stream the logs, and print things, and then they'll go to `sys.stdout` and be picked up by the remote log generator. 

While I was here, cleaned up a bit of the conda installation logic.