### PR TITLE
Add Runhouse `call` params to openapi spec generation.

### DIFF
--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -30,7 +30,7 @@ class ServerSettings(BaseModel):
 
 class CallParams(BaseModel):
     data: Any = None
-    serialization: Optional[str] = None
+    serialization: Optional[str] = "json"
     run_name: Optional[str] = None
     stream_logs: Optional[bool] = False
     save: Optional[bool] = False

--- a/tests/test_resources/test_modules/test_functions/test_function.py
+++ b/tests/test_resources/test_modules/test_functions/test_function.py
@@ -352,7 +352,7 @@ class TestFunction:
         verify = cluster.client.verify
         sum1 = requests.post(
             url=f"{addr}/call",
-            json={"data": ([1, 2], {})},
+            json={"data": ([1, 2], {}), "serialization": None},
             headers=rns_client.request_headers(cluster.rns_address)
             if cluster.den_auth
             else None,
@@ -362,7 +362,7 @@ class TestFunction:
         assert sum1 == 3
         sum2 = requests.post(
             url=f"{addr}/call",
-            json={"data": ([], {"a": 1, "b": 2})},
+            json={"data": ([], {"a": 1, "b": 2}), "serialization": None},
             headers=rns_client.request_headers(cluster.rns_address)
             if cluster.den_auth
             else None,

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -390,6 +390,7 @@ class TestHTTPServerDockerDenAuthOnly:
             json={
                 "data": [args, kwargs],
                 "stream_logs": False,
+                "serialization": None,
             },
             headers=INVALID_HEADERS,
         )


### PR DESCRIPTION
* change `json` to be the default in `CallParams`. this is no big deal because when calling from the `client` we explicitly set serialization to `pickle` anyway

* use `CallParams` to generate the params for our `post_call` method, and set the `data` field to have the explicit params set up by the user