### PR TITLE
Change daemon-side components to be fully `async` for performance improvements.

### DIFF
--- a/runhouse/__init__.py
+++ b/runhouse/__init__.py
@@ -38,6 +38,7 @@ from runhouse.rns.top_level_rns_fns import (
     set_folder,
     unset_folder,
 )
+from runhouse.utils import sync_function
 
 # Note these are global variables that are instantiated within globals.py:
 from .globals import configs, obj_store
@@ -58,7 +59,7 @@ def __getattr__(name):
     if name == "here":
         # If it's either the first time or the cluster was not initialized before, attempt to retrieve the cluster again
         if _rh_here_stored is None or _rh_here_stored == "file":
-            _rh_here_stored = get_local_cluster_object()
+            _rh_here_stored = sync_function(get_local_cluster_object)()
         return _rh_here_stored
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/runhouse/resources/future_module.py
+++ b/runhouse/resources/future_module.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import AsyncIterable, Awaitable, Generator
 
 from runhouse.resources.module import Module
@@ -14,8 +13,8 @@ class FutureModule(Module, Awaitable):
     def result(self):
         return self._future.result()
 
-    def remote_await(self):
-        return asyncio.run(self._future)
+    async def remote_await(self):
+        return await self._future
 
     def __await__(self):
         # TODO talk about module dunder stuff through this file
@@ -95,14 +94,14 @@ class AsyncGeneratorModule(Module, AsyncIterable):
     def __aiter__(self):
         return self
 
-    def remote_anext(self):
-        return asyncio.run(self._future.__anext__())
+    async def remote_anext(self):
+        return await self._future.__anext__()
 
     async def __anext__(self):
         return self.remote_anext(run_name=self.name)
 
-    def remote_await(self):
-        return self._future.__await__()
+    async def remote_await(self):
+        return await self._future
 
     def __await__(self):
         return self.remote_await()

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -64,7 +64,7 @@ def load(name: str, instantiate: bool = True, dryrun: bool = False):
         )
 
 
-def get_local_cluster_object():
+async def get_local_cluster_object():
     # By default, obj_store.initialize does not initialize Ray, and instead
     # attempts to connect to an existing cluster.
 
@@ -73,7 +73,7 @@ def get_local_cluster_object():
     # If it was not set, let's proxy requests to `base` since we're likely on the cluster
     # and want to easily read and write from the object store that the Server is using.
     try:
-        obj_store.initialize(
+        await obj_store.ainitialize(
             servlet_name=obj_store.servlet_name or "base",
             setup_cluster_servlet=ClusterServletSetupOption.GET_OR_FAIL,
         )
@@ -82,7 +82,7 @@ def get_local_cluster_object():
 
     # When HTTPServer is initialized, the cluster_config is set
     # within the global state.
-    config = obj_store.get_cluster_config()
+    config = await obj_store.aget_cluster_config()
     if config.get("resource_subtype") is not None:
         from runhouse.resources.hardware.utils import _get_cluster_from
 

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class ClusterServlet:
-    def __init__(
+    async def __init__(
         self, cluster_config: Optional[Dict[str, Any]] = None, *args, **kwargs
     ):
 
@@ -30,22 +30,24 @@ class ClusterServlet:
     ##############################################
     # Cluster config state storage methods
     ##############################################
-    def get_cluster_config(self) -> Dict[str, Any]:
+    async def get_cluster_config(self) -> Dict[str, Any]:
         return self.cluster_config
 
-    def set_cluster_config(self, cluster_config: Dict[str, Any]):
+    async def set_cluster_config(self, cluster_config: Dict[str, Any]):
         self.cluster_config = cluster_config
 
-    def set_cluster_config_value(self, key: str, value: Any):
+    async def set_cluster_config_value(self, key: str, value: Any):
         self.cluster_config[key] = value
 
     ##############################################
     # Auth cache internal functions
     ##############################################
-    def add_user_to_auth_cache(self, token: str, refresh_cache: bool = True):
+    async def add_user_to_auth_cache(self, token: str, refresh_cache: bool = True):
         self._auth_cache.add_user(token, refresh_cache)
 
-    def resource_access_level(self, token: str, resource_uri: str) -> Union[str, None]:
+    async def resource_access_level(
+        self, token: str, resource_uri: str
+    ) -> Union[str, None]:
         # If the token in this request matches that of the owner of the cluster,
         # they have access to everything
         if configs.token and (
@@ -55,13 +57,13 @@ class ClusterServlet:
             return ResourceAccess.WRITE
         return self._auth_cache.lookup_access_level(token, resource_uri)
 
-    def user_resources(self, token: str) -> dict:
+    async def user_resources(self, token: str) -> dict:
         return self._auth_cache.get_user_resources(token)
 
-    def get_username(self, token: str) -> str:
+    async def get_username(self, token: str) -> str:
         return self._auth_cache.get_username(token)
 
-    def has_resource_access(self, token: str, resource_uri=None) -> bool:
+    async def has_resource_access(self, token: str, resource_uri=None) -> bool:
         """Checks whether user has read or write access to a given module saved on the cluster."""
         from runhouse.rns.utils.api import ResourceAccess
 
@@ -88,46 +90,46 @@ class ClusterServlet:
 
         return True
 
-    def clear_auth_cache(self, token: str = None):
+    async def clear_auth_cache(self, token: str = None):
         self._auth_cache.clear_cache(token)
 
     ##############################################
     # Key to servlet where it is stored mapping
     ##############################################
-    def mark_env_servlet_name_as_initialized(self, env_servlet_name: str):
+    async def mark_env_servlet_name_as_initialized(self, env_servlet_name: str):
         self._initialized_env_servlet_names.add(env_servlet_name)
 
-    def is_env_servlet_name_initialized(self, env_servlet_name: str) -> bool:
+    async def is_env_servlet_name_initialized(self, env_servlet_name: str) -> bool:
         return env_servlet_name in self._initialized_env_servlet_names
 
-    def get_all_initialized_env_servlet_names(self) -> Set[str]:
+    async def get_all_initialized_env_servlet_names(self) -> Set[str]:
         return self._initialized_env_servlet_names
 
-    def get_key_to_env_servlet_name_dict_keys(self) -> List[Any]:
+    async def get_key_to_env_servlet_name_dict_keys(self) -> List[Any]:
         return list(self._key_to_env_servlet_name.keys())
 
-    def get_key_to_env_servlet_name_dict(self) -> Dict[Any, str]:
+    async def get_key_to_env_servlet_name_dict(self) -> Dict[Any, str]:
         return self._key_to_env_servlet_name
 
-    def get_env_servlet_name_for_key(self, key: Any) -> str:
+    async def get_env_servlet_name_for_key(self, key: Any) -> str:
         return self._key_to_env_servlet_name.get(key, None)
 
-    def put_env_servlet_name_for_key(self, key: Any, env_servlet_name: str):
+    async def put_env_servlet_name_for_key(self, key: Any, env_servlet_name: str):
         if not self.is_env_servlet_name_initialized(env_servlet_name):
             raise ValueError(
                 f"Env servlet name {env_servlet_name} not initialized, and you tried to mark a resource as in it."
             )
         self._key_to_env_servlet_name[key] = env_servlet_name
 
-    def pop_env_servlet_name_for_key(self, key: Any, *args) -> str:
+    async def pop_env_servlet_name_for_key(self, key: Any, *args) -> str:
         # *args allows us to pass default or not
         return self._key_to_env_servlet_name.pop(key, *args)
 
-    def clear_key_to_env_servlet_name_dict(self):
+    async def clear_key_to_env_servlet_name_dict(self):
         self._key_to_env_servlet_name = {}
 
     ##############################################
     # Remove Env Servlet
     ##############################################
-    def remove_env_servlet_name(self, env_servlet_name: str):
+    async def remove_env_servlet_name(self, env_servlet_name: str):
         self._initialized_env_servlet_names.remove(env_servlet_name)

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -115,7 +115,7 @@ class ClusterServlet:
         return self._key_to_env_servlet_name.get(key, None)
 
     async def put_env_servlet_name_for_key(self, key: Any, env_servlet_name: str):
-        if not self.is_env_servlet_name_initialized(env_servlet_name):
+        if not await self.is_env_servlet_name_initialized(env_servlet_name):
             raise ValueError(
                 f"Env servlet name {env_servlet_name} not initialized, and you tried to mark a resource as in it."
             )

--- a/runhouse/servers/env_servlet.py
+++ b/runhouse/servers/env_servlet.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 def error_handling_decorator(func):
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    async def wrapper(*args, **kwargs):
         ctx = kwargs.pop("ctx", None)
         ctx_token = None
         if ctx:
@@ -35,7 +35,7 @@ def error_handling_decorator(func):
         # so we should return the result of the function directly, or raise
         # the exception if there is one, instead of returning a Response object.
         try:
-            output = func(*args, **kwargs)
+            output = await func(*args, **kwargs)
             if serialization is None or serialization == "none":
                 obj_store.unset_ctx(ctx_token) if ctx_token else None
                 return output
@@ -60,10 +60,10 @@ def error_handling_decorator(func):
 
 
 class EnvServlet:
-    def __init__(self, env_name: str, *args, **kwargs):
+    async def __init__(self, env_name: str, *args, **kwargs):
         self.env_name = env_name
 
-        obj_store.initialize(
+        await obj_store.ainitialize(
             self.env_name,
             has_local_storage=True,
             setup_cluster_servlet=ClusterServletSetupOption.GET_OR_FAIL,
@@ -80,20 +80,20 @@ class EnvServlet:
     # even if unused, because they are used by the decorator
     ##############################################################
     @error_handling_decorator
-    def put_resource_local(
+    async def put_resource_local(
         self,
         data: Any,  # This first comes in a serialized format which the decorator re-populates after deserializing
         serialization: Optional[str] = None,
     ):
         resource_config, state, dryrun = tuple(data)
-        return obj_store.put_resource_local(resource_config, state, dryrun)
+        return await obj_store.aput_resource_local(resource_config, state, dryrun)
 
     @error_handling_decorator
-    def put_local(self, key: Any, data: Any, serialization: Optional[str] = None):
-        return obj_store.put_local(key, data)
+    async def put_local(self, key: Any, data: Any, serialization: Optional[str] = None):
+        return await obj_store.aput_local(key, data)
 
     @error_handling_decorator
-    def call_local(
+    async def call_local(
         self,
         key: Any,
         method_name: str = None,
@@ -109,7 +109,7 @@ class EnvServlet:
         else:
             args, kwargs = [], {}
 
-        return obj_store.call_local(
+        return await obj_store.acall_local(
             key,
             method_name,
             run_name=run_name,
@@ -120,7 +120,7 @@ class EnvServlet:
         )
 
     @error_handling_decorator
-    def get_local(
+    async def get_local(
         self,
         key: Any,
         default: Optional[Any] = None,
@@ -134,23 +134,23 @@ class EnvServlet:
     # These do not catch exceptions, and do not wrap the output
     # in a Response object.
     ##############################################################
-    def keys_local(self):
+    async def keys_local(self):
         return obj_store.keys_local()
 
-    def rename_local(self, key: Any, new_key: Any):
-        return obj_store.rename_local(key, new_key)
+    async def rename_local(self, key: Any, new_key: Any):
+        return await obj_store.arename_local(key, new_key)
 
-    def contains_local(self, key: Any):
+    async def contains_local(self, key: Any):
         return obj_store.contains_local(key)
 
-    def pop_local(self, key: Any, *args):
-        return obj_store.pop_local(key, *args)
+    async def pop_local(self, key: Any, *args):
+        return await obj_store.apop_local(key, *args)
 
-    def delete_local(self, key: Any):
-        return obj_store.delete_local(key)
+    async def delete_local(self, key: Any):
+        return await obj_store.adelete_local(key)
 
-    def clear_local(self):
-        return obj_store.clear_local()
+    async def clear_local(self):
+        return await obj_store.aclear_local()
 
-    def status_local(self):
+    async def status_local(self):
         return obj_store.status_local()

--- a/runhouse/servers/http/auth.py
+++ b/runhouse/servers/http/auth.py
@@ -70,7 +70,7 @@ class AuthCache:
             self.USERNAMES.pop(token, None)
 
 
-def verify_cluster_access(
+async def averify_cluster_access(
     cluster_uri: str,
     token: str,
 ) -> bool:
@@ -91,16 +91,16 @@ def verify_cluster_access(
             return True
 
     # Check if user already has saved resources in cache
-    cached_resources: dict = obj_store.user_resources(token)
+    cached_resources: dict = await obj_store.auser_resources(token)
 
     # e.g. {"/jlewitt1/bert-preproc": "read"}
     cluster_access_level = cached_resources.get(cluster_uri)
 
     if cluster_access_level is None:
         # Reload from cache and check again
-        obj_store.add_user_to_auth_cache(token)
+        await obj_store.aadd_user_to_auth_cache(token)
 
-        cached_resources: dict = obj_store.user_resources(token)
+        cached_resources: dict = await obj_store.auser_resources(token)
         cluster_access_level = cached_resources.get(cluster_uri)
 
     return cluster_access_level in [ResourceAccess.WRITE, ResourceAccess.READ]

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -13,6 +13,7 @@ from ray import cloudpickle as pickle
 from ray.exceptions import RayTaskError
 
 from runhouse.logger import ClusterLogsFormatter
+from runhouse.servers.obj_store import RunhouseStopIteration
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +132,8 @@ def handle_exception_response(
     exception: Exception, traceback, serialization="pickle", from_http_server=False
 ):
     if not (
-        isinstance(exception, StopIteration)
+        isinstance(exception, RunhouseStopIteration)
+        or isinstance(exception, StopIteration)
         or isinstance(exception, GeneratorExit)
         or isinstance(exception, StopAsyncIteration)
     ):
@@ -161,6 +163,9 @@ def handle_exception_response(
         # If the exception is an HTTPException, we should let it flow back through the server so it gets
         # handled by FastAPI's exception handling and returned to the user with the correct status code
         raise exception
+
+    if isinstance(exception, RunhouseStopIteration):
+        exception = StopIteration()
 
     exception_data = {
         "error": exception,

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextvars
 import inspect
 import logging
@@ -11,6 +12,7 @@ import ray
 
 import runhouse
 from runhouse.rns.utils.api import ResourceVisibility
+from runhouse.utils import sync_function
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +31,10 @@ class ClusterServletSetupOption(str, Enum):
 
 
 class ObjStoreError(Exception):
+    pass
+
+
+class RunhouseStopIteration(Exception):
     pass
 
 
@@ -76,13 +82,13 @@ def get_cluster_servlet(create_if_not_exists: bool = False):
 
 def context_wrapper(func):
     @wraps(func)
-    def wrapper(self, *args, **kwargs):
+    async def wrapper(self, *args, **kwargs):
         ctx_token = None
         try:
             if not req_ctx.get():
-                ctx_token = self._populate_ctx_locally()
+                ctx_token = await self.apopulate_ctx_locally()
 
-            res = func(self, *args, **kwargs)
+            res = await func(self, *args, **kwargs)
         except Exception as e:
             if ctx_token:
                 self.unset_ctx(ctx_token)
@@ -126,7 +132,7 @@ class ObjStore:
         self.installed_envs = {}  # TODO: consider deleting it?
         self._kv_store: Dict[Any, Any] = None
 
-    def initialize(
+    async def ainitialize(
         self,
         servlet_name: Optional[str] = None,
         has_local_storage: bool = False,
@@ -193,12 +199,12 @@ class ObjStore:
 
         # There can only be one initialized EnvServlet with a given name AND with local storage.
         if has_local_storage and servlet_name:
-            if self.is_env_servlet_name_initialized(servlet_name):
+            if await self.ais_env_servlet_name_initialized(servlet_name):
                 raise ValueError(
                     f"There already exists an EnvServlet with name {servlet_name}."
                 )
             else:
-                self.mark_env_servlet_name_as_initialized(servlet_name)
+                await self.amark_env_servlet_name_as_initialized(servlet_name)
 
         self.servlet_name = servlet_name
         self.has_local_storage = has_local_storage
@@ -209,9 +215,33 @@ class ObjStore:
         cuda_visible_devices = list(range(int(num_gpus)))
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, cuda_visible_devices))
 
+    def initialize(
+        self,
+        servlet_name: Optional[str] = None,
+        has_local_storage: bool = False,
+        setup_ray: RaySetupOption = RaySetupOption.GET_OR_FAIL,
+        ray_address: str = "auto",
+        setup_cluster_servlet: ClusterServletSetupOption = ClusterServletSetupOption.GET_OR_CREATE,
+    ):
+        return sync_function(self.ainitialize)(
+            servlet_name,
+            has_local_storage,
+            setup_ray,
+            ray_address,
+            setup_cluster_servlet,
+        )
+
     ##############################################
     # Generic helpers
     ##############################################
+    @staticmethod
+    async def acall_actor_method(
+        actor: ray.actor.ActorHandle, method: str, *args, run_async=False, **kwargs
+    ):
+        if actor is None:
+            raise ObjStoreError("Attempting to call an actor method on a None actor.")
+        return await getattr(actor, method).remote(*args, **kwargs)
+
     @staticmethod
     def call_actor_method(
         actor: ray.actor.ActorHandle, method: str, *args, run_async=False, **kwargs
@@ -304,13 +334,13 @@ class ObjStore:
         ctx = RequestContext(**ctx_args)
         return req_ctx.set(ctx)
 
-    def _populate_ctx_locally(self):
+    async def apopulate_ctx_locally(self):
         from runhouse.globals import configs
 
-        den_auth_enabled = self.get_cluster_config().get("den_auth")
+        den_auth_enabled = (await self.aget_cluster_config()).get("den_auth")
         token = configs.token
         if den_auth_enabled and token:
-            self.add_user_to_auth_cache(token, refresh_cache=False)
+            await self.aadd_user_to_auth_cache(token, refresh_cache=False)
         return self.set_ctx(request_id=str(uuid.uuid4()), token=token)
 
     @staticmethod
@@ -320,46 +350,70 @@ class ObjStore:
     ##############################################
     # Cluster config state storage methods
     ##############################################
-    def get_cluster_config(self):
+    async def aget_cluster_config(self):
         # TODO: Potentially add caching here
         if self.cluster_servlet is not None:
-            return self.call_actor_method(self.cluster_servlet, "get_cluster_config")
+            return await self.acall_actor_method(
+                self.cluster_servlet, "get_cluster_config"
+            )
         else:
             return {}
 
-    def set_cluster_config(self, config: Dict[str, Any]):
-        return self.call_actor_method(
+    def get_cluster_config(self):
+        return sync_function(self.aget_cluster_config)()
+
+    async def aset_cluster_config(self, config: Dict[str, Any]):
+        return await self.acall_actor_method(
             self.cluster_servlet, "set_cluster_config", config
         )
 
-    def set_cluster_config_value(self, key: str, value: Any):
-        return self.call_actor_method(
+    def set_cluster_config(self, config: Dict[str, Any]):
+        return sync_function(self.aset_cluster_config)(config)
+
+    async def aset_cluster_config_value(self, key: str, value: Any):
+        return await self.acall_actor_method(
             self.cluster_servlet, "set_cluster_config_value", key, value
         )
+
+    def set_cluster_config_value(self, key: str, value: Any):
+        return sync_function(self.aset_cluster_config_value)(key, value)
 
     ##############################################
     # Auth cache internal functions
     ##############################################
-    def add_user_to_auth_cache(self, token: str, refresh_cache: bool = True):
-        return self.call_actor_method(
+    async def aadd_user_to_auth_cache(self, token: str, refresh_cache: bool = True):
+        return await self.acall_actor_method(
             self.cluster_servlet, "add_user_to_auth_cache", token, refresh_cache
         )
 
-    def resource_access_level(self, token: str, resource_uri: str):
-        return self.call_actor_method(
+    def add_user_to_auth_cache(self, token: str, refresh_cache: bool = True):
+        return sync_function(self.aadd_user_to_auth_cache)(token, refresh_cache)
+
+    async def aresource_access_level(self, token: str, resource_uri: str):
+        return await self.acall_actor_method(
             self.cluster_servlet,
             "resource_access_level",
             token,
             resource_uri,
         )
 
+    def resource_access_level(self, token: str, resource_uri: str):
+        return sync_function(self.aresource_access_level)(token, resource_uri)
+
+    async def auser_resources(self, token: str):
+        return await self.acall_actor_method(
+            self.cluster_servlet, "user_resources", token
+        )
+
     def user_resources(self, token: str):
-        return self.call_actor_method(self.cluster_servlet, "user_resources", token)
+        return sync_function(self.auser_resources)(token)
 
-    def get_username(self, token: str):
-        return self.call_actor_method(self.cluster_servlet, "get_username", token)
+    async def aget_username(self, token: str):
+        return await self.acall_actor_method(
+            self.cluster_servlet, "get_username", token
+        )
 
-    def has_resource_access(self, token: str, resource_uri=None) -> bool:
+    async def ahas_resource_access(self, token: str, resource_uri=None) -> bool:
         """Checks whether user has read or write access to a given module saved on the cluster."""
         from runhouse.globals import configs, rns_client
         from runhouse.rns.utils.api import ResourceAccess
@@ -381,7 +435,7 @@ class ObjStore:
                 return True
 
         cluster_uri = load_current_cluster_rns_address()
-        cluster_access = self.resource_access_level(token, cluster_uri)
+        cluster_access = await self.aresource_access_level(token, cluster_uri)
         if cluster_access == ResourceAccess.WRITE:
             # if user has write access to cluster will have access to all resources
             return True
@@ -393,58 +447,66 @@ class ObjStore:
             # If module does not have a name, must have access to the cluster
             return False
 
-        resource_access_level = self.resource_access_level(token, resource_uri)
+        resource_access_level = await self.aresource_access_level(token, resource_uri)
         if resource_access_level not in [ResourceAccess.WRITE, ResourceAccess.READ]:
             return False
 
         return True
 
-    def clear_auth_cache(self, token: str = None):
-        return self.call_actor_method(self.cluster_servlet, "clear_auth_cache", token)
+    async def aclear_auth_cache(self, token: str = None):
+        return await self.acall_actor_method(
+            self.cluster_servlet, "clear_auth_cache", token
+        )
 
     ##############################################
     # Key to servlet where it is stored mapping
     ##############################################
-    def mark_env_servlet_name_as_initialized(self, env_servlet_name: str):
-        return self.call_actor_method(
+    async def amark_env_servlet_name_as_initialized(self, env_servlet_name: str):
+        return await self.acall_actor_method(
             self.cluster_servlet,
             "mark_env_servlet_name_as_initialized",
             env_servlet_name,
         )
 
-    def is_env_servlet_name_initialized(self, env_servlet_name: str) -> bool:
-        return self.call_actor_method(
+    async def ais_env_servlet_name_initialized(self, env_servlet_name: str) -> bool:
+        return await self.acall_actor_method(
             self.cluster_servlet, "is_env_servlet_name_initialized", env_servlet_name
         )
 
-    def get_all_initialized_env_servlet_names(self) -> Set[str]:
+    async def aget_all_initialized_env_servlet_names(self) -> Set[str]:
         return list(
-            self.call_actor_method(
+            await self.acall_actor_method(
                 self.cluster_servlet,
                 "get_all_initialized_env_servlet_names",
             )
         )
 
-    def get_env_servlet_name_for_key(self, key: Any):
-        return self.call_actor_method(
+    def get_all_initialized_env_servlet_names(self) -> Set[str]:
+        return sync_function(self.aget_all_initialized_env_servlet_names)()
+
+    async def aget_env_servlet_name_for_key(self, key: Any):
+        return await self.acall_actor_method(
             self.cluster_servlet, "get_env_servlet_name_for_key", key
         )
 
-    def _put_env_servlet_name_for_key(self, key: Any, env_servlet_name: str):
-        return self.call_actor_method(
+    def get_env_servlet_name_for_key(self, key: Any):
+        return sync_function(self.aget_env_servlet_name_for_key)(key)
+
+    async def _aput_env_servlet_name_for_key(self, key: Any, env_servlet_name: str):
+        return await self.acall_actor_method(
             self.cluster_servlet, "put_env_servlet_name_for_key", key, env_servlet_name
         )
 
-    def _pop_env_servlet_name_for_key(self, key: Any, *args) -> str:
-        return self.call_actor_method(
+    async def _apop_env_servlet_name_for_key(self, key: Any, *args) -> str:
+        return await self.acall_actor_method(
             self.cluster_servlet, "pop_env_servlet_name_for_key", key, *args
         )
 
     ##############################################
     # Remove Env Servlet
     ##############################################
-    def remove_env_servlet_name(self, env_servlet_name: str):
-        return self.call_actor_method(
+    async def aremove_env_servlet_name(self, env_servlet_name: str):
+        return await self.acall_actor_method(
             self.cluster_servlet, "remove_env_servlet_name", env_servlet_name
         )
 
@@ -452,10 +514,13 @@ class ObjStore:
     # KV Store: Keys
     ##############################################
     @staticmethod
-    def keys_for_env_servlet_name(env_servlet_name: str) -> List[Any]:
-        return ObjStore.call_actor_method(
+    async def akeys_for_env_servlet_name(env_servlet_name: str) -> List[Any]:
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name), "keys_local"
         )
+
+    def keys_for_env_servlet_name(self, env_servlet_name: str) -> List[Any]:
+        return sync_function(self.akeys_for_env_servlet_name)(env_servlet_name)
 
     def keys_local(self) -> List[Any]:
         if self.has_local_storage:
@@ -463,20 +528,23 @@ class ObjStore:
         else:
             return []
 
-    def keys(self) -> List[Any]:
+    async def akeys(self) -> List[Any]:
         # Return keys across the cluster, not only in this process
-        return self.call_actor_method(
+        return await self.acall_actor_method(
             self.cluster_servlet, "get_key_to_env_servlet_name_dict_keys"
         )
+
+    def keys(self) -> List[Any]:
+        return sync_function(self.akeys)()
 
     ##############################################
     # KV Store: Put
     ##############################################
     @staticmethod
-    def put_for_env_servlet_name(
+    async def aput_for_env_servlet_name(
         env_servlet_name: str, key: Any, data: Any, serialization: Optional[str] = None
     ):
-        return ObjStore.call_actor_method(
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name),
             "put_local",
             key,
@@ -484,14 +552,14 @@ class ObjStore:
             serialization=serialization,
         )
 
-    def put_local(self, key: Any, value: Any):
+    async def aput_local(self, key: Any, value: Any):
         if self.has_local_storage:
             self._kv_store[key] = value
-            self._put_env_servlet_name_for_key(key, self.servlet_name)
+            await self._aput_env_servlet_name_for_key(key, self.servlet_name)
         else:
             raise NoLocalObjStoreError()
 
-    def put(
+    async def aput(
         self,
         key: Any,
         value: Any,
@@ -515,22 +583,52 @@ class ObjStore:
                 )
 
         # If it does exist somewhere, no more!
-        if self.get(key, default=None) is not None:
+        if await self.aget(key, default=None) is not None:
             logger.warning("Key already exists in some env, overwriting.")
-            self.pop(key)
+            await self.apop(key)
 
         if self.has_local_storage and env == self.servlet_name:
             if serialization is not None:
                 raise ObjStoreError(
                     "We should never reach this branch if serialization is not None."
                 )
-            self.put_local(key, value)
+            await self.aput_local(key, value)
         else:
-            self.put_for_env_servlet_name(env, key, value, serialization)
+            await self.aput_for_env_servlet_name(env, key, value, serialization)
+
+    def put(
+        self,
+        key: Any,
+        value: Any,
+        env: Optional[str] = None,
+        serialization: Optional[str] = None,
+        create_env_if_not_exists: bool = False,
+    ):
+        return sync_function(self.aput)(
+            key, value, env, serialization, create_env_if_not_exists
+        )
 
     ##############################################
     # KV Store: Get
     ##############################################
+    @staticmethod
+    async def aget_from_env_servlet_name(
+        env_servlet_name: str,
+        key: Any,
+        default: Optional[Any] = None,
+        serialization: Optional[str] = None,
+        remote: bool = False,
+    ):
+        logger.info(f"Getting {key} from servlet {env_servlet_name}")
+        return await ObjStore.acall_actor_method(
+            ObjStore.get_env_servlet(env_servlet_name),
+            "get_local",
+            key,
+            default=default,
+            serialization=serialization,  # Crucial that this is a kwarg, or the wrapper doesn't pick it up!!
+            remote=remote,
+        )
+
     @staticmethod
     def get_from_env_servlet_name(
         env_servlet_name: str,
@@ -539,14 +637,8 @@ class ObjStore:
         serialization: Optional[str] = None,
         remote: bool = False,
     ):
-        logger.info(f"Getting {key} from servlet {env_servlet_name}")
-        return ObjStore.call_actor_method(
-            ObjStore.get_env_servlet(env_servlet_name),
-            "get_local",
-            key,
-            default=default,
-            serialization=serialization,  # Crucial that this is a kwarg, or the wrapper doesn't pick it up!!
-            remote=remote,
+        return sync_function(ObjStore.aget_from_env_servlet_name)(
+            env_servlet_name, key, default, serialization, remote
         )
 
     def get_local(self, key: Any, default: Optional[Any] = None, remote: bool = False):
@@ -570,14 +662,14 @@ class ObjStore:
                 raise KeyError(f"No local store exists; key {key} not found.")
             return default
 
-    def get(
+    async def aget(
         self,
         key: Any,
         serialization: Optional[str] = None,
         remote: bool = False,
         default: Optional[Any] = None,
     ):
-        env_servlet_name_containing_key = self.get_env_servlet_name_for_key(key)
+        env_servlet_name_containing_key = await self.aget_env_servlet_name_for_key(key)
 
         if not env_servlet_name_containing_key:
             if default == KeyError:
@@ -599,7 +691,7 @@ class ObjStore:
             # because the EnvServlet already packaged the config into a Response object. This is desired, as we
             # only want the remote object to be reconstructed when it's being returned to the user, which would
             # not be here if serialization is not None (probably the HTTPClient).
-            res = self.get_from_env_servlet_name(
+            res = await self.aget_from_env_servlet_name(
                 env_servlet_name_containing_key,
                 key,
                 default=default,
@@ -616,7 +708,7 @@ class ObjStore:
             and "resource_type" in res
         ):
             config = res
-            if config.get("system") == self.get_cluster_config():
+            if config.get("system") == await self.aget_cluster_config():
                 from runhouse import here
 
                 config["system"] = here
@@ -627,12 +719,21 @@ class ObjStore:
 
         return res
 
+    def get(
+        self,
+        key: Any,
+        serialization: Optional[str] = None,
+        remote: bool = False,
+        default: Optional[Any] = None,
+    ):
+        return sync_function(self.aget)(key, serialization, remote, default)
+
     ##############################################
     # KV Store: Contains
     ##############################################
     @staticmethod
-    def contains_for_env_servlet_name(env_servlet_name: str, key: Any):
-        return ObjStore.call_actor_method(
+    async def acontains_for_env_servlet_name(env_servlet_name: str, key: Any):
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name), "contains_local", key
         )
 
@@ -642,11 +743,11 @@ class ObjStore:
         else:
             return False
 
-    def contains(self, key: Any):
+    async def acontains(self, key: Any):
         if self.contains_local(key):
             return True
 
-        env_servlet_name = self.get_env_servlet_name_for_key(key)
+        env_servlet_name = await self.aget_env_servlet_name_for_key(key)
         if env_servlet_name == self.servlet_name and self.has_local_storage:
             raise ObjStoreError(
                 "Key not found in kv store despite env servlet specifying that it is here."
@@ -655,16 +756,19 @@ class ObjStore:
         if env_servlet_name is None:
             return False
 
-        return self.contains_for_env_servlet_name(env_servlet_name, key)
+        return await self.acontains_for_env_servlet_name(env_servlet_name, key)
+
+    def contains(self, key: Any):
+        return sync_function(self.acontains)(key)
 
     ##############################################
     # KV Store: Pop
     ##############################################
     @staticmethod
-    def pop_from_env_servlet_name(
+    async def apop_from_env_servlet_name(
         env_servlet_name: str, key: Any, serialization: Optional[str] = "pickle", *args
     ) -> Any:
-        return ObjStore.call_actor_method(
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name),
             "pop_local",
             key,
@@ -672,7 +776,7 @@ class ObjStore:
             *args,
         )
 
-    def pop_local(self, key: Any, *args) -> Any:
+    async def apop_local(self, key: Any, *args) -> Any:
         if self.has_local_storage:
             try:
                 res = self._kv_store.pop(key)
@@ -685,7 +789,7 @@ class ObjStore:
 
             # If the key was found in this env, we also need to pop it
             # from the global env for key cache.
-            env_name = self._pop_env_servlet_name_for_key(key, None)
+            env_name = await self._apop_env_servlet_name_for_key(key, None)
             if env_name and env_name != self.servlet_name:
                 raise ObjStoreError(
                     "The key was popped from this env, but the global env for key cache says it's in another one."
@@ -698,15 +802,17 @@ class ObjStore:
             else:
                 raise KeyError(f"No local store exists; key {key} not found.")
 
-    def pop(self, key: Any, serialization: Optional[str] = "pickle", *args) -> Any:
+    async def apop(
+        self, key: Any, serialization: Optional[str] = "pickle", *args
+    ) -> Any:
         try:
-            return self.pop_local(key)
+            return await self.apop_local(key)
         except KeyError as e:
             key_err = e
 
         # The key was not found in this env
         # So, we check the global key to env cache to see if it's elsewhere
-        env_servlet_name = self.get_env_servlet_name_for_key(key)
+        env_servlet_name = await self.aget_env_servlet_name_for_key(key)
         if env_servlet_name:
             if env_servlet_name == self.servlet_name and self.has_local_storage:
                 raise ObjStoreError(
@@ -714,7 +820,7 @@ class ObjStore:
                 )
             else:
                 # The key was found in another env, so we need to pop it from there
-                return self.pop_from_env_servlet_name(
+                return await self.apop_from_env_servlet_name(
                     env_servlet_name, key, serialization
                 )
         else:
@@ -724,24 +830,27 @@ class ObjStore:
             else:
                 raise key_err
 
+    def pop(self, key: Any, serialization: Optional[str] = "pickle", *args) -> Any:
+        return sync_function(self.apop)(key, serialization, *args)
+
     ##############################################
     # KV Store: Delete
     ##############################################
     @staticmethod
-    def delete_for_env_servlet_name(env_servlet_name: str, key: Any):
-        return ObjStore.call_actor_method(
+    async def adelete_for_env_servlet_name(env_servlet_name: str, key: Any):
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name), "delete_local", key
         )
 
-    def delete_local(self, key: Any):
-        self.pop_local(key)
+    async def adelete_local(self, key: Any):
+        await self.apop_local(key)
 
-    def _delete_env_contents(self, env_name: Any):
+    async def adelete_env_contents(self, env_name: Any):
         from runhouse.globals import env_servlets
 
         # clear keys in the env servlet
-        deleted_keys = self.keys_for_env_servlet_name(env_name)
-        self.clear_for_env_servlet_name(env_name)
+        deleted_keys = await self.akeys_for_env_servlet_name(env_name)
+        await self.aclear_for_env_servlet_name(env_name)
 
         # delete the env servlet actor and remove its references
         if env_name in env_servlets:
@@ -749,26 +858,31 @@ class ObjStore:
             ray.kill(actor)
 
             del env_servlets[env_name]
-        self.remove_env_servlet_name(env_name)
+        await self.aremove_env_servlet_name(env_name)
 
         return deleted_keys
 
-    def delete(self, key: Union[Any, List[Any]]):
+    def delete_env_contents(self, env_name: Any):
+        return sync_function(self.adelete_env_contents)(env_name)
+
+    async def adelete(self, key: Union[Any, List[Any]]):
         keys_to_delete = [key] if isinstance(key, str) else key
         deleted_keys = []
 
         for key_to_delete in keys_to_delete:
-            if key_to_delete in self.get_all_initialized_env_servlet_names():
-                deleted_keys += self._delete_env_contents(key_to_delete)
+            if key_to_delete in await self.aget_all_initialized_env_servlet_names():
+                deleted_keys += await self.adelete_env_contents(key_to_delete)
 
             if key_to_delete in deleted_keys:
                 continue
 
             if self.contains_local(key_to_delete):
-                self.delete_local(key_to_delete)
+                await self.adelete_local(key_to_delete)
                 deleted_keys.append(key_to_delete)
             else:
-                env_servlet_name = self.get_env_servlet_name_for_key(key_to_delete)
+                env_servlet_name = await self.aget_env_servlet_name_for_key(
+                    key_to_delete
+                )
                 if env_servlet_name == self.servlet_name and self.has_local_storage:
                     raise ObjStoreError(
                         "Key not found in kv store despite env servlet specifying that it is here."
@@ -776,49 +890,57 @@ class ObjStore:
                 if env_servlet_name is None:
                     raise KeyError(f"Key {key} not found in any env.")
 
-                self.delete_for_env_servlet_name(env_servlet_name, key_to_delete)
+                await self.adelete_for_env_servlet_name(env_servlet_name, key_to_delete)
                 deleted_keys.append(key_to_delete)
+
+    def delete(self, key: Union[Any, List[Any]]):
+        return sync_function(self.adelete)(key)
 
     ##############################################
     # KV Store: Clear
     ##############################################
     @staticmethod
-    def clear_for_env_servlet_name(env_servlet_name: str):
-        return ObjStore.call_actor_method(
+    async def aclear_for_env_servlet_name(env_servlet_name: str):
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name), "clear_local"
         )
 
-    def clear_local(self):
+    async def aclear_local(self):
         if self.has_local_storage:
             for k in list(self._kv_store.keys()):
                 # Pop handles removing from global obj store vs local one
-                self.pop_local(k)
+                await self.apop_local(k)
+
+    async def aclear(self):
+        logger.warning("Clearing all keys from all envs in the object store!")
+        for env_servlet_name in await self.aget_all_initialized_env_servlet_names():
+            if env_servlet_name == self.servlet_name and self.has_local_storage:
+                await self.aclear_local()
+            else:
+                await self.aclear_for_env_servlet_name(env_servlet_name)
 
     def clear(self):
-        logger.warning("Clearing all keys from all envs in the object store!")
-        for env_servlet_name in self.get_all_initialized_env_servlet_names():
-            if env_servlet_name == self.servlet_name and self.has_local_storage:
-                self.clear_local()
-            else:
-                self.clear_for_env_servlet_name(env_servlet_name)
+        return sync_function(self.aclear)()
 
     ##############################################
     # KV Store: Rename
     ##############################################
     @staticmethod
-    def rename_for_env_servlet_name(env_servlet_name: str, old_key: Any, new_key: Any):
-        return ObjStore.call_actor_method(
+    async def arename_for_env_servlet_name(
+        env_servlet_name: str, old_key: Any, new_key: Any
+    ):
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name),
             "rename_local",
             old_key,
             new_key,
         )
 
-    def rename_local(self, old_key: Any, new_key: Any):
+    async def arename_local(self, old_key: Any, new_key: Any):
         if self.servlet_name is None or not self.has_local_storage:
             raise NoLocalObjStoreError()
 
-        obj = self.pop(old_key)
+        obj = await self.apop(old_key)
         if obj is not None and hasattr(obj, "rns_address"):
             # Note - we set the obj.name here so the new_key is correctly turned into an rns_address, whether its
             # a full address or just a name. Then, the new_key is set to just the name so its store properly in the
@@ -827,26 +949,31 @@ class ObjStore:
             new_key = obj.name  # new_key is now just the name
 
         # By passing default, we don't throw an error if the key is not found
-        self.put(new_key, obj, env=self.servlet_name)
+        await self.aput(new_key, obj, env=self.servlet_name)
 
-    def rename(self, old_key: Any, new_key: Any):
+    async def arename(self, old_key: Any, new_key: Any):
         # We also need to rename the resource itself
-        env_servlet_name_containing_old_key = self.get_env_servlet_name_for_key(old_key)
+        env_servlet_name_containing_old_key = await self.aget_env_servlet_name_for_key(
+            old_key
+        )
         if (
             env_servlet_name_containing_old_key == self.servlet_name
             and self.has_local_storage
         ):
-            self.rename_local(old_key, new_key)
+            await self.arename_local(old_key, new_key)
         else:
-            self.rename_for_env_servlet_name(
+            await self.arename_for_env_servlet_name(
                 env_servlet_name_containing_old_key, old_key, new_key
             )
+
+    def rename(self, old_key: Any, new_key: Any):
+        return sync_function(self.arename)(old_key, new_key)
 
     ##############################################
     # KV Store: Call
     ##############################################
     @staticmethod
-    def call_for_env_servlet_name(
+    async def acall_for_env_servlet_name(
         env_servlet_name: str,
         key: Any,
         method_name: str,
@@ -855,9 +982,8 @@ class ObjStore:
         run_name: Optional[str] = None,
         stream_logs: bool = False,
         remote: bool = False,
-        run_async: bool = False,
     ):
-        return ObjStore.call_actor_method(
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_servlet_name),
             "call_local",
             key,
@@ -868,10 +994,9 @@ class ObjStore:
             stream_logs=stream_logs,
             remote=remote,
             ctx=dict(req_ctx.get()),
-            run_async=run_async,
         )
 
-    def call_local(
+    async def acall_local(
         self,
         key: str,
         method_name: Optional[str] = None,
@@ -907,7 +1032,7 @@ class ObjStore:
         from runhouse.resources.module import Module
         from runhouse.resources.resource import Resource
 
-        if self.get_cluster_config().get("den_auth"):
+        if (await self.aget_cluster_config()).get("den_auth"):
             if not isinstance(obj, Resource) or obj.visibility not in [
                 ResourceVisibility.UNLISTED,
                 ResourceVisibility.PUBLIC,
@@ -925,7 +1050,7 @@ class ObjStore:
                 # Setting to None in the case of non-resource or no rns_address will force auth to only
                 # succeed if the user has WRITE or READ access to the cluster
                 resource_uri = obj.rns_address if hasattr(obj, "rns_address") else None
-                if key != Env.DEFAULT_NAME and not self.has_resource_access(
+                if key != Env.DEFAULT_NAME and not await self.ahas_resource_access(
                     ctx.token, resource_uri
                 ):
                     # Do not validate access to the default Env
@@ -956,12 +1081,26 @@ class ObjStore:
             logger.debug(obj.__dict__)
             raise ValueError(f"Method {method_name} not found on module {obj}")
 
-        if hasattr(method, "__call__") or method_name == "__call__":
+        if method_name in ["remote_anext", "remote_await"]:
+            # If the method is a coroutine or generator, we need to call it with await
+            # This is a special case because when the method comes through first time around, we notice that the
+            # result is a coroutine, repackage it in a "FutureModule" or "AsyncGeneratorModule", and then return
+            # it to the user. Then, when the user actually awaits, they call our magic `__await__` method, which
+            # calls our synchronous dunder method, which is then caught here and *actually* awaited.
+            logger.info(
+                f"{self.servlet_name} env: Calling special method via await {method_name} on module {key}"
+            )
+            res = await method(*args, **kwargs)
+
+        elif hasattr(method, "__call__") or method_name == "__call__":
             # If method is callable, call it and return the result
             logger.info(
                 f"{self.servlet_name} env: Calling method {method_name} on module {key}"
             )
-            res = method(*args, **kwargs)
+            try:
+                res = method(*args, **kwargs)
+            except StopIteration:
+                raise RunhouseStopIteration()
         else:
             if args and len(args) == 1:
                 # if there's an arg, this is a "set" call on the property
@@ -1007,8 +1146,8 @@ class ObjStore:
                 f"{self.servlet_name} servlet: Method {method_name} on module {key} is a {laziness_type}. "
                 f"Storing result to be retrieved later at result key {res}."
             )
-            fut = self.construct_call_retrievable(res, run_name, laziness_type)
-            self.put_local(run_name, fut)
+            fut = self._construct_call_retrievable(res, run_name, laziness_type)
+            await self.aput_local(run_name, fut)
             if log_ctx:
                 log_ctx.__exit__(None, None, None)
             return fut
@@ -1020,7 +1159,7 @@ class ObjStore:
                 # This is a user-specified name, so we want to override the existing name with it
                 # and save the resource
                 res.name = run_name or res.name
-                self.put_local(res.name, res)
+                await self.aput_local(res.name, res)
 
             if remote:
                 # If we've reached this block then we know "@" is in run_name and it's an auto-generated name,
@@ -1028,7 +1167,7 @@ class ObjStore:
                 res.name = res.name or run_name
 
                 # Need to save the resource in case we haven't yet (e.g. if run_name was auto-generated)
-                self.put_local(res.name, res)
+                await self.aput_local(res.name, res)
                 # If remote is True and the result is a resource, we return just the config
                 res = res.config()
 
@@ -1038,7 +1177,7 @@ class ObjStore:
         return res
 
     @staticmethod
-    def construct_call_retrievable(res, res_key, laziness_type):
+    def _construct_call_retrievable(res, res_key, laziness_type):
         if laziness_type == "coroutine":
             from runhouse.resources.future_module import FutureModule
 
@@ -1059,7 +1198,7 @@ class ObjStore:
             raise ValueError(f"Invalid laziness type {laziness_type}")
 
     @context_wrapper
-    def call(
+    async def acall(
         self,
         key: str,
         method_name: Optional[str] = None,
@@ -1070,7 +1209,7 @@ class ObjStore:
         remote: bool = False,
         run_async: bool = False,
     ):
-        env_servlet_name_containing_key = self.get_env_servlet_name_for_key(key)
+        env_servlet_name_containing_key = await self.aget_env_servlet_name_for_key(key)
         if not env_servlet_name_containing_key:
             raise ObjStoreError(
                 f"Key {key} not found in any env, cannot call method {method_name} on it."
@@ -1087,7 +1226,7 @@ class ObjStore:
                 "kwargs", {}
             )
 
-            res = self.call_local(
+            res = await self.acall_local(
                 key,
                 method_name,
                 run_name=run_name,
@@ -1097,7 +1236,7 @@ class ObjStore:
                 **kwargs,
             )
         else:
-            res = self.call_for_env_servlet_name(
+            res = await self.acall_for_env_servlet_name(
                 env_servlet_name_containing_key,
                 key,
                 method_name,
@@ -1106,14 +1245,13 @@ class ObjStore:
                 run_name=run_name,
                 stream_logs=stream_logs,
                 remote=remote,
-                run_async=run_async,
             )
 
         if remote and isinstance(res, dict) and "resource_type" in res:
             config = res
-            if config.get("system").get("name") == self.get_cluster_config().get(
-                "name"
-            ):
+            if config.get("system").get("name") == (
+                await self.aget_cluster_config()
+            ).get("name"):
                 from runhouse import here
 
                 config["system"] = here
@@ -1124,26 +1262,64 @@ class ObjStore:
 
         return res
 
+    def call(
+        self,
+        key: str,
+        method_name: Optional[str] = None,
+        data: Any = None,
+        serialization: Optional[str] = None,
+        run_name: Optional[str] = None,
+        stream_logs: bool = False,
+        remote: bool = False,
+        run_async: bool = False,
+    ):
+        return sync_function(self.acall)(
+            key,
+            method_name,
+            data,
+            serialization,
+            run_name,
+            stream_logs,
+            remote,
+            run_async,
+        )
+
     ##############################################
     # Get several keys for function initialization utilities
     ##############################################
+    async def aget_list(self, keys: List[str], default: Optional[Any] = None):
+        return await asyncio.gather(
+            *[self.aget(key, default=default or key) for key in keys]
+        )
+
     def get_list(self, keys: List[str], default: Optional[Any] = None):
-        return [self.get(key, default=default or key) for key in keys]
+        return sync_function(self.aget_list)(keys, default)
+
+    async def aget_obj_refs_list(self, keys: List[Any]):
+
+        return await asyncio.gather(
+            *[
+                self.aget(key, default=key) if isinstance(key, str) else key
+                for key in keys
+            ]
+        )
 
     def get_obj_refs_list(self, keys: List[Any]):
-        return [
-            self.get(key, default=key) if isinstance(key, str) else key for key in keys
-        ]
+        return sync_function(self.aget_obj_refs_list)(keys)
+
+    async def aget_obj_refs_dict(self, d: Dict[Any, Any]):
+        return {
+            k: await self.aget(v, default=v) if isinstance(v, str) else v
+            for k, v in d.items()
+        }
 
     def get_obj_refs_dict(self, d: Dict[Any, Any]):
-        return {
-            k: self.get(v, default=v) if isinstance(v, str) else v for k, v in d.items()
-        }
+        return sync_function(self.aget_obj_refs_dict)(d)
 
     ##############################################
     # More specific helpers
     ##############################################
-    def put_resource(
+    async def aput_resource(
         self,
         serialized_data: Any,
         serialization: Optional[str] = None,
@@ -1159,7 +1335,7 @@ class ObjStore:
             resource_config, state, dryrun = tuple(
                 deserialize_data(serialized_data, serialization)
             )
-            return self.put_resource_local(resource_config, state, dryrun)
+            return await self.aput_resource_local(resource_config, state, dryrun)
 
         # Normally, serialization and deserialization happens within the servlet
         # However, if we're putting an env, we need to deserialize it here and
@@ -1184,14 +1360,24 @@ class ObjStore:
                 resources=resource_config.get("compute", None),
             )
 
-        return ObjStore.call_actor_method(
+        return await ObjStore.acall_actor_method(
             ObjStore.get_env_servlet(env_name),
             "put_resource_local",
             data=serialized_data,
             serialization=serialization,
         )
 
-    def put_resource_local(
+    def put_resource(
+        self,
+        serialized_data: Any,
+        serialization: Optional[str] = None,
+        env_name: Optional[str] = None,
+    ) -> "Response":
+        return sync_function(self.aput_resource)(
+            serialized_data, serialization, env_name
+        )
+
+    async def aput_resource_local(
         self,
         resource_config: Dict[str, Any],
         state: Dict[Any, Any],
@@ -1211,7 +1397,7 @@ class ObjStore:
             resource_config.pop("provider") if "provider" in resource_config else None
         )
 
-        resource_config = self.get_obj_refs_dict(resource_config)
+        resource_config = await self.aget_obj_refs_dict(resource_config)
         resource_config["name"] = name
         resource_config["resource_subtype"] = subtype
         if provider:
@@ -1232,7 +1418,7 @@ class ObjStore:
         else:
             resource.name = name
 
-        self.put(resource.name, resource)
+        await self.aput(resource.name, resource)
 
         # Return the name in case we had to set it
         return resource.name
@@ -1265,14 +1451,17 @@ class ObjStore:
         else:
             return []
 
-    def status(self):
+    async def astatus(self):
         config_cluster = self.get_cluster_config()
         config_cluster.pop("creds", None)
         cluster_servlets = {}
-        for env in self.get_all_initialized_env_servlet_names():
-            resources_in_env_modified = self.call_actor_method(
+        for env in await self.aget_all_initialized_env_servlet_names():
+            resources_in_env_modified = await self.acall_actor_method(
                 self.get_env_servlet(env), "status_local"
             )
             cluster_servlets[env] = resources_in_env_modified
         config_cluster["envs"] = cluster_servlets
         return config_cluster
+
+    def status(self):
+        return sync_function(self.astatus)()

--- a/runhouse/utils.py
+++ b/runhouse/utils.py
@@ -1,5 +1,8 @@
+import asyncio
+import contextvars
 import logging
 import subprocess
+from functools import wraps
 
 
 def run_with_logs(cmd: str, **kwargs) -> int:
@@ -48,3 +51,164 @@ def install_conda():
         run_with_logs("source $HOME/miniconda3/bin/activate", shell=True)
         if run_with_logs("conda --version") != 0:
             raise RuntimeError("Could not install Conda.")
+
+
+from concurrent.futures import ThreadPoolExecutor
+
+
+def _thread_coroutine(coroutine, context):
+    # Copy contextvars from the parent thread to the new thread
+    for var, value in context.items():
+        var.set(value)
+
+    # Technically, event loop logic is not threadsafe. However, this event loop is only in this thread.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        # The loop runs only for the duration of the thread
+        return loop.run_until_complete(coroutine)
+    finally:
+        # We don't need to do asyncio.set_event_loop(None) since the thread will just end completely
+        loop.close()
+
+
+# We should minimize calls to this since each one will start a new thread.
+# Technically we should not have many threads running async logic at once, however, the calling thread
+# will actually block until the async logic that is spawned in the other thread is done.
+def sync_function(coroutine_func):
+    @wraps(coroutine_func)
+    def wrapper(*args, **kwargs):
+        # Better API than using threading.Thread, since we just need the thread temporarily
+        # and the resources are cleaned up
+        with ThreadPoolExecutor() as executor:
+            future = executor.submit(
+                _thread_coroutine,
+                coroutine_func(*args, **kwargs),
+                contextvars.copy_context(),
+            )
+            return future.result()
+
+    return wrapper
+
+
+####################################################################################################
+# Other implementations I've tried of this
+####################################################################################################
+# WORKING
+#
+# import nest_asyncio
+# from asyncio import Task
+
+# def _to_task(future, as_task, loop):
+#     if not as_task or isinstance(future, Task):
+#         return future
+#     return loop.create_task(future)
+
+# def sync_function(coroutine_func, as_task=True):
+#     """
+#     A better implementation of `asyncio.run`.
+
+#     :param future: A future or task or call of an async method.
+#     :param as_task: Forces the future to be scheduled as task (needed for e.g. aiohttp).
+#     """
+#     @wraps(coroutine_func)
+#     def wrapper(*args, **kwargs):
+#         future = coroutine_func(*args, **kwargs)
+#         try:
+#             loop = asyncio.get_running_loop()
+#         except RuntimeError:  # no event loop running:
+#             loop = asyncio.new_event_loop()
+#             return loop.run_until_complete(_to_task(future, as_task, loop))
+#         else:
+#             nest_asyncio.apply(loop)
+#             return asyncio.run(_to_task(future, as_task, loop))
+
+#     return wrapper
+
+
+# KINDA WORKING
+#
+# I got led to this solution from an answer in here:
+# https://stackoverflow.com/questions/46827007/runtimeerror-this-event-loop-is-already-running-in-python
+# That originally used nest_asyncio, but I wanted to avoid that, and some actual good ass engineer thought of this:
+# https://stackoverflow.com/questions/52232177/runtimeerror-timeout-context-manager-should-be-used-inside-a-task/69514930#69514930
+# which I still don't really get
+
+# Another useful post: https://stackoverflow.com/questions/57238316/future-from-asyncio-run-coroutine-threadsafe-hangs-forever
+
+# import threading
+
+# def _start_background_loop(loop):
+#     asyncio.set_event_loop(loop)
+#     loop.run_forever()
+
+
+# # This should only run per process, I guess
+# _LOOP = asyncio.new_event_loop()
+# _LOOP_THREAD = threading.Thread(
+#     target=_start_background_loop, args=(_LOOP,), daemon=True
+# )
+# _LOOP_THREAD.start()
+
+# def sync_function(coroutine_func):
+#     @wraps(coroutine_func)
+#     def wrapper(*args, **kwargs):
+#         return asyncio.run_coroutine_threadsafe(
+#             coroutine_func(*args, **kwargs), _LOOP
+#         ).result()
+
+#     return wrapper
+
+
+# NOT WORKING
+#
+# def sync_function(coroutine_func):
+
+#     @wraps(coroutine_func)
+#     def wrapper(*args, **kwargs):
+#         try:
+#             old_loop = asyncio.get_running_loop()
+#         except RuntimeError:
+#             old_loop = None
+
+#         inner_new_loop = asyncio.new_event_loop()
+#         asyncio.set_event_loop(inner_new_loop)
+
+#         try:
+#             return inner_new_loop.run_until_complete(coroutine_func(*args, **kwargs))
+#         finally:
+#             inner_new_loop.close()
+#             if old_loop is not None:
+#                 asyncio.set_event_loop(old_loop)
+
+#     return wrapper
+
+# NOT WORKING
+#
+# def sync_function(coroutine_func):
+
+#     @wraps(coroutine_func)
+#     def wrapper(*args, **kwargs):
+#         try:
+#             old_loop = asyncio.get_running_loop()
+#         except RuntimeError:
+#             old_loop = None
+
+#         inner_new_loop = asyncio.new_event_loop()
+#         asyncio.set_event_loop(inner_new_loop)
+
+#         try:
+#             future = asyncio.run_coroutine_threadsafe(coroutine_func(*args, **kwargs), inner_new_loop)
+#             return future.result()
+#         finally:
+#             inner_new_loop.close()
+#             if old_loop is not None:
+#                 asyncio.set_event_loop(old_loop)
+
+#     return wrapper
+
+# NOT WORKING
+#
+# def sync_function(coroutine_func):
+#     from asgiref.sync import async_to_sync
+#     return async_to_sync(coroutine_func)

--- a/tests/test_servers/conftest.py
+++ b/tests/test_servers/conftest.py
@@ -93,7 +93,7 @@ def local_cluster():
 def local_client():
     from fastapi.testclient import TestClient
 
-    HTTPServer(from_test=True)
+    HTTPServer.initialize(from_test=True)
     client = TestClient(app)
 
     yield client
@@ -103,7 +103,7 @@ def local_client():
 def local_client_with_den_auth(logged_in_account):
     from fastapi.testclient import TestClient
 
-    HTTPServer(from_test=True)
+    HTTPServer.initialize(from_test=True)
     HTTPServer.enable_den_auth(flush=False)
     client = TestClient(app)
     with friend_account():

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -328,7 +328,7 @@ class TestObjStore:
         for key in obj_store_2_keys:
             assert obj_store.get(key)
 
-        obj_store._delete_env_contents(env_to_delete)
+        obj_store.delete_env_contents(env_to_delete)
 
         # check obj_store_2 servlet and nested keys are deleted but obj_store_1 unaffected
         assert env_to_delete not in obj_store.get_all_initialized_env_servlet_names()


### PR DESCRIPTION
`ClusterServlet`, `EnvServlet`, `ObjStore` and `HTTPServer` changed to be async.

Both actors now function as `AsyncActor`s with a single thread (https://docs.ray.io/en/latest/ray-core/actors/async_api.html)

Primarily for performance improvements:
PR below in stack (fn pointer cache):
```
 Running 15s test @ http://127.0.0.1:32300/get_pid_basic/call
  8 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    59.19ms   13.80ms 128.86ms   83.20%
    Req/Sec   135.47     25.44   210.00     74.96%
  Latency Distribution
     50%   55.58ms
     75%   61.70ms
     90%   73.78ms
     99%  108.33ms
  16259 requests in 15.08s, 3.07MB read
Requests/sec:   1078.42
Transfer/sec:    208.52KB
```
to NOW:
```
Running 15s test @ http://127.0.0.1:32300/get_pid_basic/call
  8 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    41.27ms    7.62ms 100.66ms   93.30%
    Req/Sec   194.68     30.16   242.00     73.75%
  Latency Distribution
     50%   39.64ms
     75%   41.50ms
     90%   44.19ms
     99%   80.14ms
  23322 requests in 15.04s, 4.40MB read
Requests/sec:   1550.46
Transfer/sec:    299.80KB
```

this changes all object store functions into `a{function}`. The synchronous entry points to this code are still set up with `sync_function` modifiers to call the `async` code that they run.

This was a challenging thing to build, you can see previous iterations in `runhouse.utils` in this PR. Turns out, Python `asyncio` _really_ doesn't like nested async event loops within a sync function. In other words, boundaries like
async context --> sync function --> async context are hard, since you can't have nested loops, and 

However, as library engineers we need this, as well as to slowly migrate off of sync code as we async our whole codebase (eventually). 

One solution that was tried was [here](https://stackoverflow.com/questions/52232177/runtimeerror-timeout-context-manager-should-be-used-inside-a-task/69514930#69514930) and is what is implemented - a background thread that holds the event loop and executes one "async context" at a time. Here's another [post](https://stackoverflow.com/questions/74703727/how-to-call-async-function-from-sync-funcion-and-get-result-while-a-loop-is-alr) that posits a similar solution. However, this solution ended up *not working* when we make *calls nested within the background thread to this same function*. 

I changed this to the `ThreadPoolExecutor()` method that is in the code now, and copy over `contextvars` to maintain auth between these threads. It's to be determined if other globals or other things cause problems, but all tests pass so, not too concerned?

Key useful posts in understanding this logic:
- https://stackoverflow.com/questions/46827007/runtimeerror-this-event-loop-is-already-running-in-python
- https://stackoverflow.com/questions/57238316/future-from-asyncio-run-coroutine-threadsafe-hangs-forever
- Some of the comments in here: https://stackoverflow.com/questions/65910442/how-to-use-asyncio-run-coroutine-threadsafe-correctly
- https://stackoverflow.com/questions/60113143/how-to-properly-use-asyncio-run-coroutine-threadsafe-function

Others:
- https://stackoverflow.com/questions/69161718/add-task-to-asyncio-loop-running-in-separate-thread
- To understand `run_coroutine_threadsafe`: https://superfastpython.com/asyncio-run_coroutine_threadsafe/
- https://stackoverflow.com/questions/62528272/what-does-asyncio-create-task-do

Attempted to use [`async_to_sync` by ASGIref](https://docs.djangoproject.com/en/5.0/topics/async/#async-to-sync), but it doesn't do exactly what's advertised and follows asyncio's fundamental restrictions

I'm going to leave the comments with old versions committed and remove them in a later PR, so we can have it somewhere in the commit history.