### PR TITLE
Revert use of sky_utils to skylet configs for autostop

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -48,17 +48,29 @@ class ClusterServlet:
     # Cluster autostop
     ##############################################
     def update_autostop(self):
-        from runhouse.servers import sky_utils
+        import pickle
+
+        from sky.skylet import configs as sky_configs
 
         while True:
+            autostop_mins = pickle.loads(
+                sky_configs.get_config("autostop_config")
+            ).autostop_idle_minutes
             self._last_register = float(
-                sky_utils.get_config("autostop_last_active_time")
+                sky_configs.get_config("autostop_last_active_time")
             )
-            if not self._last_register or self._last_activity > self.last_register:
-                sky_utils.set_config("autostop_last_active_time", self._last_activity)
+            if autostop_mins > 0 and (
+                not self._last_register
+                or (
+                    # within 2 min of autostop and there's more recent activity
+                    60 * autostop_mins - (time.time() - self._last_register) < 120
+                    and self._last_activity > self._last_register
+                )
+            ):
+                sky_configs.set_config("autostop_last_active_time", self._last_activity)
                 self._last_register = self._last_activity
 
-            time.sleep(58)
+            time.sleep(30)
 
     ##############################################
     # Cluster config state storage methods
@@ -86,10 +98,10 @@ class ClusterServlet:
 
     async def aset_cluster_config_value(self, key: str, value: Any):
         if key == "autostop_mins" and value > -1:
-            from runhouse.servers import sky_utils
+            from sky.skylet import configs as sky_configs
 
             self._last_activity = time.time()
-            sky_utils.set_config("autostop_last_active_time", self._last_activity)
+            sky_configs.set_config("autostop_last_active_time", self._last_activity)
         self.cluster_config[key] = value
 
         # Propagate the changes to all other process's obj_stores


### PR DESCRIPTION
temporarily added sky_utils in #697 to remove sky dependency for autostop, but ended up going w/ approach to just use sky and require sky is installed on ondemand clusters. did not revert references of sky_utils back to original sky usage, fixing in this PR