### PR TITLE
Fix call logging by unbuffering stdout/err in call threadpool

### DIFF
--- a/runhouse/resources/provenance.py
+++ b/runhouse/resources/provenance.py
@@ -527,6 +527,15 @@ class StreamTee(object):
         for stream in self.outstreams:
             if message:
                 stream.write(message)
+                # We flush here to ensure that the logs are written to the file immediately
+                # see https://github.com/run-house/runhouse/pull/724
+                stream.flush()
+
+    def writelines(self, lines):
+        self.instream.writelines(lines)
+        for stream in self.outstreams:
+            stream.writelines(lines)
+            stream.flush()
 
     def flush(self):
         self.instream.flush()


### PR DESCRIPTION
Because we started running method calls in a threadpool, the output was buffered and only flushed/printed at the end (https://stackoverflow.com/questions/18234469/python-multithreaded-print-statements-delayed-until-all-threads-complete-executi). This changes the StreamTee utility we use to print stdout/logging to flush on each write, per https://mail.python.org/pipermail/tutor/2003-November/026645.html