### PR TITLE
Remove `run_async` argument completely.

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -818,14 +818,14 @@ class Cluster(Resource):
         self.check_server()
         # Note: might be single value, might be a generator!
         if self.on_this_cluster():
-            return obj_store.call(
+            method_to_call = obj_store.acall if run_async else obj_store.call
+            return method_to_call(
                 module_name,
                 method_name,
                 data={"args": args, "kwargs": kwargs},
                 stream_logs=stream_logs,
                 run_name=run_name,
                 # remote=remote,
-                run_async=run_async,
                 serialization=None,
             )
         return self.client.call_module_method(
@@ -836,7 +836,6 @@ class Cluster(Resource):
             data={"args": args, "kwargs": kwargs},
             run_name=run_name,
             remote=remote,
-            run_async=run_async,
             save=save,
             system=self,
         )

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -549,7 +549,6 @@ class Module(Resource):
                     *args,
                     stream_logs=stream_logs,
                     run_name=run_name,
-                    run_async=True,
                     **kwargs,
                 )
 

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -288,7 +288,6 @@ class HTTPClient:
         run_name: Optional[str] = None,
         stream_logs: bool = True,
         remote: bool = False,
-        run_async=False,
         save=False,
     ):
         """wrapper to temporarily support cluster's call signature"""
@@ -301,7 +300,6 @@ class HTTPClient:
             run_name=run_name,
             stream_logs=stream_logs,
             remote=remote,
-            run_async=run_async,
             save=save,
             system=self.system,
         )
@@ -316,7 +314,6 @@ class HTTPClient:
         run_name: Optional[str] = None,
         stream_logs: bool = True,
         remote: bool = False,
-        run_async=False,
         save=False,
         system=None,
     ):
@@ -339,9 +336,8 @@ class HTTPClient:
                 stream_logs=stream_logs,
                 save=save,
                 remote=remote,
-                run_async=run_async,
             ).dict(),
-            stream=not run_async,
+            stream=True,
             headers=rns_client.request_headers(resource_address),
             auth=self.auth,
             verify=self.verify,

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -350,7 +350,6 @@ class HTTPServer:
                     serialization=params.serialization,
                     run_name=params.run_name,
                     # remote=params.remote,
-                    run_async=True,
                 )
             )
             # If stream_logs is False, we'll wait for the result and return it
@@ -437,7 +436,6 @@ class HTTPServer:
         stream_logs: Optional[bool] = False,
         save: Optional[bool] = False,
         remote: Optional[bool] = False,
-        run_async: Optional[bool] = False,
     ):
         # Default argument to json doesn't allow a user to pass in a serialization string if they want
         # But, if they didn't pass anything, we want it to be `json` by default.
@@ -453,7 +451,6 @@ class HTTPServer:
                 stream_logs=stream_logs,
                 save=save,
                 remote=remote,
-                run_async=run_async,
             )
 
             query_params_remaining = dict(request.query_params)

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -37,7 +37,6 @@ class CallParams(BaseModel):
     stream_logs: Optional[bool] = False
     save: Optional[bool] = False
     remote: Optional[bool] = False
-    run_async: Optional[bool] = False
 
 
 class PutResourceParams(BaseModel):

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -244,26 +244,18 @@ class ObjStore:
     ##############################################
     @staticmethod
     async def acall_actor_method(
-        actor: ray.actor.ActorHandle, method: str, *args, run_async=False, **kwargs
+        actor: ray.actor.ActorHandle, method: str, *args, **kwargs
     ):
         if actor is None:
             raise ObjStoreError("Attempting to call an actor method on a None actor.")
         return await getattr(actor, method).remote(*args, **kwargs)
 
     @staticmethod
-    def call_actor_method(
-        actor: ray.actor.ActorHandle, method: str, *args, run_async=False, **kwargs
-    ):
+    def call_actor_method(actor: ray.actor.ActorHandle, method: str, *args, **kwargs):
         if actor is None:
             raise ObjStoreError("Attempting to call an actor method on a None actor.")
-        if not run_async:
-            return ray.get(getattr(actor, method).remote(*args, **kwargs))
-        else:
 
-            async def _call_async():
-                return await getattr(actor, method).remote(*args, **kwargs)
-
-            return _call_async()
+        return ray.get(getattr(actor, method).remote(*args, **kwargs))
 
     @staticmethod
     def get_env_servlet(
@@ -1230,7 +1222,6 @@ class ObjStore:
         run_name: Optional[str] = None,
         stream_logs: bool = False,
         remote: bool = False,
-        run_async: bool = False,
     ):
         env_servlet_name_containing_key = await self.aget_env_servlet_name_for_key(key)
         if not env_servlet_name_containing_key:
@@ -1294,7 +1285,6 @@ class ObjStore:
         run_name: Optional[str] = None,
         stream_logs: bool = False,
         remote: bool = False,
-        run_async: bool = False,
     ):
         return sync_function(self.acall)(
             key,
@@ -1304,7 +1294,6 @@ class ObjStore:
             run_name,
             stream_logs,
             remote,
-            run_async,
         )
 
     ##############################################

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -172,7 +172,6 @@ class TestHTTPClient:
             "stream_logs": True,
             "save": False,
             "remote": False,
-            "run_async": False,
         }
         expected_headers = rns_client.request_headers(
             resource_address=self.local_cluster.rns_address
@@ -182,9 +181,9 @@ class TestHTTPClient:
         mock_post.assert_called_once_with(
             expected_url,
             json=expected_json_data,
-            stream=True,
             headers=expected_headers,
             auth=None,
+            stream=True,
             verify=expected_verify,
         )
 
@@ -219,7 +218,6 @@ class TestHTTPClient:
             "stream_logs": True,
             "save": False,
             "remote": False,
-            "run_async": False,
         }
         expected_url = f"http://localhost:32300/{module_name}/{method_name}"
         expected_headers = rns_client.request_headers(self.local_cluster.rns_address)
@@ -228,9 +226,9 @@ class TestHTTPClient:
         mock_post.assert_called_with(
             expected_url,
             json=expected_json_data,
-            stream=True,
             headers=expected_headers,
             auth=None,
+            stream=True,
             verify=expected_verify,
         )
 


### PR DESCRIPTION
We aren't really using the `run_async` arg in object store and HTTP client, with the new async structure. Kill it off!