### PR TITLE
Remove `set_cluster_name`.

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -549,9 +549,6 @@ class Cluster(Resource):
                 system=self,
             )
 
-        if self.rns_address:
-            self.client.set_cluster_name(self.rns_address)
-
     def check_server(self, restart_server=True):
         if self.on_this_cluster():
             return


### PR DESCRIPTION
Added a breaking test case where we do a bunch of stuff with a passed in cluster.

Originally changed in this PR: https://github.com/run-house/runhouse/pull/477/files

Specifically, when loading a module shared by others, the user may not have permissions to the underlying cluster, so they can't call `set_settings`. 

This was reproduced here: `pytest -v --level release -k "test_shared_readonly"`