### PR TITLE
Catching module exception in load_config

### DIFF
--- a/tests/test_resources/test_modules/exception_module.py
+++ b/tests/test_resources/test_modules/exception_module.py
@@ -1,0 +1,10 @@
+import pyarrow  # noqa
+import runhouse as rh
+
+
+class ExceptionModule(rh.Module):
+    def __init__(self):
+        super().__init__()
+
+    def test_fn(self):
+        return None

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -674,6 +674,15 @@ class TestModule:
         # Assert that the spec can be converted to json
         assert json.loads(json.dumps(spec))
 
+    @pytest.mark.level("local")
+    def test_dependency_exception(self, cluster):
+        from .exception_module import ExceptionModule
+
+        with pytest.raises(ModuleNotFoundError) as err:
+            exc_module = ExceptionModule()
+            exc_module.to(cluster)
+        assert "pyarrow" in str(err.value)
+
 
 def test_load_and_use_readonly_module(mod_name, cpu_count, size=3):
     remote_df = rh.module(name=mod_name)


### PR DESCRIPTION
ModuleNotFound in module's load_config was previously ignored, for cases when user is loading a (shared) module that doesn't live on their local env. This however also ignores ModuleNotFound errors due to other factors such as missing dependencies, which should be caught.
