### PR TITLE
Some improvements to the parallel embedding example.

### DIFF
--- a/examples/parallel-hf-embedding-ec2/README.md
+++ b/examples/parallel-hf-embedding-ec2/README.md
@@ -1,4 +1,4 @@
-# Run several Hugging Face embedding models on AWS EC2 using Runhouse & Langchain
+# An embarrassingly parallel embedding task with Hugging Face models on AWS EC2
 
 This example demonstrates how to use Runhouse primitives to embed a large number of websites in parallel.
 We use a [BGE large model from Hugging Face](https://huggingface.co/BAAI/bge-large-en-v1.5) and load it via


### PR DESCRIPTION
**wikipedia, chunk_size=1, 4/4, stream_logs=True**
`Embedded 906 docs across 4 replicas with 4 concurrent calls: 307.0286202430725`
**wikipedia, chunk_size=1, 4/16, stream_logs=True**
`Embedded 906 docs across 4 replicas with 16 concurrent calls: 135.8996410369873`
**wikipedia, chunk_size=1, 4/128, stream_logs=True**
`Embedded 906 docs across 4 replicas with 128 concurrent calls: 115.94204783439636`
**wikipedia, chunk_size=1, 4/128, stream_logs=False**
`Embedded 906 docs across 4 replicas with 128 concurrent calls: 117.65519213676453`

also tested with a larger chunk_size (partitioning) caused an oom