### PR TITLE
Update den auth default to None in cluster factory

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -85,7 +85,7 @@ class Cluster(Resource):
 
         self.ips = ips
         self.client = None
-        self.den_auth = den_auth
+        self.den_auth = den_auth or False
         self.cert_config = TLSCertConfig(cert_path=ssl_certfile, key_path=ssl_keyfile)
 
         self.ssl_certfile = ssl_certfile

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -27,7 +27,7 @@ def cluster(
     ssl_keyfile: str = None,
     ssl_certfile: str = None,
     domain: str = None,
-    den_auth: bool = False,
+    den_auth: bool = None,
     default_env: Union["Env", str] = None,
     dryrun: bool = False,
     **kwargs,
@@ -55,7 +55,7 @@ def cluster(
         domain(str, optional): Domain name for the cluster. Relevant if enabling HTTPs on the cluster.
         den_auth (bool, optional): Whether to use Den authorization on the server. If ``True``, will validate incoming
             requests with a Runhouse token provided in the auth headers of the request with the format:
-            ``{"Authorization": "Bearer <token>"}``. (Default: ``False``).
+            ``{"Authorization": "Bearer <token>"}``. (Default: ``None``).
         default_env (Env or str, optional): Environment that the Runhouse server is started on in the cluster. Used to
             specify an isolated environment (e.g. conda env) or any setup and requirements prior to starting the Runhouse
             server. (Default: ``None``)
@@ -99,6 +99,7 @@ def cluster(
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,
             domain=domain,
+            den_auth=den_auth,
             default_env=default_env,
             kwargs=kwargs if len(kwargs) > 0 else None,
         )
@@ -315,7 +316,7 @@ def ondemand_cluster(
     ssl_keyfile: str = None,
     ssl_certfile: str = None,
     domain: str = None,
-    den_auth: bool = False,
+    den_auth: bool = None,
     default_env: Union["Env", str] = None,
     dryrun: bool = False,
     **kwargs,
@@ -354,7 +355,7 @@ def ondemand_cluster(
         domain(str, optional): Domain name for the cluster. Relevant if enabling HTTPs on the cluster.
         den_auth (bool, optional): Whether to use Den authorization on the server. If ``True``, will validate incoming
             requests with a Runhouse token provided in the auth headers of the request with the format:
-            ``{"Authorization": "Bearer <token>"}``. (Default: ``False``).
+            ``{"Authorization": "Bearer <token>"}``. (Default: ``None``).
         default_env (Env or str, optional): Environment that the Runhouse server is started on in the cluster. Used to
             specify an isolated environment (e.g. conda env) or any setup and requirements prior to starting the Runhouse
             server. (Default: ``None``)
@@ -482,7 +483,7 @@ def sagemaker_cluster(
     ssl_keyfile: str = None,
     ssl_certfile: str = None,
     domain: str = None,
-    den_auth: bool = False,
+    den_auth: bool = None,
     default_env: Union["Env", str] = None,
     dryrun: bool = False,
     **kwargs,
@@ -538,7 +539,7 @@ def sagemaker_cluster(
         domain(str, optional): Domain name for the cluster. Relevant if enabling HTTPs on the cluster.
         den_auth (bool, optional): Whether to use Den authorization on the server. If ``True``, will validate incoming
             requests with a Runhouse token provided in the auth headers of the request with the format:
-            ``{"Authorization": "Bearer <token>"}``. (Default: ``False``).
+            ``{"Authorization": "Bearer <token>"}``. (Default: ``None``).
         default_env (Env or str, optional): Environment that the Runhouse server is started on in the cluster. Used to
             specify an isolated environment (e.g. conda env) or any setup and requirements prior to starting the Runhouse
             server. (Default: ``None``)


### PR DESCRIPTION
default value `False` for den auth in cluster factory caused alt_options to be set, so calling `cluster("name")` would sometimes result in a config mismatch and fail to reconstruct the resource correctly. set it to none in factory and correspondingly update to False in cluster init instead.
