### PR TITLE
Don't replace `base_env` with `system.default_env`.

### DIFF
--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -206,7 +206,7 @@ class Env(Resource):
         new_env.secrets = self._secrets_to(system)
 
         if isinstance(system, Cluster):
-            # TODO: Think about this. When sending an env that was unnamed to a cluster, should the remote env
+            # TODO: (default env). When sending an env that was unnamed to a cluster, should the remote env
             # be named the same as the local env? Or should it be named the same as the default env?
             # if new_env.name == Env.DEFAULT_NAME:
             #     new_env.name = system.default_env.name

--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -58,6 +58,7 @@ def _get_env_from(env):
         return Env.from_config(env)
     elif (
         isinstance(env, str)
+        # TODO: (default env) revisit this logic
         and Env.DEFAULT_NAME not in env
         and rns_client.exists(env, resource_type="env")
     ):

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -437,6 +437,8 @@ class Module(Resource):
             _get_cluster_from(system, dryrun=self.dryrun) if system else self.system
         )
         if not env:
+            # TODO: (default env). Should we change the env to the system default env if the default name was
+            # used to create the module?
             if not self.env or (
                 self.env
                 and self.env.config()

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -187,16 +187,18 @@ class ProviderSecret(Secret):
             )
 
         if env or self.env_vars:
-            env = (
-                system.default_env
-                if (
-                    not env
-                    # TODO: Think about this, pretty sure we should be putting in the env if it was passed
-                    # or env.config()
-                    # == Env(name=Env.DEFAULT_NAME, working_dir="./").config()
-                )
-                else env
-            )
+            env = env if env else system.default_env
+            # TODO: (default env), pretty sure we should be putting in the env if it was passed, even if it's
+            # the default env. But if it's not passed, we should be using the default env.
+            # env = (
+            #     system.default_env
+            #     if (
+            #         not env
+            #         or env.config()
+            #         == Env(name=Env.DEFAULT_NAME, working_dir="./").config()
+            #     )
+            #     else env
+            # )
             env_key = env if isinstance(env, str) else env.name
             if not system.get(env_key):
                 env = env if isinstance(env, Env) else Env(name=env_key)


### PR DESCRIPTION
There are several instances where, if the env happened to be `base_env`, we replace it with the cluster default env. The problem is we don't always replace this client side and it creates some inconsistencies. Wanted to discuss this logic a bit more

I've marked these with `TODO: (default env)`

cc: @carolineechen when you're back