### PR TITLE
Syntactical simplifications, remove unused vars.

### DIFF
--- a/runhouse/rns/login.py
+++ b/runhouse/rns/login.py
@@ -119,8 +119,6 @@ def login(
 
     if download_config:
         configs.download_and_save_defaults()
-        # We need to fresh the RNSClient to use the newly loaded configs
-        rns_client.refresh_defaults()
     if upload_config:
         configs.load_defaults_from_file()
         configs.upload_defaults(defaults=configs.defaults_cache)

--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -61,33 +61,7 @@ class RNSClient:
         self._index_base_folders(rns_base_folders)
         self._current_folder = None
 
-        self.refresh_defaults()
         self.session = requests.Session()
-
-    # TODO [DG] move the below into Defaults() so they never need to be refreshed?
-    def refresh_defaults(self):
-        use_local_configs = (
-            ["local"] if self._configs.get("use_local_configs", True) else []
-        )
-        use_rns = (
-            ["rns"]
-            if self._configs.get("use_rns", self._configs.token or False)
-            else []
-        )
-
-        self.save_to = use_local_configs + use_rns
-        self.load_from = use_local_configs + use_rns
-
-        if self.token is None:
-            self.save_to.pop(
-                self.save_to.index("rns")
-            ) if "rns" in self.save_to else self.save_to
-            self.load_from.pop(
-                self.load_from.index("rns")
-            ) if "rns" in self.load_from else self.load_from
-            logger.info(
-                "No auth token provided, so not using RNS API to save and load configs"
-            )
 
     @classmethod
     def find_parent_with_file(cls, dir_path, file, searched_dirs=None):

--- a/runhouse/rns/top_level_rns_fns.py
+++ b/runhouse/rns/top_level_rns_fns.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Dict, List
+from typing import Dict
 
 from runhouse.globals import configs, obj_store, rns_client
 
@@ -103,14 +103,6 @@ async def get_local_cluster_object():
         return system
 
     return "file"
-
-
-def set_save_to(save_to: List[str]):
-    rns_client.save_to = save_to
-
-
-def set_load_from(load_from: List[str]):
-    rns_client.load_from = load_from
 
 
 def save(resource, name: str = None, overwrite: bool = True, folder: str = None):

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -95,11 +95,10 @@ def validate_cluster_access(func):
             else:
                 res = func(*args, **kwargs)
         except Exception as e:
+            raise e
+        finally:
             if ctx_token:
                 obj_store.unset_ctx(ctx_token)
-            raise e
-
-        obj_store.unset_ctx(ctx_token)
         return res
 
     return wrapper

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -96,12 +96,10 @@ def context_wrapper(func):
 
             res = await func(self, *args, **kwargs)
         except Exception as e:
+            raise e
+        finally:
             if ctx_token:
                 self.unset_ctx(ctx_token)
-            raise e
-
-        if ctx_token:
-            self.unset_ctx(ctx_token)
 
         return res
 


### PR DESCRIPTION
remove `save_to` and `load_from` as they're unused. 

simplify try/except/finally blocks

first of a series of rns_client & defaults clean ups
