### PR TITLE
Rewrite Module tests to be more thorough and separate.

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -501,6 +501,10 @@ class Cluster(Resource):
         else:
             env_name = env
 
+        # Env name could somehow be a full length `username/base_env`, trim it down to just the env name
+        if env_name:
+            env_name = env_name.split("/")[-1]
+
         state = state or {}
         if self.on_this_cluster():
             data = (resource.config(condensed=False), state, dryrun)

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -887,6 +887,9 @@ class Module(Resource):
     def _save_sub_resources(self, folder: str = None):
         if isinstance(self.system, Resource) and self.system.name:
             self.system.save(folder=folder)
+        # TODO: (default env) should we save the default env here? This can lead to a weird case where
+        # we share something in the default env with someone else, but they can't load down the env itself
+        # and are just passing around a string, like `rohinb2/base_env`.
         if isinstance(self.env, Resource) and self.env != Env(
             name=Env.DEFAULT_NAME, working_dir="./"
         ):
@@ -1209,6 +1212,14 @@ def _module_subclass_factory(cls, cls_pointers):
         if not new_module.dryrun and new_module.system:
             # We use system.put_resource here because the signatures for HTTPClient.put_resource and
             # obj_store.put_resource are different, but we should fix that.
+
+            # If the system is still a string, we know that the user has _no_ access to the Cluster
+            # If they were able to discover the cluster, their system string would be replaced by a Cluster object
+            # when _check_for_child_configs --> _get_cluster_from was called
+            if isinstance(new_module.system, str):
+                raise ValueError(
+                    "You must have access to the underlying cluster for this unconstructed Module in order to put a resource on it."
+                )
             new_module.system.put_resource(new_module, env=env)
             new_module.system.call(new_module.name, "_remote_init", *args, **kwargs)
         else:


### PR DESCRIPTION
Right now we have `test_shared_readonly` which is the main test that was checking inter cluster calling flows and calling after sharing. This test was being skipped in release testing because `TEST_TOKEN` and `TEST_USERNAME` were not set. 

Now, it fails because the underlying `AsyncGenerator` that we use to mock `async for` calls is not shared with the user. I've renamed this. I've renamed this to `test_share_module_with_generator_read_only_inter_cluster`

Creating a more simple tests that checks `share` and `revoke` with calling a simple Module.

- `export TEST_TOKEN=...`
- `export TEST_USERNAME=...`
- `pytest -v --level local -k "test_share_module_read_only"`
- `pytest -v --level release -k "test_share_module_read_only_inter_cluster"`
- `pytest -v --level local "test_construct_shared_module"`
- **FAILING CURRENTLY**: `pytest -v --level release "test_share_module_with_generator_read_only_inter_cluster"`



