### PR TITLE
Make `env_servlets` cache an instance field instead of global.

### DIFF
--- a/runhouse/globals.py
+++ b/runhouse/globals.py
@@ -32,4 +32,3 @@ rns_client = RNSClient(configs=configs)
 # Note: this initalizes a dummy global object. The obj_store must
 # be properly initialized by a servlet via initialize.
 obj_store = ObjStore()
-env_servlets = {}

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -4,7 +4,7 @@ import threading
 import time
 from typing import Any, Dict, List, Optional, Set, Union
 
-from runhouse.globals import configs, ObjStore, rns_client
+from runhouse.globals import configs, obj_store, rns_client
 from runhouse.resources.hardware import load_cluster_config_from_file
 from runhouse.rns.utils.api import ResourceAccess
 from runhouse.servers.http.auth import AuthCache
@@ -76,10 +76,11 @@ class ClusterServlet:
         # Propagate the changes to all other process's obj_stores
         await asyncio.gather(
             *[
-                ObjStore.acall_actor_method(
-                    ObjStore.get_env_servlet(env_servlet_name),
+                obj_store.acall_env_servlet_method(
+                    env_servlet_name,
                     "aset_cluster_config",
                     cluster_config,
+                    use_env_servlet_cache=False,
                 )
                 for env_servlet_name in await self.aget_all_initialized_env_servlet_names()
             ]
@@ -98,11 +99,12 @@ class ClusterServlet:
         # Propagate the changes to all other process's obj_stores
         await asyncio.gather(
             *[
-                ObjStore.acall_actor_method(
-                    ObjStore.get_env_servlet(env_servlet_name),
+                obj_store.acall_env_servlet_method(
+                    env_servlet_name,
                     "aset_cluster_config_value",
                     key,
                     value,
+                    use_env_servlet_cache=False,
                 )
                 for env_servlet_name in await self.aget_all_initialized_env_servlet_names()
             ]

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -46,7 +46,6 @@ from runhouse.servers.http.http_utils import (
 )
 from runhouse.servers.obj_store import (
     ClusterServletSetupOption,
-    ObjStore,
     ObjStoreError,
     RaySetupOption,
 )
@@ -199,7 +198,7 @@ class HTTPServer:
         # TODO: We aren't sure _exactly_ where this is or isn't used.
         # There are a few spots where we do `env_name or "base"`, and
         # this allows that base env to be pre-initialized.
-        _ = ObjStore.get_env_servlet(
+        _ = obj_store.get_env_servlet(
             env_name="base",
             create=True,
             runtime_env=runtime_env,
@@ -679,7 +678,7 @@ class HTTPServer:
             if not env_name:
                 output = await obj_store.akeys()
             else:
-                output = await ObjStore.akeys_for_env_servlet_name(env_name)
+                output = await obj_store.akeys_for_env_servlet_name(env_name)
 
             # Expicitly tell the client not to attempt to deserialize the output
             return Response(

--- a/tests/test_servers/test_server_obj_store.py
+++ b/tests/test_servers/test_server_obj_store.py
@@ -1,6 +1,6 @@
 import pytest
 
-from runhouse.servers.obj_store import ObjStore, ObjStoreError
+from runhouse.servers.obj_store import ObjStoreError
 
 from tests.utils import friend_account, get_ray_servlet_and_obj_store
 
@@ -341,7 +341,9 @@ class TestObjStore:
 
         # check that corresponding Ray actor is killed
         with pytest.raises(ObjStoreError):
-            ObjStore.get_env_servlet(env_name=env_to_delete, raise_ex_if_not_found=True)
+            obj_store.get_env_servlet(
+                env_name=env_to_delete, raise_ex_if_not_found=True
+            )
 
 
 @pytest.mark.servertest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@ def get_ray_servlet_and_obj_store(env_name):
     test_obj_store = ObjStore()
     test_obj_store.initialize(env_name, setup_ray=RaySetupOption.GET_OR_FAIL)
 
-    servlet = ObjStore.get_env_servlet(
+    servlet = test_obj_store.get_env_servlet(
         env_name=env_name,
         create=True,
     )


### PR DESCRIPTION
We don't need this to be global, it's only used in the object store. 

In general, minimizing the amount of global stuff we have referencing important objects is better to avoid weird memory issues.