### PR TITLE
Tiny performance improvments

### DIFF
--- a/runhouse/constants.py
+++ b/runhouse/constants.py
@@ -26,7 +26,7 @@ DEFAULT_RAY_PORT = 6379
 
 DEFAULT_SERVER_HOST = "0.0.0.0"
 
-LOGGING_WAIT_TIME = 1
+LOGGING_WAIT_TIME = 0.5
 
 # Commands
 SERVER_START_CMD = f"{sys.executable} -m runhouse.servers.http.http_server"

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -471,7 +471,6 @@ class HTTPServer:
             }
             params.data = serialize_data(data, serialization)
 
-            logger.info(f"GET call with params: {dict(params)}")
             return await HTTPServer._call(key, method_name, params)
         except Exception as e:
             logger.exception(e)

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -70,7 +70,7 @@ def get_cluster_servlet(create_if_not_exists: bool = False):
                 get_if_exists=True,
                 lifetime="detached",
                 namespace="runhouse",
-                max_concurrency=1000,
+                max_concurrency=10000,
                 resources={f"node:{current_ip}": 0.001},
             )
             .remote()
@@ -316,7 +316,7 @@ class ObjStore:
                     resources=resources,
                     lifetime="detached",
                     namespace="runhouse",
-                    max_concurrency=1000,
+                    max_concurrency=10000,
                 )
                 .remote(env_name=env_name)
             )


### PR DESCRIPTION
### TL;DR

This PR decreases the `LOGGING_WAIT_TIME` to .5 from 1 and increases `max_concurrency` from 1000 to 10,000 in both `get_cluster_servlet` and `get_env_servlet` functions at `obj_store.py`.

### What changed?

- The `LOGGING_WAIT_TIME` constant in the `constants.py` file has been decreased to .5 from 1.
- The `max_concurrency` parameter in both `get_cluster_servlet` and `get_env_servlet` functions in the `obj_store.py` file has been increased from 1000 to 10,000.
- The logging of GET call parameters in the `get_call` function in `http_server.py` file has been removed.

### Why make this change?

This change is made to increase the server's concurrent handling capacity and to make the logging output more efficient by reducing the wait time. It also removes redundant logging.

---

