### PR TITLE
Add `generate_openapi_spec` method to `Module`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ install_requires = [
     "typer",
     "uvicorn",
     "wheel",
+    "apispec",
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the following

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,3 +13,4 @@ docker
 s3fs
 pandas
 pyarrow
+openapi-core

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -657,6 +657,23 @@ class TestModule:
         )
         test_fn(mod_name=remote_df.rns_address, cpu_count=cpu_count, size=size)
 
+    @pytest.mark.level("unit")
+    def test_openapi_spec_generation(self):
+        from openapi_core import OpenAPI
+
+        remote_calc = rh.module(Calculator)
+
+        # Normally we'd send the calculator to a system, save it, and then call this
+        # But for testing purposes we can just pass in a name so this can run as a unit test
+        spec = remote_calc.generate_openapi_spec(spec_name="CalculatorAPI")
+
+        # This automatically validates the spec
+        openapi = OpenAPI.from_dict(spec)
+        assert openapi
+
+        # Assert that the spec can be converted to json
+        assert json.loads(json.dumps(spec))
+
 
 def test_load_and_use_readonly_module(mod_name, cpu_count, size=3):
     remote_df = rh.module(name=mod_name)


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## Description for Pull Request
> 
> ### TL;DR
> Added a method to generate OpenAPI spec for a module, updated dependencies, and added tests for OpenAPI spec generation.
> 
> ### What changed
> - Added a `generate_openapi_spec` method to the `Module` class in `module.py` to generate an OpenAPI spec for the module.
> - Updated dependencies in `setup.py` to include `apispec` and in `tests/requirements.txt` to include `openapi-core`.
> - Added tests in `test_module.py` to test the generation of OpenAPI spec for a module.
> 
> ### How to test
> 1. Ensure the `generate_openapi_spec` method in `module.py` generates the OpenAPI spec correctly for the module.
> 2. Check that the updated dependencies in `setup.py` and `tests/requirements.txt` are installed successfully.
> 3. Run the tests in `test_module.py` to verify the OpenAPI spec generation for a module.
> 
> ### Why make this change
> - The addition of the `generate_openapi_spec` method allows for easy generation of OpenAPI specs for modules.
> - Updating dependencies ensures that the required packages for OpenAPI spec generation are available.
> - Adding tests ensures that the OpenAPI spec generation functionality is tested and working as expected.
</details>