### PR TITLE
Make asyncio event loop session-scoped for tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ extend-exclude = ["runhouse/servers/grpc/unary_pb2.py", "runhouse/servers/grpc/u
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "examples/*" = ["E501"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import enum
 import subprocess
 
@@ -184,6 +185,20 @@ def logged_in_account():
         raise ValueError(
             "The friend test account should not be active while running logged-in tests."
         )
+
+
+# Have to override the event_loop fixture to make it session scoped
+# The cluster keeps a client, which holds an AsyncClient, which holds an event loop,
+# but the event loop is closed after one test is run. This causes the next test to fail saying the
+# event loop is closed. This is a workaround to keep the event loop open for the entire session.
+@pytest.fixture(scope="session")
+def event_loop():
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
 
 
 # https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files


### PR DESCRIPTION
explained in comments. conflicts with the event loop when it's used in a cluster.
