### PR TITLE
Switch `restart_ray` to True so that we start our own Ray cluster instead of using SkyPilot's.

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -456,7 +456,7 @@ def _start_server(
 
 @app.command()
 def start(
-    restart_ray: bool = typer.Option(False, help="Restart the Ray runtime"),
+    restart_ray: bool = typer.Option(True, help="Restart the Ray runtime"),
     screen: bool = typer.Option(False, help="Start the server in a screen"),
     nohup: bool = typer.Option(
         False, help="Start the server in a nohup if screen is not available"
@@ -518,7 +518,7 @@ def start(
 @app.command()
 def restart(
     name: str = typer.Option(None, help="A *saved* remote cluster object to restart."),
-    restart_ray: bool = typer.Option(False, help="Restart the Ray runtime"),
+    restart_ray: bool = typer.Option(True, help="Restart the Ray runtime"),
     screen: bool = typer.Option(
         True,
         help="Start the server in a screen. Only relevant when restarting locally.",

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -730,7 +730,7 @@ class Cluster(Resource):
         self,
         _rh_install_url: str = None,
         resync_rh: bool = True,
-        restart_ray: bool = False,
+        restart_ray: bool = True,
         restart_proxy: bool = False,
     ):
         """Restart the RPC server.


### PR DESCRIPTION
instead of using SkyPilot's.