### PR TITLE
Use sky config for more accurate autostop

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -39,18 +39,22 @@ class ClusterServlet:
     # Cluster autostop
     ##############################################
     def update_autostop(self):
+        import pickle
+
         from sky.skylet import configs as sky_configs
 
         while True:
-            autostop = int(self.cluster_config.get("autostop_mins", -1))
+            autostop_mins = pickle.loads(
+                sky_configs.get_config("autostop_config")
+            ).autostop_idle_minute
             self._last_register = float(
                 sky_configs.get_config("autostop_last_active_time")
             )
-            if autostop > 0 and (
+            if autostop_mins > 0 and (
                 not self._last_register
                 or (
                     # within 2 min of autostop and there's more recent activity
-                    60 * autostop - (time.time() - self._last_register) < 120
+                    60 * autostop_mins - (time.time() - self._last_register) < 120
                     and self._last_activity > self._last_register
                 )
             ):


### PR DESCRIPTION
to be reflective of if a user uses sky cli command to set autostop instead of cluster.keep_warm/autostop_mins
