### PR TITLE
Fix env servlet name in put_resource

### DIFF
--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -1171,15 +1171,14 @@ class ObjStore:
             # distinct. The `env_name` is the name of the env servlet where we want to store
             # the resource itself. The `env_name_to_create` is the name of the env servlet
             # that we need to create because we are putting an env resource somewhere on the cluster.
-            env_name_to_create = resource_config["env_name"]
             runtime_env = (
-                {"conda_env": env_name_to_create}
+                {"conda_env": resource_config["env_name"]}
                 if resource_config["resource_subtype"] == "CondaEnv"
                 else {}
             )
 
             _ = ObjStore.get_env_servlet(
-                env_name=env_name_to_create,
+                env_name=env_name,
                 create=True,
                 runtime_env=runtime_env,
                 resources=resource_config.get("compute", None),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,10 +282,10 @@ from tests.fixtures.secret_fixtures import (
 from tests.test_resources.test_envs.conftest import (
     base_conda_env,  # noqa: F401
     base_env,  # noqa: F401
-    conda_env_from_dict,  # noqa: F401
     conda_env_from_local,  # noqa: F401
     conda_env_from_path,  # noqa: F401
     env,  # noqa: F401
+    named_conda_env_from_dict,  # noqa: F401
 )
 
 # ----------------- Blobs -----------------

--- a/tests/test_resources/test_envs/conftest.py
+++ b/tests/test_resources/test_envs/conftest.py
@@ -49,9 +49,9 @@ def base_conda_env():
 
 
 @pytest.fixture(scope="function")
-def conda_env_from_dict():
+def named_conda_env_from_dict():
     env_name = "conda_from_dict"
-    conda_dict = _get_conda_env(name=env_name)
+    conda_dict = _get_conda_env(name=f"{env_name}_env")
 
     args = {"name": env_name, "conda_env": conda_dict}
     env = rh.conda_env(**args)

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -39,7 +39,7 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
             "base_env",
             "named_env",
             "base_conda_env",
-            "conda_env_from_dict",
+            "named_conda_env_from_dict",
             "conda_env_from_local",
             "conda_env_from_path",
         ]
@@ -49,15 +49,15 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
         "cluster": [
             "docker_cluster_pk_ssh_no_auth",
         ]
-        # TODO: extend envs to "base_conda_env", "conda_env_from_dict"],
+        # TODO: extend envs to "base_conda_env", "named_conda_env_from_dict"],
         # and add local clusters once conda docker container is set up
     }
     MINIMAL = {
-        "env": ["base_env", "named_env", "base_conda_env"],
+        "env": ["base_env", "named_env", "base_conda_env", "named_conda_env_from_dict"],
         "cluster": ["ondemand_aws_cluster"],
     }
     RELEASE = {
-        "env": ["base_env", "named_env", "base_conda_env", "conda_env_from_dict"],
+        "env": ["base_env", "named_env", "base_conda_env", "named_conda_env_from_dict"],
         "cluster": [
             "ondemand_aws_cluster",
             "password_cluster",
@@ -68,7 +68,7 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
             "base_env",
             "named_env",
             "base_conda_env",
-            "conda_env_from_dict",
+            "named_conda_env_from_dict",
             "conda_env_from_local",
             "conda_env_from_path",
         ],


### PR DESCRIPTION
some confusion about env.name (resource name) vs env.env_name (e.g. conda env's name for passing into runtime_env or for conda commands)
