### PR TITLE
Add native async support client side.

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -825,7 +825,12 @@ class Cluster(Resource):
                 # remote=remote,
                 serialization=None,
             )
-        return self.client.call_module_method(
+        method_to_call = (
+            self.client.acall_module_method
+            if run_async
+            else self.client.call_module_method
+        )
+        return method_to_call(
             module_name,
             method_name,
             resource_address=self.rns_address,

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ install_requires = [
     "uvicorn",
     "wheel",
     "apispec",
+    "httpx",
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the following


### PR DESCRIPTION
Adds support for running of any Runhouse module or function `async` server side and client side.

The tests detail this aggressively, but basically you can take any `sync` function, and do `run_async=True` and it will function as `async` locally, e.g.

```
def sync_fn(a, b):
    return a + b

fn = rh.function(sync_fn).to(cluster)
# Either of these would work
sum = await fn(1, 2, run_async=True)
sum = fn(1, 2)
```

the reverse works for `async` functions:
```
async def async_fn(a, b):
    return a + b

fn = rh.function(async_fn).to(cluster)
# Either of these would work
sum = await fn(1, 2)
sum = fn(1, 2, run_async=False)
```

The function will run in a thread on the server if it is sync, and run within the global event loop on the server if it is async.

NOTE: This means that poorly written async functions that run blocking sync things in their code, *will* block up the server.