### PR TITLE
Cache `dir(Module)`.

### DIFF
--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -242,13 +242,14 @@ class Module(Resource):
             for (name, method) in inspect.getmembers(self.__class__)
             if not name[0] == "_"
             and name not in MODULE_ATTRS
-            and name not in dir(Module)
+            and name not in MODULE_METHODS
             and callable(method)
             # Checks if there's an arg called "local" in the method signature, and if so, if it's default is True.
             and not getattr(
                 inspect.signature(method).parameters.get("local"), "default", False
             )
         }
+
         return member_attrs
 
     def method_signature(self, method):
@@ -370,7 +371,7 @@ class Module(Resource):
             state = {
                 attr: val
                 for attr, val in self.__dict__.items()
-                if attr not in MODULE_ATTRS and attr not in dir(Module)
+                if attr not in MODULE_ATTRS and attr not in MODULE_METHODS
             }
         return state
 
@@ -488,7 +489,11 @@ class Module(Resource):
     def __getattribute__(self, item):
         """Override to allow for remote execution if system is a remote cluster. If not, the subclass's own
         __getattr__ will be called."""
-        if item in dir(Module) or item in MODULE_ATTRS or not hasattr(self, "_client"):
+        if (
+            item in MODULE_METHODS
+            or item in MODULE_ATTRS
+            or not hasattr(self, "_client")
+        ):
             return super().__getattribute__(item)
 
         try:
@@ -1285,3 +1290,6 @@ def module(
         pointers=cls_pointers,
         name=name,
     )
+
+
+MODULE_METHODS = dir(Module)


### PR DESCRIPTION
doesn't change at all, we can cache it. creds to @dongreenberg for idea for speed up
before:
```
Running 15s test @ http://127.0.0.1:32300/get_pid_basic/call
  8 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    81.37ms   38.06ms 322.34ms   83.72%
    Req/Sec   103.15     30.77   181.00     74.32%
  Latency Distribution
     50%   74.02ms
     75%   87.99ms
     90%  115.63ms
     99%  242.10ms
  12156 requests in 15.02s, 2.30MB read
Requests/sec:    809.28
Transfer/sec:    156.48KB
```

after:
```
Running 15s test @ http://127.0.0.1:32300/get_pid_basic/call
  8 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    55.76ms   22.54ms 226.28ms   89.68%
    Req/Sec   146.47     32.04   212.00     76.50%
  Latency Distribution
     50%   54.53ms
     75%   62.44ms
     90%   75.19ms
     99%  153.93ms
  17595 requests in 15.10s, 3.32MB read
Requests/sec:   1165.55
Transfer/sec:    225.37KB
```