### PR TITLE
Cache `get_obj_from_pointers` call for function.

### DIFF
--- a/runhouse/resources/functions/function.py
+++ b/runhouse/resources/functions/function.py
@@ -33,6 +33,7 @@ class Function(Module):
                 To create a Function, please use the factory method :func:`function`.
         """
         self.fn_pointers = fn_pointers
+        self._loaded_fn = None
         super().__init__(name=name, dryrun=dryrun, system=system, env=env, **kwargs)
 
     # ----------------- Constructor helper methods -----------------
@@ -111,8 +112,9 @@ class Function(Module):
 
     def call(self, *args, **kwargs) -> Any:
         # We need this strictly because Module's __getattribute__ overload can't pick up the __call__ method
-        fn = self._get_obj_from_pointers(*self.fn_pointers)
-        return fn(*args, **kwargs)
+        if not self._loaded_fn:
+            self._loaded_fn = self._get_obj_from_pointers(*self.fn_pointers)
+        return self._loaded_fn(*args, **kwargs)
 
     def method_signature(self, method):
         if callable(method) and method.__name__ == "call":


### PR DESCRIPTION
minor improvement.

before
```
Running 15s test @ http://127.0.0.1:32300/get_pid_basic/call
  8 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    83.08ms   39.42ms 324.69ms   85.55%
    Req/Sec   101.83     29.51   170.00     76.46%
  Latency Distribution
     50%   75.05ms
     75%   86.38ms
     90%  118.45ms
     99%  273.68ms
  11976 requests in 15.09s, 2.26MB read
Requests/sec:    793.70
Transfer/sec:    153.48KB
```

after:
```
Running 15s test @ http://127.0.0.1:32300/get_pid_basic/call
  8 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    78.04ms   31.41ms 445.33ms   80.36%
    Req/Sec   105.00     22.21   161.00     73.19%
  Latency Distribution
     50%   72.78ms
     75%   81.94ms
     90%  110.39ms
     99%  204.28ms
  12536 requests in 15.07s, 2.37MB read
Requests/sec:    831.68
Transfer/sec:    160.81KB
```

This also makes functions act more like modules and keeps the code in memory, so if the package was updated, but the function wasn't, it'll still reference the old function.