### PR TITLE
Use check_server instead of is_up for cluster endpoint

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -212,7 +212,7 @@ class Cluster(Resource):
         the internal url (including the local connected port rather than the sever port). If cluster is not up,
         returns None.
         """
-        if not self.is_up():
+        if not (self.address or self.on_this_cluster()):
             return None
 
         if self.server_connection_type in [

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -123,6 +123,14 @@ class OnDemandCluster(Cluster):
         )
         return config
 
+    def endpoint(self, external=False):
+        try:
+            self.check_server()
+        except ValueError:
+            return None
+
+        return super().endpoint(external)
+
     def _copy_sky_yaml_from_cluster(self, abs_yaml_path: str):
         if not Path(abs_yaml_path).exists():
             Path(abs_yaml_path).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
avoids redundant calls to cluster.is_up()
