### PR TITLE
Don't serialize tracebacks in OutputType.EXCEPTION Responses

### DIFF
--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -271,12 +271,12 @@ class HTTPServer:
         except Exception as e:
             logger.exception(e)
             exception_data = {
-                "error": e,
+                "error": serialize_data(e, serialization),
                 "traceback": traceback.format_exc(),
             }
             return Response(
                 output_type=OutputType.EXCEPTION,
-                data=serialize_data(exception_data, serialization),
+                data=exception_data,
                 serialization=serialization,
             )
 
@@ -298,12 +298,12 @@ class HTTPServer:
         except Exception as e:
             logger.exception(e)
             exception_data = {
-                "error": e,
+                "error": serialize_data(e, serialization),
                 "traceback": traceback.format_exc(),
             }
             return Response(
                 output_type=OutputType.EXCEPTION,
-                data=serialize_data(exception_data, serialization),
+                data=exception_data,
                 serialization=serialization,
             )
 
@@ -472,12 +472,12 @@ class HTTPServer:
         except Exception as e:
             logger.exception(e)
             exception_data = {
-                "error": e,
+                "error": serialize_data(e, serialization),
                 "traceback": traceback.format_exc(),
             }
             return Response(
                 output_type=OutputType.EXCEPTION,
-                data=serialize_data(exception_data, serialization),
+                data=exception_data,
                 serialization=serialization,
             )
 
@@ -554,14 +554,14 @@ class HTTPServer:
             # working through an HTTP call stream_logs is False by default, so a normal HTTPException will be raised
             # above before entering this generator.
             exception_data = {
-                "error": e,
+                "error": serialize_data(e, serialization),
                 "traceback": traceback.format_exc(),
             }
             yield json.dumps(
                 jsonable_encoder(
                     Response(
                         output_type=OutputType.EXCEPTION,
-                        data=serialize_data(exception_data, serialization),
+                        data=exception_data,
                         serialization=serialization,
                     )
                 )

--- a/tests/test_servers/test_servlet.py
+++ b/tests/test_servers/test_servlet.py
@@ -83,5 +83,5 @@ class TestServlet:
             remote=False,
         )
         assert resp.output_type == "exception"
-        exception_data = deserialize_data(resp.data, "pickle")
-        assert isinstance(exception_data["error"], KeyError)
+        error = deserialize_data(resp.data["error"], "pickle")
+        assert isinstance(error, KeyError)


### PR DESCRIPTION
Previously, we serialized both the exception and the traceback together, so if the deserialization failed (e.g. if there was a library incompatibility between the client and server which blocked unpickling) we couldn't see the traceback either, even though it's a string. It's important that we try to desrialize the exception so users have a chance to catch it properly locally, but if it's impossible to deserialize, we may as well just raise a runtime error and still print the traceback. If the response from the cluster is still in the old format, we'll still try to unpickle it for compatibility, but we can eventually deprecate that.
