### PR TITLE
Change `AuthCache` logic to request per user+resource keypair.

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -83,9 +83,6 @@ class ClusterServlet:
     ##############################################
     # Auth cache internal functions
     ##############################################
-    async def aadd_user_to_auth_cache(self, token: str, refresh_cache: bool = True):
-        self._auth_cache.add_user(token, refresh_cache)
-
     async def aresource_access_level(
         self, token: str, resource_uri: str
     ) -> Union[str, None]:
@@ -97,9 +94,6 @@ class ClusterServlet:
         ):
             return ResourceAccess.WRITE
         return self._auth_cache.lookup_access_level(token, resource_uri)
-
-    async def auser_resources(self, token: str) -> dict:
-        return self._auth_cache.get_user_resources(token)
 
     async def aget_username(self, token: str) -> str:
         return self._auth_cache.get_username(token)

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -73,9 +73,6 @@ def validate_cluster_access(func):
         ctx_token = obj_store.set_ctx(request_id=request_id, token=token)
 
         try:
-            if func_call and token:
-                await obj_store.aadd_user_to_auth_cache(token, refresh_cache=False)
-
             if den_auth_enabled and not func_call:
                 if token is None:
                     raise HTTPException(

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -355,20 +355,10 @@ class TestAuthCacheObjStore:
             token = test_account_dict["token"]
 
             # Add test account resources to the local cache
-            obj_store.add_user_to_auth_cache(token)
-            resources = obj_store.user_resources(token)
-            assert resources
-
             resource_uri = f"/{test_account_dict['username']}/summer"
             access_level = obj_store.resource_access_level(token, resource_uri)
 
             assert access_level == "write"
-
-    @pytest.mark.level("unit")
-    def test_no_resources_for_invalid_token(self, obj_store):
-        token = "abc"
-        resources = obj_store.user_resources(token)
-        assert not resources
 
     @pytest.mark.level("unit")
     def test_no_resource_access_for_invalid_token(self, obj_store):


### PR DESCRIPTION
Killed off all logic where we add a user to the auth cache. Instead, we should function like a true cache and just abstract away the reading with a cache.

Now don't cache all resources, make a new request to Den for every resource + user pairing. Simplified auth calls all around