### PR TITLE
Rename cluster default env name when empty

### DIFF
--- a/runhouse/resources/asgi.py
+++ b/runhouse/resources/asgi.py
@@ -100,7 +100,7 @@ def asgi(
         return Asgi.from_name(name, dryrun)
 
     if not isinstance(env, Env):
-        env = _get_env_from(env) or Env(name=Env.DEFAULT_NAME)
+        env = _get_env_from(env) or Env()
         env.working_dir = env.working_dir or "./"
 
     callers_global_vars = inspect.currentframe().f_back.f_globals.items()

--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 
 class Env(Resource):
     RESOURCE_TYPE = "env"
-    DEFAULT_NAME = "base_env"
 
     def __init__(
         self,

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -61,12 +61,15 @@ def _current_cluster(key="config"):
 
 
 def _default_env_if_on_cluster():
-    from runhouse import Env
+    from runhouse import Cluster, Env
 
     config = _current_cluster()
     return (
         _get_env_from(
-            config.get("default_env", Env(name=Env.DEFAULT_NAME, working_dir="./"))
+            config.get(
+                "default_env",
+                Env(name=Cluster.EMPTY_DEFAULT_ENV_NAME, working_dir="./"),
+            )
         )
         if config
         else None
@@ -95,3 +98,7 @@ def _get_cluster_from(system, dryrun=False):
             pass
 
     return system
+
+
+def _unnamed_default_env_name(cluster_name):
+    return f"{cluster_name}_default_env"

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -65,11 +65,14 @@ def load(name: str, instantiate: bool = True, dryrun: bool = False):
 
 
 async def get_local_cluster_object():
-    from runhouse.resources.envs import Env
+    from runhouse.resources.hardware import Cluster
 
     # By default, obj_store.initialize does not initialize Ray, and instead
     # attempts to connect to an existing cluster.
-    from runhouse.resources.hardware.utils import load_cluster_config_from_file
+    from runhouse.resources.hardware.utils import (
+        _unnamed_default_env_name,
+        load_cluster_config_from_file,
+    )
 
     # In case we are calling `rh.here` within the same Python process
     # as an initialized object store, keep the same name.
@@ -78,13 +81,16 @@ async def get_local_cluster_object():
     try:
         servlet_name = obj_store.servlet_name
         if not servlet_name:
-            default_env = load_cluster_config_from_file().get("default_env", None)
+            cluster_config = load_cluster_config_from_file()
+            default_env = cluster_config.get("default_env", None)
             if isinstance(default_env, str):
                 servlet_name = default_env
             elif isinstance(default_env, Dict):
-                servlet_name = default_env.get("name", Env.DEFAULT_NAME)
+                servlet_name = default_env.get(
+                    "name", _unnamed_default_env_name(cluster_config.get("name"))
+                )
             else:
-                servlet_name = Env.DEFAULT_NAME
+                servlet_name = Cluster.EMPTY_DEFAULT_ENV_NAME
 
         await obj_store.ainitialize(
             servlet_name=servlet_name,

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -174,9 +174,9 @@ class HTTPServer:
                 return await call_next(request)
 
         if not default_env_name:
-            from runhouse.resources.envs import Env
+            from runhouse.resources.hardware import Cluster
 
-            default_env_name = Env.DEFAULT_NAME
+            default_env_name = Cluster.EMPTY_DEFAULT_ENV_NAME
 
         # Ray and ClusterServlet should already be
         # initialized by the start script (see below)

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -1093,7 +1093,6 @@ class ObjStore:
 
         obj = self.get_local(key, default=KeyError)
 
-        from runhouse.resources.envs.env import Env
         from runhouse.resources.module import Module
         from runhouse.resources.resource import Resource
 
@@ -1112,7 +1111,7 @@ class ObjStore:
                 # Setting to None in the case of non-resource or no rns_address will force auth to only
                 # succeed if the user has WRITE or READ access to the cluster
                 resource_uri = obj.rns_address if hasattr(obj, "rns_address") else None
-                if key != Env.DEFAULT_NAME and not await self.ahas_resource_access(
+                if key != self.servlet_name and not await self.ahas_resource_access(
                     ctx.token, resource_uri
                 ):
                     # Do not validate access to the default Env

--- a/tests/fixtures/docker_cluster_fixtures.py
+++ b/tests/fixtures/docker_cluster_fixtures.py
@@ -14,6 +14,7 @@ import runhouse as rh
 from runhouse.constants import DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT, DEFAULT_SSH_PORT
 from runhouse.globals import rns_client
 
+from runhouse.resources.hardware.cluster import Cluster
 from tests.conftest import init_args
 from tests.utils import friend_account, test_env
 
@@ -273,7 +274,7 @@ def set_up_local_cluster(
         # If re-using fixtures make sure the crt file gets copied on to the cluster
         rh_cluster.restart_server()
 
-    if rh_cluster.default_env.name == rh.Env.DEFAULT_NAME:
+    if rh_cluster.default_env.name == Cluster.EMPTY_DEFAULT_ENV_NAME:
         test_env(logged_in=logged_in).to(rh_cluster)
 
     def cleanup():

--- a/tests/fixtures/on_demand_cluster_fixtures.py
+++ b/tests/fixtures/on_demand_cluster_fixtures.py
@@ -5,7 +5,7 @@ import pytest
 import runhouse as rh
 
 from runhouse.constants import DEFAULT_HTTPS_PORT
-from runhouse.resources.envs import Env
+from runhouse.resources.hardware import Cluster
 
 from tests.conftest import init_args
 from tests.utils import test_env
@@ -26,7 +26,7 @@ def setup_test_cluster(args, request):
         cluster.restart_server()
 
     cluster.save()
-    if cluster.default_env.name == Env.DEFAULT_NAME:
+    if cluster.default_env.name == Cluster.EMPTY_DEFAULT_ENV_NAME:
         test_env().to(cluster)
     return cluster
 

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -262,6 +262,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         status_output_string = status_output_string.encode("utf-8").decode(
             "unicode_escape"
         )
+        status_output_string = status_output_string.replace("\n", "")
         assert "Runhouse Daemon is running" in status_output_string
         assert f"server_port: {cluster.server_port}" in status_output_string
         assert (

--- a/tests/test_servers/test_http_client.py
+++ b/tests/test_servers/test_http_client.py
@@ -136,8 +136,6 @@ class TestHTTPClient:
 
     @pytest.mark.level("unit")
     def test_call_module_method(self, mocker):
-        from runhouse import Env
-
         response_sequence = [
             json.dumps({"output_type": "stdout", "data": "Log message"}),
             json.dumps(
@@ -157,7 +155,7 @@ class TestHTTPClient:
 
         # Call the method under test
         method_name = "install"
-        module_name = Env.DEFAULT_NAME
+        module_name = rh.Cluster.EMPTY_DEFAULT_ENV_NAME
         result = self.client.call(
             module_name, method_name, resource_address=self.local_cluster.rns_address
         )
@@ -247,8 +245,6 @@ class TestHTTPClient:
 
     @pytest.mark.level("unit")
     def test_call_module_method_config(self, mocker, local_cluster):
-        from runhouse import Env
-
         test_data = self.local_cluster.config()
         mock_response = mocker.Mock()
         mock_response.status_code = 200
@@ -260,7 +256,9 @@ class TestHTTPClient:
         mocker.patch("requests.Session.post", return_value=mock_response)
 
         cluster = self.client.call(
-            Env.DEFAULT_NAME, "install", resource_address=local_cluster.rns_address
+            rh.Cluster.EMPTY_DEFAULT_ENV_NAME,
+            "install",
+            resource_address=local_cluster.rns_address,
         )
         assert cluster.config() == test_data
 


### PR DESCRIPTION
after introducing cluster default envs as a property of a cluster, we no longer need a catch all name for all unnamed envs, which can have confusing behavior. rather,
* cluster w/ a specified default env: if the env is unnamed, the name is assigned to be `{cluster.name}_default_env` (similar to how cluster ssh secrets are automatically named). this is used as the key for the env servlet, and also for purposes of saving the cluster.
* cluster does not have a specified default env: use the var `Cluster.EMPTY_DEFAULT_ENV_NAME = _cluster_default_env`, which is part of the cluster class, rather than the env class. this is used as the env servlet key, and not part of the cluster config so will not be saved.