### PR TITLE
Change Caddy installation to download from Github.

### DIFF
--- a/docker/slim/password-file-auth/Dockerfile
+++ b/docker/slim/password-file-auth/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /app/ssh
 
 # Install the required packages
 RUN apt-get update --allow-insecure-repositories && \
-    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen curl sudo ufw git awscli && \
+    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen wget curl sudo ufw git awscli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/slim/public-key-auth/Dockerfile
+++ b/docker/slim/public-key-auth/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /app/ssh
 
 # Install the required packages
 RUN apt-get update --allow-insecure-repositories && \
-    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen curl sudo ufw git awscli && \
+    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen wget curl sudo ufw git awscli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/runhouse/servers/caddy/config.py
+++ b/runhouse/servers/caddy/config.py
@@ -142,11 +142,19 @@ class CaddyConfig:
             # https://caddyserver.com/docs/running#using-the-service
             logger.info("Installing Caddy...")
 
+            caddy_version = "2.7.6"
+            arch = subprocess.run(
+                "dpkg --print-architecture",
+                shell=True,
+                text=True,
+                check=True,
+                capture_output=True,
+            ).stdout.strip()
+            caddy_deb_url = f"https://github.com/caddyserver/caddy/releases/download/v{caddy_version}/caddy_{caddy_version}_linux_{arch}.deb"
+
             commands = [
-                "sudo apt update && sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https",
-                "yes | curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg",  # noqa
-                "yes | curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list",  # noqa
-                "sudo apt update && sudo apt install caddy -y",
+                f"sudo wget -q {caddy_deb_url}",
+                f'sudo apt install "./caddy_{caddy_version}_linux_{arch}.deb"',
             ]
 
             for cmd in commands:


### PR DESCRIPTION
Can't install Caddy from Cloudsmith all the time: https://github.com/caddyserver/dist/issues/115.
