### PR TITLE
Format serialized_data for `call` as a dictionary with `args` and `kwargs`

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -828,7 +828,7 @@ class Cluster(Resource):
             return obj_store.call(
                 module_name,
                 method_name,
-                data=(args, kwargs),
+                data={"args": args, "kwargs": kwargs},
                 stream_logs=stream_logs,
                 run_name=run_name,
                 # remote=remote,
@@ -840,7 +840,7 @@ class Cluster(Resource):
             method_name,
             resource_address=self.rns_address,
             stream_logs=stream_logs,
-            data=[args, kwargs],
+            data={"args": args, "kwargs": kwargs},
             run_name=run_name,
             remote=remote,
             run_async=run_async,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -492,7 +492,7 @@ class Module(Resource):
                     run_name=kwargs.pop("run_name", None),
                     stream_logs=kwargs.pop("stream_logs", True),
                     remote=kwargs.pop("remote", False),
-                    data=[args, kwargs],
+                    data={"args": args, "kwargs": kwargs},
                 )
 
             def remote(self, *args, stream_logs=True, run_name=None, **kwargs):
@@ -606,7 +606,7 @@ class Module(Resource):
                 return client.call(
                     key=name,
                     method_name=key,
-                    data=[[value], {}],
+                    data={"args": [value], "kwargs": {}},
                 )
 
             @classmethod
@@ -668,7 +668,9 @@ class Module(Resource):
         else:
             if not client or not name:
                 return self.resolved_state(**kwargs)
-            return client.call(name, "resolved_state", data=[(), kwargs])
+            return client.call(
+                name, "resolved_state", data={"args": [], "kwargs": kwargs}
+            )
 
     async def fetch_async(
         self, key: str, remote: bool = False, stream_logs: bool = False
@@ -733,7 +735,7 @@ class Module(Resource):
             return self._client().call(
                 key=self._name,
                 method_name=key,
-                data=([value], {}),
+                data={"args": [value], "kwargs": {}},
                 stream_logs=False,
             )
 

--- a/runhouse/servers/env_servlet.py
+++ b/runhouse/servers/env_servlet.py
@@ -114,7 +114,11 @@ class EnvServlet:
         remote: bool = False,
         ctx: Optional[dict] = None,
     ):
-        args, kwargs = tuple(data) if data else ([], {})
+        if data is not None:
+            args, kwargs = data.get("args", []), data.get("kwargs", {})
+        else:
+            args, kwargs = [], {}
+
         return obj_store.call_local(
             key,
             method_name,

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -413,7 +413,11 @@ class HTTPServer:
                 if k in call_params_dict:
                     del query_params_remaining[k]
 
-            params.data = serialize_data([[], query_params_remaining], serialization)
+            data = {
+                "args": [],
+                "kwargs": query_params_remaining,
+            }
+            params.data = serialize_data(data, serialization)
 
             logger.info(f"GET call with params: {dict(params)}")
             return await HTTPServer._call(key, method_name, params)

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -1082,8 +1082,9 @@ class ObjStore:
         ):
             from runhouse.servers.http.http_utils import deserialize_data
 
-            args, kwargs = (
-                tuple(deserialize_data(data, serialization)) if data else ([], {})
+            deserialized_data = deserialize_data(data, serialization) or {}
+            args, kwargs = deserialized_data.get("args", []), deserialized_data.get(
+                "kwargs", {}
             )
 
             res = self.call_local(

--- a/tests/test_resources/test_modules/test_functions/test_function.py
+++ b/tests/test_resources/test_modules/test_functions/test_function.py
@@ -352,7 +352,13 @@ class TestFunction:
         verify = cluster.client.verify
         sum1 = requests.post(
             url=f"{addr}/call",
-            json={"data": ([1, 2], {}), "serialization": None},
+            json={
+                "data": {
+                    "args": [1, 2],
+                    "kwargs": {},
+                },
+                "serialization": None,
+            },
             headers=rns_client.request_headers(cluster.rns_address)
             if cluster.den_auth
             else None,
@@ -362,7 +368,13 @@ class TestFunction:
         assert sum1 == 3
         sum2 = requests.post(
             url=f"{addr}/call",
-            json={"data": ([], {"a": 1, "b": 2}), "serialization": None},
+            json={
+                "data": {
+                    "args": [],
+                    "kwargs": {"a": 1, "b": 2},
+                },
+                "serialization": None,
+            },
             headers=rns_client.request_headers(cluster.rns_address)
             if cluster.den_auth
             else None,

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -200,21 +200,20 @@ class TestHTTPClient:
         )
         mock_post = mocker.patch("requests.Session.post", return_value=mock_response)
 
-        args = [1, 2]
-        kwargs = {"a": 3, "b": 4}
+        data = {"args": [1, 2], "kwargs": {"a": 3, "b": 4}}
         module_name = "module"
         method_name = "install"
 
         self.client.call(
             module_name,
             method_name,
-            data=[args, kwargs],
+            data=data,
             resource_address=self.local_cluster.rns_address,
         )
 
         # Assert that the post request was called with the correct data
         expected_json_data = {
-            "data": serialize_data([args, kwargs], "pickle"),
+            "data": serialize_data(data, "pickle"),
             "serialization": "pickle",
             "run_name": None,
             "stream_logs": True,

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -127,13 +127,12 @@ class TestHTTPServerDocker:
         # Create new func on the cluster, then call it
         method_name = "call"
         module_name = remote_func.name
-        args = (1, 2)
-        kwargs = {}
+        data = {"args": [1, 2], "kwargs": {}}
 
         response = http_client.post(
             f"{module_name}/{method_name}",
             json={
-                "data": serialize_data([args, kwargs], "pickle"),
+                "data": serialize_data(data, "pickle"),
                 "stream_logs": True,
                 "serialization": "pickle",
             },
@@ -179,8 +178,7 @@ class TestHTTPServerDocker:
         method_name = "call"
         module_name = remote_log_streaming_func.name
         clus = remote_log_streaming_func.system
-        args = [3]
-        kwargs = {}
+        data = {"args": [3], "kwargs": {}}
 
         if clus.server_connection_type in ["tls", "none"]:
             url = f"{clus.endpoint()}:{clus.client_port}/{module_name}/{method_name}"
@@ -191,7 +189,7 @@ class TestHTTPServerDocker:
             "POST",
             url,
             json={
-                "data": serialize_data([args, kwargs], "pickle"),
+                "data": serialize_data(data, "pickle"),
                 "stream_logs": True,
                 "serialization": "pickle",
             },
@@ -219,7 +217,13 @@ class TestHTTPServerDocker:
 
         response = await async_http_client.post(
             f"/{remote_func.name}/{method}",
-            json={"data": ([1, 2], {}), "serialization": None},
+            json={
+                "data": {
+                    "args": [1, 2],
+                    "kwargs": {},
+                },
+                "serialization": None,
+            },
             headers=rns_client.request_headers(remote_func.system.rns_address),
         )
         assert response.status_code == 200
@@ -234,7 +238,13 @@ class TestHTTPServerDocker:
 
         response = await async_http_client.post(
             f"/{remote_func.name}/{method}",
-            json={"data": ([1, 2], {}), "serialization": "random"},
+            json={
+                "data": {
+                    "args": [1, 2],
+                    "kwargs": {},
+                },
+                "serialization": "random",
+            },
             headers=rns_client.request_headers(remote_func.system.rns_address),
         )
         assert response.status_code == 400
@@ -250,7 +260,13 @@ class TestHTTPServerDocker:
         response = await async_http_client.post(
             f"/{remote_func.name}/{method}",
             json={
-                "data": serialize_data(([1, 2], {}), "pickle"),
+                "data": serialize_data(
+                    {
+                        "args": [1, 2],
+                        "kwargs": {},
+                    },
+                    "pickle",
+                ),
                 "serialization": "pickle",
             },
             headers=rns_client.request_headers(remote_func.system.rns_address),
@@ -270,7 +286,15 @@ class TestHTTPServerDocker:
 
         response = await async_http_client.post(
             f"/{remote_func.name}/{method}",
-            json={"data": json.dumps(([1, 2], {})), "serialization": "json"},
+            json={
+                "data": json.dumps(
+                    {
+                        "args": [1, 2],
+                        "kwargs": {},
+                    }
+                ),
+                "serialization": "json",
+            },
             headers=rns_client.request_headers(remote_func.system.rns_address),
         )
         assert response.status_code == 200
@@ -410,7 +434,7 @@ class TestHTTPServerDockerDenAuthOnly:
         response = http_client.post(
             f"{module_name}/{method_name}",
             json={
-                "data": [args, kwargs],
+                "data": {"args": args, "kwargs": kwargs},
                 "stream_logs": False,
                 "serialization": None,
             },


### PR DESCRIPTION
When generating an `openapi_spec` for this code, we need an object / dictionary rather than an arbitrary list... more robust for an actual server to call this now