### PR TITLE
Update relative links in examples

### DIFF
--- a/examples/llama2/llama2_ec2.py
+++ b/examples/llama2/llama2_ec2.py
@@ -40,7 +40,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, TextStreamer
 # This is a Runhouse class that allows you to
 # run code in your class on a remote machine.
 #
-# Learn more in the [Runhouse docs on functions and modules](https://www.run.house/docs/stable/tutorials/api-modules).
+# Learn more in the [Runhouse docs on functions and modules](/docs/tutorials/api-modules).
 class HFChatModel(rh.Module):
     def __init__(self, model_id="meta-llama/Llama-2-13b-chat-hf", **model_kwargs):
         super().__init__()
@@ -78,7 +78,7 @@ class HFChatModel(rh.Module):
 # Our `instance_type` here is defined as `A10G:1`, which is the accelerator type and count that we need. We could
 # alternatively specify a specific AWS instance type, such as `p3.2xlarge` or `g4dn.xlarge`.
 #
-# Learn more in the [Runhouse docs on clusters](https://www.run.house/docs/stable/tutorials/api-clusters).
+# Learn more in the [Runhouse docs on clusters](/docs/tutorials/api-clusters).
 #
 # NOTE: Make sure that your code runs within a `if __name__ == "__main__":` block, as shown below. Otherwiwse,
 # the script code will run when Runhouse attempts to run code remotely.
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # to be installed on the remote machine, as well as any secrets that need to be synced up from local to remote.
     # Passing `huggingface` to the `secrets` parameter will load the Hugging Face token we set up earlier.
     #
-    # Learn more in the [Runhouse docs on envs](https://www.run.house/docs/stable/tutorials/api-envs).
+    # Learn more in the [Runhouse docs on envs](/docs/tutorials/api-envs).
     env = rh.env(
         reqs=[
             "torch",

--- a/examples/stable-diffusion-xl-aws-ec2/sdxl.py
+++ b/examples/stable-diffusion-xl-aws-ec2/sdxl.py
@@ -43,7 +43,7 @@ from PIL import Image
 # This is a Runhouse class that allows you to
 # run code in your class on a remote machine.
 #
-# Learn more in the [Runhouse docs on functions and modules](https://www.run.house/docs/stable/tutorials/api-modules).
+# Learn more in the [Runhouse docs on functions and modules](/docs/tutorials/api-modules).
 class StableDiffusionXLPipeline(rh.Module):
     def __init__(
         self,
@@ -114,7 +114,7 @@ def decode_base64_image(image_string):
 # Our `instance_type` here is defined as `g5.8xlarge`, which is an AWS instance type. We can alternatively specify
 # an accelerator type and count, such as `A10G:1`, and any instance type with those specifications will be used.
 #
-# Learn more in the [Runhouse docs on clusters](https://www.run.house/docs/stable/tutorials/api-clusters).
+# Learn more in the [Runhouse docs on clusters](/docs/tutorials/api-clusters).
 #
 # NOTE: Make sure that your code runs within a `if __name__ == "__main__":` block, as shown below. Otherwiwse,
 # the script code will run when Runhouse attempts to run code remotely.
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     # to be installed on the remote machine, as well as any secrets that need to be synced up from local to remote.
     # Passing `huggingface` to the `secrets` parameter will load the Hugging Face token we set up earlier.
     #
-    # Learn more in the [Runhouse docs on envs](https://www.run.house/docs/stable/tutorials/api-envs).
+    # Learn more in the [Runhouse docs on envs](/docs/tutorials/api-envs).
     env = rh.env(
         name="sdxl_inference",
         reqs=[

--- a/examples/stable-diffusion-xl-aws-inferentia2/inf2_sdxl.py
+++ b/examples/stable-diffusion-xl-aws-inferentia2/inf2_sdxl.py
@@ -47,7 +47,7 @@ from PIL import Image
 # This is a Runhouse class that allows you to
 # run code in your class on a remote machine.
 #
-# Learn more in the [Runhouse docs on functions and modules](https://www.run.house/docs/stable/tutorials/api-modules).
+# Learn more in the [Runhouse docs on functions and modules](/docs/tutorials/api-modules).
 class StableDiffusionXLPipeline(rh.Module):
     def __init__(
         self,
@@ -129,11 +129,11 @@ def decode_base64_image(image_string):
 # The cluster we set up here also uses `tls` for the `server_connection_type`, which means that all communication
 # will be over HTTPS and encrypted. We need to tell SkyPilot to open port 443 for this to work.
 #
-# We also set `den_auth` to `True`, which means that we will use [Runhouse Den](https://www.run.house/dashboard) to
+# We also set `den_auth` to `True`, which means that we will use [Runhouse Den](/dashboard) to
 # authenticate public requests to this cluster. This means that we can open this cluster to the public internet, and
 # only people who have ran `runhouse login` and set up Runhouse accounts will be able to access it.
 #
-# Learn more in the [Runhouse docs on clusters](https://www.run.house/docs/stable/tutorials/api-clusters).
+# Learn more in the [Runhouse docs on clusters](/docs/tutorials/api-clusters).
 #
 # NOTE: Make sure that your code runs within a `if __name__ == "__main__":` block, as shown below. Otherwiwse,
 # the script code will run when Runhouse attempts to run code remotely.
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     # Passing `huggingface` to the `secrets` parameter will load the Hugging Face token we set up earlier.
     # We also can set environment variables, such as `NEURON_RT_NUM_CORES` which is required for AWS Neuron.
     #
-    # Learn more in the [Runhouse docs on envs](https://www.run.house/docs/stable/tutorials/api-envs).
+    # Learn more in the [Runhouse docs on envs](/docs/tutorials/api-envs).
     env = rh.env(
         name="sdxl_inference",
         reqs=[


### PR DESCRIPTION
Notes on relative links (within `www.run.house`):
- Always use a relative path, e.g. `/docs/tuturials...` v. `https://www.run.house/docs/tutorials`
- Remove branch name from urls, that will be automatically handled if needed