### PR TITLE
Add tests for default env

### DIFF
--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -206,8 +206,10 @@ class Env(Resource):
         new_env.secrets = self._secrets_to(system)
 
         if isinstance(system, Cluster):
-            if new_env.name == Env.DEFAULT_NAME:
-                new_env.name = system.default_env.name
+            # TODO: Think about this. When sending an env that was unnamed to a cluster, should the remote env
+            # be named the same as the local env? Or should it be named the same as the default env?
+            # if new_env.name == Env.DEFAULT_NAME:
+            #     new_env.name = system.default_env.name
             key = system.put_resource(new_env)
             env_vars = _process_env_vars(self.env_vars)
             if env_vars:

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -878,7 +878,9 @@ class Module(Resource):
     def _save_sub_resources(self, folder: str = None):
         if isinstance(self.system, Resource) and self.system.name:
             self.system.save(folder=folder)
-        if isinstance(self.env, Resource) and self.env.name != Env.DEFAULT_NAME:
+        if isinstance(self.env, Resource) and self.env != Env(
+            name=Env.DEFAULT_NAME, working_dir="./"
+        ):
             self.env.save(folder=folder)
 
     def rename(self, name: str):

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -191,8 +191,9 @@ class ProviderSecret(Secret):
                 system.default_env
                 if (
                     not env
-                    or env.config()
-                    == Env(name=Env.DEFAULT_NAME, working_dir="./").config()
+                    # TODO: Think about this, pretty sure we should be putting in the env if it was passed
+                    # or env.config()
+                    # == Env(name=Env.DEFAULT_NAME, working_dir="./").config()
                 )
                 else env
             )

--- a/runhouse/resources/secrets/secret.py
+++ b/runhouse/resources/secrets/secret.py
@@ -349,6 +349,7 @@ class Secret(Resource):
         if system.on_this_cluster():
             new_secret.pin()
         else:
+            env = env or system.default_env
             system.put_resource(new_secret, env=env)
 
         return new_secret

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,7 @@ from tests.fixtures.on_demand_cluster_fixtures import (
     ondemand_aws_cluster,  # noqa: F401
     ondemand_aws_https_cluster_with_auth,  # noqa: F401
     ondemand_cluster,  # noqa: F401
+    ondemand_default_conda_env_cluster,  # noqa: F401
     ondemand_gcp_cluster,  # noqa: F401
     ondemand_k8s_cluster,  # noqa: F401
     v100_gpu_cluster,  # noqa: F401
@@ -389,6 +390,7 @@ default_fixtures[TestLevels.RELEASE] = {
         "ondemand_gcp_cluster",
         "ondemand_k8s_cluster",
         "ondemand_aws_https_cluster_with_auth",
+        "ondemand_default_conda_env_cluster",
         "password_cluster",
         "static_cpu_cluster",
     ]
@@ -400,7 +402,9 @@ default_fixtures[TestLevels.MAXIMAL] = {
         "docker_cluster_pwd_ssh_no_auth",
         "ondemand_aws_cluster",
         "ondemand_gcp_cluster",
+        "ondemand_k8s_cluster",
         "ondemand_aws_https_cluster_with_auth",
+        "ondemand_default_conda_env_cluster",
         "password_cluster",
         "multinode_cpu_cluster",
         "static_cpu_cluster",

--- a/tests/fixtures/on_demand_cluster_fixtures.py
+++ b/tests/fixtures/on_demand_cluster_fixtures.py
@@ -5,6 +5,7 @@ import pytest
 import runhouse as rh
 
 from runhouse.constants import DEFAULT_HTTPS_PORT
+from runhouse.resources.envs import Env
 
 from tests.conftest import init_args
 from tests.utils import test_env
@@ -25,7 +26,8 @@ def setup_test_cluster(args, request):
         cluster.restart_server()
 
     cluster.save()
-    test_env().to(cluster)
+    if cluster.default_env.name == Env.DEFAULT_NAME:
+        test_env().to(cluster)
     return cluster
 
 
@@ -117,6 +119,22 @@ def multinode_cpu_cluster(request):
         "name": "rh-cpu-multinode",
         "num_instances": 2,
         "instance_type": "CPU:2+",
+    }
+    cluster = setup_test_cluster(args, request)
+    return cluster
+
+
+@pytest.fixture(scope="session")
+def ondemand_default_conda_env_cluster(request):
+    env_vars = {"var1": "val1", "var2": "val2"}
+    default_env = rh.conda_env(
+        name="default_env", reqs=test_env().reqs + ["skypilot"], env_vars=env_vars
+    )
+    args = {
+        "name": "default-env-cpu",
+        "instance_type": "CPU:2+",
+        "provider": "aws",
+        "default_env": default_env,
     }
     cluster = setup_test_cluster(args, request)
     return cluster

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -137,6 +137,8 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
 
     @pytest.mark.level("local")
     def test_cluster_recreate(self, cluster):
+        # Create underlying ssh connection if not already
+        cluster.run(["echo hello"])
         num_open_tunnels = len(rh.globals.sky_ssh_runner_cache)
 
         # Create a new cluster object for the same remote cluster

--- a/tests/test_resources/test_clusters/test_cluster_default_env.py
+++ b/tests/test_resources/test_clusters/test_cluster_default_env.py
@@ -1,0 +1,105 @@
+import pytest
+
+import runhouse as rh
+
+import tests.test_resources.test_clusters.test_cluster
+from tests.test_resources.test_clusters.test_cluster import summer
+from tests.test_resources.test_envs.test_env import _get_env_var_value
+
+from tests.utils import get_random_str
+
+
+def import_env():
+    import pandas  # noqa
+    import pytest  # noqa
+
+    return "success"
+
+
+class TestCluster(tests.test_resources.test_clusters.test_cluster.TestCluster):
+    MAP_FIXTURES = {"resource": "cluster"}
+
+    UNIT = {"cluster": []}
+    LOCAL = {"cluster": ["docker_cluster_pk_ssh"]}
+    MINIMAL = {"cluster": ["ondemand_default_conda_env_cluster"]}
+    RELEASE = {"cluster": ["ondemand_default_conda_env_cluster"]}
+    MAXIMAL = {"cluster": ["ondemand_default_conda_env_cluster"]}
+
+    @pytest.mark.level("local")
+    def test_default_env_in_status(self, cluster):
+        res = cluster.status()
+        assert cluster.default_env.name in res.get("envs")
+
+    @pytest.mark.level("local")
+    def test_put_in_default_env(self, cluster):
+        k1 = get_random_str()
+        cluster.put(k1, "v1")
+
+        assert k1 in cluster.keys(env=cluster.default_env.name)
+        cluster.delete(k1)
+
+    @pytest.mark.level("local")
+    def test_fn_to_default_env(self, cluster):
+        remote_summer = rh.function(summer).to(cluster)
+
+        assert remote_summer.name in cluster.keys(env=cluster.default_env.name)
+        assert remote_summer(3, 4) == 7
+
+    @pytest.mark.level("local")
+    def test_run_in_default_env(self, cluster):
+        for req in cluster.default_env.reqs:
+            req = req.replace("_", "-")
+            assert cluster.run(f"pip freeze | grep {req}")[0][0] == 0
+
+    @pytest.mark.level("minimal")
+    def test_default_conda_env_created(self, cluster):
+        conda_env = cluster.default_env
+
+        assert cluster.default_env.env_name in cluster.run("conda info --envs")[0][1]
+        assert isinstance(cluster.get(conda_env.name), rh.CondaEnv)
+
+    @pytest.mark.level("release")
+    def test_switch_default_env(self, cluster):
+        # test setting a new default env, w/o restarting the runhouse server
+        test_env = cluster.default_env
+        new_env = rh.conda_env(name="new_conda_env", reqs=["diffusers"])
+        cluster.default_env = new_env
+
+        # check cluster attr set, and  new env exists on the system
+        assert new_env.env_name in cluster.run("conda info --envs")[0][1]
+        assert cluster.default_env.name == new_env.name
+        assert new_env.name in cluster.status().get("envs")
+
+        # check that env defaults to new default env for run/put
+        assert cluster.run("pip freeze | grep diffusers")[0][0] == 0
+
+        k1 = get_random_str()
+        cluster.put(k1, "v1")
+        assert k1 in cluster.keys(env=new_env.env_name)
+
+        # set it back
+        cluster.default_env = test_env
+        cluster.delete(new_env.name)
+
+    @pytest.mark.level("release")
+    def test_default_env_var_run(self, cluster):
+        env_vars = cluster.default_env.env_vars
+
+        assert env_vars
+        for var in env_vars.keys():
+            res = cluster.run([f"echo ${var}"], env=cluster.default_env)
+            assert res[0][0] == 0
+            assert env_vars[var] in res[0][1]
+
+    @pytest.mark.level("release")
+    def test_default_env_var_fn(self, cluster):
+        env_vars = cluster.default_env.env_vars
+
+        get_env_var_cpu = rh.function(_get_env_var_value).to(system=cluster)
+        for var in env_vars.keys():
+            assert get_env_var_cpu(var) == env_vars[var]
+
+    @pytest.mark.level("local")
+    def test_fn_env_var_import(self, cluster):
+        fn = rh.function(import_env).to(cluster)
+        assert fn() == "success"

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -53,11 +53,21 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
         # and add local clusters once conda docker container is set up
     }
     MINIMAL = {
-        "env": ["base_env", "named_env", "base_conda_env", "named_conda_env_from_dict"],
+        "env": [
+            "base_env",
+            "named_env",
+            "base_conda_env",
+            "named_conda_env_from_dict",
+        ],
         "cluster": ["ondemand_aws_cluster"],
     }
     RELEASE = {
-        "env": ["base_env", "named_env", "base_conda_env", "named_conda_env_from_dict"],
+        "env": [
+            "base_env",
+            "named_env",
+            "base_conda_env",
+            "named_conda_env_from_dict",
+        ],
         "cluster": [
             "ondemand_aws_cluster",
             "password_cluster",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,7 +91,7 @@ def friend_account_in_org():
 
 def test_env(logged_in=False):
     return rh.env(
-        reqs=["pytest", "httpx", "pytest_asyncio"],
+        reqs=["pytest", "httpx", "pytest_asyncio", "pandas"],
         working_dir=None,
         setup_cmds=[
             f"mkdir -p ~/.rh; touch ~/.rh/config.yaml; "


### PR DESCRIPTION
new default_env_cluster test, subclasses test_cluster + some default_env specific testing

fixtures
* new ondemand fixture w/ a default env that's a cluster env
* for existing docker pk ssh fixture, directly set default env=test env instead of sending test env to cluster