### PR TITLE
Cluster default env

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -299,12 +299,9 @@ def _start_server(
     domain=None,
     certs_address=None,
     use_local_telemetry=False,
-<<<<<<< HEAD
     api_server_url=None,
-=======
     default_env=None,
     conda_env=None,
->>>>>>> adaa6415 (add default env)
 ):
     ############################################
     # Build CLI commands to start the server

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 import webbrowser
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import ray
 
@@ -147,6 +147,9 @@ def _print_status(config):
         console.print(config["name"])
 
     first_info_to_print = ["den_auth", "server_connection_type", "server_port"]
+
+    if config.get("default_env") and isinstance(config["default_env"], Dict):
+        config["default_env"] = config["default_env"]["name"]
 
     for info in config:
         if info in first_info_to_print:
@@ -296,7 +299,12 @@ def _start_server(
     domain=None,
     certs_address=None,
     use_local_telemetry=False,
+<<<<<<< HEAD
     api_server_url=None,
+=======
+    default_env=None,
+    conda_env=None,
+>>>>>>> adaa6415 (add default env)
 ):
     ############################################
     # Build CLI commands to start the server
@@ -376,6 +384,16 @@ def _start_server(
     if api_server_url_flag:
         logger.info(f"Setting api_server url to {api_server_url}")
         flags.append(api_server_url_flag)
+
+    default_env_flag = f" --default-env {default_env}" if default_env else ""
+    if default_env_flag:
+        logger.info(f"Starting server on default env: {default_env}")
+        flags.append(default_env_flag)
+
+    conda_env_flag = f" --conda-env {conda_env}" if conda_env else ""
+    if default_env_flag:
+        logger.info(f"Creating runtime env for conda env: {conda_env}")
+        flags.append(conda_env_flag)
 
     # Check if screen or nohup are available
     screen = screen and _check_if_command_exists("screen")
@@ -471,6 +489,10 @@ def start(
     use_local_telemetry: bool = typer.Option(
         False, help="Whether to use local telemetry"
     ),
+    default_env: str = typer.Option(None, help="Default env to start the server on."),
+    conda_env: str = typer.Option(
+        None, help="Name of conda env corresponding to default env if it is a CondaEnv."
+    ),
 ):
     """Start the HTTP or HTTPS server on the cluster."""
     _start_server(
@@ -487,6 +509,8 @@ def start(
         domain=domain,
         certs_address=certs_address,
         use_local_telemetry=use_local_telemetry,
+        default_env=default_env,
+        conda_env=conda_env,
     )
 
 
@@ -547,6 +571,10 @@ def restart(
         default="https://api.run.house",
         help="URL of Runhouse Den",
     ),
+    default_env: str = typer.Option(None, help="Default env to start the server on."),
+    conda_env: str = typer.Option(
+        None, help="Name of conda env corresponding to default env if it is a CondaEnv."
+    ),
 ):
     """Restart the HTTP server on the cluster."""
     if name:
@@ -572,6 +600,8 @@ def restart(
         certs_address=certs_address,
         use_local_telemetry=use_local_telemetry,
         api_server_url=api_server_url,
+        default_env=default_env,
+        conda_env=conda_env,
     )
 
 

--- a/runhouse/resources/envs/conda_env.py
+++ b/runhouse/resources/envs/conda_env.py
@@ -110,9 +110,12 @@ class CondaEnv(Env):
                 on the cluster using SSH. (default: ``None``)
         """
         if not any(["python" in dep for dep in self.conda_yaml["dependencies"]]):
-            base_python_version = run_setup_command(
+            status_codes = run_setup_command(
                 "python --version", cluster=cluster, stream_logs=False
-            )[1].split()[1]
+            )
+            base_python_version = (
+                status_codes[1].split()[1] if status_codes[0] == 0 else "3.10.9"
+            )
             self.conda_yaml["dependencies"].append(f"python=={base_python_version}")
         install_conda(cluster=cluster)
         local_env_exists = (

--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -5,14 +5,15 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 from runhouse.globals import obj_store
-
-from runhouse.resources.envs.utils import run_setup_command, run_with_logs
+from runhouse.resources.envs.utils import (
+    _process_env_vars,
+    run_setup_command,
+    run_with_logs,
+)
 from runhouse.resources.folders import Folder
 from runhouse.resources.hardware import _get_cluster_from, Cluster
 from runhouse.resources.packages import Package
 from runhouse.resources.resource import Resource
-
-from .utils import _env_vars_from_file
 
 
 logger = logging.getLogger(__name__)
@@ -208,11 +209,7 @@ class Env(Resource):
             if new_env.name == Env.DEFAULT_NAME:
                 new_env.name = system.default_env.name
             key = system.put_resource(new_env)
-            env_vars = (
-                _env_vars_from_file(self.env_vars)
-                if isinstance(self.env_vars, str)
-                else self.env_vars
-            )
+            env_vars = _process_env_vars(self.env_vars)
             if env_vars:
                 system.call(key, "_set_env_vars", env_vars)
             system.call(key, "install", force=force_install)

--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -205,6 +205,8 @@ class Env(Resource):
         new_env.secrets = self._secrets_to(system)
 
         if isinstance(system, Cluster):
+            if new_env.name == Env.DEFAULT_NAME:
+                new_env.name = system.default_env.name
             key = system.put_resource(new_env)
             env_vars = (
                 _env_vars_from_file(self.env_vars)

--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -37,6 +37,13 @@ def _process_reqs(reqs):
     return preprocessed_reqs
 
 
+def _process_env_vars(env_vars):
+    processed_vars = (
+        _env_vars_from_file(env_vars) if isinstance(env_vars, str) else env_vars
+    )
+    return processed_vars
+
+
 def _get_env_from(env):
     if isinstance(env, Resource):
         return env

--- a/runhouse/resources/functions/aws_lambda.py
+++ b/runhouse/resources/functions/aws_lambda.py
@@ -169,11 +169,11 @@ class LambdaFunction(Function):
         return LambdaFunction(**config, dryrun=dryrun).deploy()
 
     @classmethod
-    def from_name(cls, name, dryrun=False, alt_options=None):
+    def from_name(cls, name, dryrun=False, alt_options=None, _resolve_children=True):
         config = rns_client.load_config(name=name)
         if not config:
             raise ValueError(f"Could not find a Lambda called {name}.")
-        return cls.from_config(config)
+        return cls.from_config(config, _resolve_children=_resolve_children)
 
     @classmethod
     def from_handler_file(

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -118,9 +118,13 @@ class Cluster(Resource):
 
     @property
     def default_env(self):
-        from runhouse.resources.envs import env
+        from runhouse.resources.envs import Env
 
-        return self._default_env if self._default_env else env()
+        return (
+            self._default_env
+            if self._default_env
+            else Env(Env.DEFAULT_NAME, working_dir="./")
+        )
 
     @default_env.setter
     def default_env(self, env):
@@ -830,7 +834,12 @@ class Cluster(Resource):
             self._start_ray_workers(DEFAULT_RAY_PORT, env=self.default_env)
 
         if default_env:
+            from runhouse.resources.envs.utils import _process_env_vars
+
             self.put_resource(default_env)
+            env_vars = _process_env_vars(default_env.env_vars)
+            if env_vars:
+                self.call(default_env.name, "_set_env_vars", env_vars)
 
         return status_codes
 

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -55,6 +55,7 @@ class Cluster(Resource):
         name: Optional[str] = None,
         ips: List[str] = None,
         creds: "Secret" = None,
+        default_env: "Env" = None,
         server_host: str = None,
         server_port: int = None,
         ssh_port: int = None,
@@ -97,6 +98,8 @@ class Cluster(Resource):
         self.domain = domain
         self.use_local_telemetry = use_local_telemetry
 
+        self._default_env = _get_env_from(default_env)
+
     @property
     def address(self):
         return self.ips[0] if isinstance(self.ips, List) else None
@@ -112,6 +115,22 @@ class Cluster(Resource):
             return {}
 
         return self._creds.values
+
+    @property
+    def default_env(self):
+        from runhouse.resources.envs import env
+
+        return self._default_env if self._default_env else env()
+
+    @default_env.setter
+    def default_env(self, env):
+        self._default_env = _get_env_from(env)
+        if self.is_up():
+            self.check_server()
+            if not self.get(self._default_env.name):
+                self._sync_default_env_to_cluster()
+            self.put_resource(self._default_env)
+            self.save_config_to_cluster()
 
     def save_config_to_cluster(self, node: str = None):
 
@@ -153,10 +172,14 @@ class Cluster(Resource):
         return self
 
     def _save_sub_resources(self, folder: str = None):
+        from runhouse.resources.envs import Env
         from runhouse.resources.secrets import Secret
 
         if self._creds and isinstance(self._creds, Secret):
             self._creds.save(folder=folder)
+
+        if self._default_env and isinstance(self._default_env, Env):
+            self._default_env.save()
 
     @classmethod
     def from_config(cls, config: dict, dryrun=False, _resolve_children=True):
@@ -203,6 +226,12 @@ class Cluster(Resource):
 
         config["creds"] = creds
         config["api_server_url"] = rns_client.api_server_url
+
+        if self._default_env:
+            default_env = self._resource_string_for_subconfig(
+                self._default_env, condensed
+            )
+            config["default_env"] = default_env
 
         if self._use_custom_certs:
             config["ssl_certfile"] = self.cert_config.cert_path
@@ -315,12 +344,21 @@ class Cluster(Resource):
         )
         return self
 
+    def _sync_default_env_to_cluster(self):
+        if not self._default_env:
+            return
+
+        logging.info(f"Syncing default env {self._default_env.name} to cluster")
+        self._default_env.install(cluster=self)
+
     def _sync_runhouse_to_cluster(self, _install_url=None, env=None):
         if self.on_this_cluster():
             return
 
         if not self.address:
             raise ValueError(f"No address set for cluster <{self.name}>. Is it up?")
+
+        env = env or self.default_env
 
         local_rh_package_path = Path(importlib.util.find_spec("runhouse").origin).parent
 
@@ -357,7 +395,10 @@ class Cluster(Resource):
 
         for node in self.ips:
             status_codes = self.run(
-                [rh_install_cmd], node=node, env=env, stream_logs=True
+                [rh_install_cmd],
+                node=node,
+                env=env,
+                stream_logs=True,
             )
 
             if status_codes[0][0] != 0:
@@ -382,7 +423,9 @@ class Cluster(Resource):
         from runhouse.resources.envs.env import Env
 
         self.check_server()
-        env = _get_env_from(env) or Env(name=env or Env.DEFAULT_NAME)
+        env = _get_env_from(env or self._default_env) or Env(
+            name=env or Env.DEFAULT_NAME
+        )
         env.reqs = env._reqs + reqs
         env.to(self)
 
@@ -416,14 +459,14 @@ class Cluster(Resource):
     ):
         """Copy secrets from current environment onto the cluster"""
         self.check_server()
-        self.sync_secrets(provider_secrets, env=env)
+        self.sync_secrets(provider_secrets, env=env or self.default_env)
 
     def put(self, key: str, obj: Any, env=None):
         """Put the given object on the cluster's object store at the given key."""
         self.check_server()
         if self.on_this_cluster():
             return obj_store.put(key, obj, env=env)
-        return self.client.put_object(key, obj, env=env)
+        return self.client.put_object(key, obj, env=env or self.default_env.name)
 
     def put_resource(
         self, resource: Resource, state: Dict = None, dryrun: bool = False, env=None
@@ -437,7 +480,7 @@ class Cluster(Resource):
             if hasattr(resource, "env")
             else resource.name or resource.env_name
             if resource.RESOURCE_TYPE == "env"
-            else None
+            else self._default_env
         )
 
         if env and not isinstance(env, str):
@@ -659,7 +702,7 @@ class Cluster(Resource):
         and a domain is provided."""
         return self._use_https and not (self._use_caddy and self.domain is not None)
 
-    def _start_ray_workers(self, ray_port):
+    def _start_ray_workers(self, ray_port, env):
         for host in self.ips:
             if host == self.address:
                 # This is the master node, skip
@@ -672,6 +715,7 @@ class Cluster(Resource):
                     f"ray start --address={self.address}:{ray_port} --disable-usage-stats",
                 ],
                 node=host,
+                env=env,
             )
 
     def restart_server(
@@ -679,7 +723,6 @@ class Cluster(Resource):
         _rh_install_url: str = None,
         resync_rh: bool = True,
         restart_ray: bool = False,
-        env: Union[str, "Env"] = None,
         restart_proxy: bool = False,
     ):
         """Restart the RPC server.
@@ -695,8 +738,14 @@ class Cluster(Resource):
         """
         logger.info(f"Restarting Runhouse API server on {self.name}.")
 
+        default_env = _get_env_from(self._default_env) if self._default_env else None
+        if default_env:
+            self._sync_default_env_to_cluster()
+
         if resync_rh:
-            self._sync_runhouse_to_cluster(_install_url=_rh_install_url)
+            self._sync_runhouse_to_cluster(
+                _install_url=_rh_install_url, env=default_env
+            )
             logger.debug("Finished syncing Runhouse to cluster.")
 
         https_flag = self._use_https
@@ -751,9 +800,17 @@ class Cluster(Resource):
             + (" --use-local-telemetry" if use_local_telemetry else "")
             + f" --port {self.server_port}"
             + f" --api-server-url {rns_client.api_server_url}"
+            + (f" --default-env {self.default_env.name}" if self.default_env else "")
+            + (
+                f" --conda-env {self.default_env.env_name}"
+                if self.default_env.config().get("resource_subtype", None) == "CondaEnv"
+                else ""
+            )
         )
 
-        status_codes = self.run(commands=[cmd], env=env)
+        status_codes = self.run(
+            commands=[cmd], env=self._default_env, node=self.address
+        )
         if not status_codes[0][0] == 0:
             raise ValueError(f"Failed to restart server {self.name}")
 
@@ -770,7 +827,10 @@ class Cluster(Resource):
             self.client.use_https = https_flag
 
         if restart_ray and len(self.ips) > 1:
-            self._start_ray_workers(DEFAULT_RAY_PORT)
+            self._start_ray_workers(DEFAULT_RAY_PORT, env=self.default_env)
+
+        if default_env:
+            self.put_resource(default_env)
 
         return status_codes
 
@@ -783,7 +843,7 @@ class Cluster(Resource):
         """
         cmd = CLI_STOP_CMD if stop_ray else f"{CLI_STOP_CMD} --no-stop-ray"
 
-        status_codes = self.run([cmd], env=env, stream_logs=False)
+        status_codes = self.run([cmd], env=env or self._default_env, stream_logs=False)
         assert status_codes[0][0] == 1
 
     @contextlib.contextmanager
@@ -1090,6 +1150,11 @@ class Cluster(Resource):
             >>> cpu.run(["python script.py"], run_name="my_exp")
             >>> cpu.run(["python script.py"], node="3.89.174.234")
         """
+        if isinstance(commands, str):
+            commands = [commands]
+
+        env = env or self._default_env
+
         if node == "all":
             res_list = []
             for node in self.ips:
@@ -1116,7 +1181,7 @@ class Cluster(Resource):
                 if isinstance(env, str)
                 else env.name
                 if isinstance(env, Env)
-                else "base_env"
+                else None
             )
             return_codes = []
             for command in commands:
@@ -1282,7 +1347,6 @@ class Cluster(Resource):
             Running Python commands with nested quotes can be finicky. If using nested quotes,
             try to wrap the outer quote with double quotes (") and the inner quotes with a single quote (').
         """
-        # If no node provided, assume the commands are to be run on the head node
         cmd_prefix = "python3 -c"
         command_str = "; ".join(commands)
         command_str_repr = (
@@ -1295,7 +1359,7 @@ class Cluster(Resource):
         # If invoking a run as part of the python commands also return the Run object
         return_codes = self.run(
             [formatted_command],
-            env=env,
+            env=env or self._default_env,
             stream_logs=stream_logs,
             node=node,
             port_forward=port_forward,
@@ -1321,6 +1385,7 @@ class Cluster(Resource):
         self.check_server()
         from runhouse.resources.secrets import Secret
 
+        env = env or self._default_env
         if isinstance(env, str):
             from runhouse.resources.envs import Env
 
@@ -1494,6 +1559,7 @@ class Cluster(Resource):
     @classmethod
     def _check_for_child_configs(cls, config: dict):
         """Overload by child resources to load any resources they hold internally."""
+        from runhouse.resources.envs.env import Env
         from runhouse.resources.secrets.secret import Secret
         from runhouse.resources.secrets.utils import load_config, setup_cluster_creds
 
@@ -1507,4 +1573,13 @@ class Cluster(Resource):
             else:
                 creds = setup_cluster_creds(creds, config["name"])
         config["creds"] = creds
+
+        default_env = config.pop("default_env", None)
+        if isinstance(default_env, str):
+            default_env = Env.from_name(default_env, _resolve_children=False)
+        elif isinstance(default_env, dict):
+            default_env = Env.from_config(default_env)
+        if default_env:
+            config["default_env"] = default_env
+
         return config

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -28,6 +28,7 @@ def cluster(
     ssl_certfile: str = None,
     domain: str = None,
     den_auth: bool = False,
+    default_env: Union["Env", str] = None,
     dryrun: bool = False,
     **kwargs,
 ) -> Union[Cluster, OnDemandCluster, SageMakerCluster]:
@@ -55,6 +56,7 @@ def cluster(
         den_auth (bool, optional): Whether to use Den authorization on the server. If ``True``, will validate incoming
             requests with a Runhouse token provided in the auth headers of the request with the format:
             ``{"Authorization": "Bearer <token>"}``. (Default: ``False``).
+        # TODO [CC]: Add default_env docstrings
         dryrun (bool): Whether to create the Cluster if it doesn't exist, or load a Cluster object as a dryrun.
             (Default: ``False``)
 
@@ -95,6 +97,7 @@ def cluster(
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,
             domain=domain,
+            default_env=default_env,
             kwargs=kwargs if len(kwargs) > 0 else None,
         )
         # Filter out None/default values
@@ -125,6 +128,7 @@ def cluster(
             ssl_certfile=ssl_certfile,
             domain=domain,
             den_auth=den_auth,
+            default_env=default_env,
             dryrun=dryrun,
             **kwargs,
         )
@@ -153,6 +157,7 @@ def cluster(
             ssl_certfile=ssl_certfile,
             domain=domain,
             den_auth=den_auth,
+            default_env=default_env,
             dryrun=dryrun,
             **kwargs,
         )
@@ -176,6 +181,7 @@ def cluster(
         ssl_certfile=ssl_certfile,
         domain=domain,
         den_auth=den_auth,
+        default_env=default_env,
         dryrun=dryrun,
         **kwargs,
     )
@@ -307,7 +313,8 @@ def ondemand_cluster(
     ssl_keyfile: str = None,
     ssl_certfile: str = None,
     domain: str = None,
-    den_auth: bool = None,
+    den_auth: bool = False,
+    default_env: Union["Env", str] = None,
     dryrun: bool = False,
     **kwargs,
 ) -> OnDemandCluster:
@@ -379,6 +386,7 @@ def ondemand_cluster(
         kube_config_path = kwargs.pop("kube_config_path", None)
         context = kwargs.pop("context", None)
         server_connection_type = kwargs.pop("server_connection_type", None)
+        default_env = kwargs.pop("default_env", None)
 
         return kubernetes_cluster(
             name=name,
@@ -387,6 +395,7 @@ def ondemand_cluster(
             kube_config_path=kube_config_path,
             context=context,
             server_connection_type=server_connection_type,
+            default_env=default_env,
         )
 
     if name:
@@ -406,6 +415,7 @@ def ondemand_cluster(
             ssl_certfile=ssl_certfile,
             domain=domain,
             den_auth=den_auth,
+            default_env=default_env,
         )
         # Filter out None/default values
         alt_options = {k: v for k, v in alt_options.items() if v is not None}
@@ -435,6 +445,7 @@ def ondemand_cluster(
         ssl_certfile=ssl_certfile,
         domain=domain,
         den_auth=den_auth,
+        default_env=default_env,
         name=name,
         dryrun=dryrun,
         **kwargs,
@@ -467,6 +478,7 @@ def sagemaker_cluster(
     ssl_certfile: str = None,
     domain: str = None,
     den_auth: bool = False,
+    default_env: Union["Env", str] = None,
     dryrun: bool = False,
     **kwargs,
 ) -> SageMakerCluster:
@@ -595,6 +607,7 @@ def sagemaker_cluster(
             ssl_certfile=ssl_certfile,
             domain=domain,
             den_auth=den_auth,
+            default_env=default_env,
         )
         # Filter out None/default values
         alt_options = {k: v for k, v in alt_options.items() if v is not None}
@@ -632,6 +645,7 @@ def sagemaker_cluster(
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         domain=domain,
+        default_env=default_env,
         dryrun=dryrun,
         **kwargs,
     )

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -41,6 +41,7 @@ class OnDemandCluster(Cluster):
         instance_type: str = None,
         num_instances: int = None,
         provider: str = None,
+        default_env: "Env" = None,
         dryrun=False,
         autostop_mins=None,
         use_spot=False,
@@ -66,6 +67,7 @@ class OnDemandCluster(Cluster):
         """
         super().__init__(
             name=name,
+            default_env=default_env,
             server_host=server_host,
             server_port=server_port,
             server_connection_type=server_connection_type,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -76,7 +76,7 @@ class Module(Resource):
                 self._env = (
                     self._system.default_env
                     if self._system
-                    else Env(name=Env.DEFAULT_NAME)
+                    else Env(name=Env.DEFAULT_NAME, working_dir="./")
                 )
             # If we're creating pointers, we're also local to the class definition and package, so it should be
             # set as the workdir (we can do this in a fancier way later)
@@ -428,7 +428,11 @@ class Module(Resource):
             _get_cluster_from(system, dryrun=self.dryrun) if system else self.system
         )
         if not env:
-            if not self.env or (self.env and self.env.name == Env.DEFAULT_NAME):
+            if not self.env or (
+                self.env
+                and self.env.config()
+                == Env(name=Env.DEFAULT_NAME, working_dir="./").config()
+            ):
                 env = system.default_env if system else self.env
             else:
                 env = self.env

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -72,7 +72,12 @@ class Module(Resource):
             # of rh.Module, and we need to do the factory constructor logic here.
 
             # When creating a module as a subclass of rh.Module, we need to collect pointers here
-            self._env = self._env or Env(name=Env.DEFAULT_NAME)
+            if not self._env:
+                self._env = (
+                    self._system.default_env
+                    if self._system
+                    else Env(name=Env.DEFAULT_NAME)
+                )
             # If we're creating pointers, we're also local to the class definition and package, so it should be
             # set as the workdir (we can do this in a fancier way later)
             self._env.working_dir = self._env.working_dir or "./"
@@ -152,8 +157,8 @@ class Module(Resource):
                         if isinstance(env, str)
                         else env["name"]
                         if isinstance(env, Dict)
-                        else "base_env"
-                        if env is not None
+                        else system.default_env.name
+                        if system.default_env
                         else None
                     )
                     if (system and _current_cluster == _get_cluster_from(system)) and (
@@ -422,7 +427,12 @@ class Module(Resource):
         system = (
             _get_cluster_from(system, dryrun=self.dryrun) if system else self.system
         )
-        env = env or self.env
+        if not env:
+            if not self.env or (self.env and self.env.name == Env.DEFAULT_NAME):
+                env = system.default_env if system else self.env
+            else:
+                env = self.env
+
         env = _get_env_from(env)
 
         if system:

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -187,7 +187,16 @@ class ProviderSecret(Secret):
             )
 
         if env or self.env_vars:
-            env_key = env.name if isinstance(env, Env) else (env or "base_env")
+            env = (
+                system.default_env
+                if (
+                    not env
+                    or env.config()
+                    == Env(name=Env.DEFAULT_NAME, working_dir="./").config()
+                )
+                else env
+            )
+            env_key = env if isinstance(env, str) else env.name
             if not system.get(env_key):
                 env = env if isinstance(env, Env) else Env(name=env_key)
                 env_key = system.put_resource(env)

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import List
+from typing import Dict, List
 
 from runhouse.globals import configs, obj_store, rns_client
 
@@ -65,16 +65,29 @@ def load(name: str, instantiate: bool = True, dryrun: bool = False):
 
 
 async def get_local_cluster_object():
+    from runhouse.resources.envs import Env
+
     # By default, obj_store.initialize does not initialize Ray, and instead
     # attempts to connect to an existing cluster.
+    from runhouse.resources.hardware.utils import load_cluster_config_from_file
 
     # In case we are calling `rh.here` within the same Python process
     # as an initialized object store, keep the same name.
     # If it was not set, let's proxy requests to `base` since we're likely on the cluster
     # and want to easily read and write from the object store that the Server is using.
     try:
+        servlet_name = obj_store.servlet_name
+        if not servlet_name:
+            default_env = load_cluster_config_from_file().get("default_env", None)
+            if isinstance(default_env, str):
+                servlet_name = default_env
+            elif isinstance(default_env, Dict):
+                servlet_name = default_env.get("name", Env.DEFAULT_NAME)
+            else:
+                servlet_name = Env.DEFAULT_NAME
+
         await obj_store.ainitialize(
-            servlet_name=obj_store.servlet_name or "base",
+            servlet_name=servlet_name,
             setup_cluster_servlet=ClusterServletSetupOption.GET_OR_FAIL,
         )
     except ConnectionError:

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -119,7 +119,7 @@ class HTTPServer:
         *args,
         **kwargs,
     ):
-        runtime_env = {"conda": conda_env} if conda_env else {}
+        runtime_env = {"conda": conda_env} if conda_env else None
 
         # If enable_local_span_collection flag is passed, setup the span exporter and related functionality
         if enable_local_span_collection:
@@ -185,7 +185,9 @@ class HTTPServer:
 
         if from_test:
             await obj_store.ainitialize(
-                default_env, setup_ray=RaySetupOption.TEST_PROCESS
+                default_env,
+                setup_ray=RaySetupOption.TEST_PROCESS,
+                runtime_env=runtime_env,
             )
 
         # TODO disabling due to latency, figure out what to do with this

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -112,6 +112,7 @@ class HTTPServer:
     @classmethod
     async def ainitialize(
         cls,
+        default_env=None,
         conda_env=None,
         enable_local_span_collection=None,
         from_test: bool = False,
@@ -177,8 +178,15 @@ class HTTPServer:
         # initialized by the start script (see below)
         # But if the HTTPServer was started standalone in a test,
         # We still want to make sure the cluster servlet is initialized
+        if not default_env:
+            from runhouse.resources.envs import Env
+
+            default_env = Env.DEFAULT_NAME
+
         if from_test:
-            await obj_store.ainitialize("base", setup_ray=RaySetupOption.TEST_PROCESS)
+            await obj_store.ainitialize(
+                default_env, setup_ray=RaySetupOption.TEST_PROCESS
+            )
 
         # TODO disabling due to latency, figure out what to do with this
         # try:
@@ -194,12 +202,9 @@ class HTTPServer:
             except Exception as e:
                 logger.error(f"Failed to collect cluster telemetry stats: {str(e)}")
 
-        # We initialize a base env servlet where some things may run.
-        # TODO: We aren't sure _exactly_ where this is or isn't used.
-        # There are a few spots where we do `env_name or "base"`, and
-        # this allows that base env to be pre-initialized.
+        # We initialize a default env servlet where some things may run.
         _ = obj_store.get_env_servlet(
-            env_name="base",
+            env_name=default_env,
             create=True,
             runtime_env=runtime_env,
         )
@@ -207,6 +212,7 @@ class HTTPServer:
     @classmethod
     def initialize(
         cls,
+        default_env=None,
         conda_env=None,
         enable_local_span_collection=None,
         from_test: bool = False,
@@ -214,7 +220,12 @@ class HTTPServer:
         **kwargs,
     ):
         return sync_function(cls.ainitialize)(
-            conda_env, enable_local_span_collection, from_test, *args, **kwargs
+            default_env,
+            conda_env,
+            enable_local_span_collection,
+            from_test,
+            *args,
+            **kwargs,
         )
 
     @classmethod
@@ -575,7 +586,7 @@ class HTTPServer:
     @validate_cluster_access
     async def put_resource(request: Request, params: PutResourceParams):
         try:
-            env_name = params.env_name or "base"
+            env_name = params.env_name
             return await obj_store.aput_resource(
                 serialized_data=params.serialized_data,
                 serialization=params.serialization,
@@ -903,6 +914,12 @@ async def main():
         default=None,
         help="Address to use for generating self-signed certs and enabling HTTPS. (e.g. public IP address)",
     )
+    parser.add_argument(
+        "--default-env",
+        type=str,
+        default="base",
+        help="Name of env where the HTTP server is started.",
+    )
 
     parser.add_argument(
         "--api-server-url",
@@ -916,6 +933,7 @@ async def main():
     conda_name = parse_args.conda_env
     restart_proxy = parse_args.restart_proxy
     api_server_url = parse_args.api_server_url
+    default_env = parse_args.default_env
 
     # The object store and the cluster servlet within it need to be
     # initialized in order to call `obj_store.get_cluster_config()`, which
@@ -925,7 +943,7 @@ async def main():
     # We connect this to the "base" env, which we'll initialize later,
     # so writes to the obj_store within the server get proxied to the "base" env.
     await obj_store.ainitialize(
-        "base",
+        default_env,
         setup_cluster_servlet=ClusterServletSetupOption.FORCE_CREATE,
     )
 
@@ -1107,6 +1125,7 @@ async def main():
     logger.info("Updated cluster config with parsed argument values.")
 
     await HTTPServer.ainitialize(
+        default_env=default_env,
         conda_env=conda_name,
         enable_local_span_collection=use_local_telemetry
         or configs.data_collection_enabled(),

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -195,6 +195,8 @@ class ObjStore:
                 "Warning, cluster servlet is not initialized. Object Store operations will not work."
             )
 
+        # TODO -- set the servlet name here to be the default env on the cluster
+
         # There are 3 operating modes of the KV store:
         # servlet_name is set, has_local_storage is True: This is an EnvServlet with a local KV store.
         # servlet_name is set, has_local_storage is False: This is an ObjStore class that is not an EnvServlet,


### PR DESCRIPTION
default env flow
* passed in at cluster initialization
* default env installations is set up on cluster using pure ssh commands
* run the http server start inside the env, passing in default_env which is propagated to the cluster env set up
* put the default env resource on the cluster, and set the env vars after

behavior
* cluster.run, cluster.put, etc runs inside cluster.default_env if not explicitly specified
* if no default env is provided, defaults to base_env

TODOs (can be in follow up?)
* env vars support -- currently set w/ after runhouse start on the default env. can be instead appended to runhouse start command and as a result flow into all subprocesses (flow to add to start cmd kinda annoying tho)