### PR TITLE
Add `ThreadPoolExecutor` to synchronous function calls server side.

### DIFF
--- a/runhouse/resources/future_module.py
+++ b/runhouse/resources/future_module.py
@@ -1,6 +1,7 @@
 from typing import AsyncIterable, Awaitable, Generator
 
 from runhouse.resources.module import Module
+from runhouse.servers.obj_store import RunhouseStopIteration
 
 
 class FutureModule(Module, Awaitable):
@@ -67,7 +68,10 @@ class GeneratorModule(Module, Generator):
         return self
 
     def remote_next(self):
-        return self._future.__next__()
+        try:
+            return self._future.__next__()
+        except StopIteration:
+            raise RunhouseStopIteration()
 
     def __next__(self):
         return self.remote_next(run_name=self.name)


### PR DESCRIPTION
We want to make sure that heavily synchronous things still run in their own thread since, now that we are using an `AsyncActor`, there is only one thread in the Ray actor.

Useful code dealing with thread pools here:
- https://stackoverflow.com/questions/54758930/python-3-how-to-submit-an-async-function-to-a-threadpool
- https://docs.python.org/3/library/asyncio-eventloop.html#executing-code-in-thread-or-process-pools

If I wanted to run the coroutine in the thread: https://stackoverflow.com/questions/46074841/why-coroutines-cannot-be-used-with-run-in-executor instead of the sync function. Done in this PR: https://github.com/run-house/runhouse/pull/660/files

When to use `run_in_executor`: https://stackoverflow.com/questions/55027940/is-run-in-executor-optimized-for-running-in-a-loop-with-coroutines