### PR TITLE
Support default env syncing for runhouse start/restart

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -493,6 +493,7 @@ def _start_server(
     api_server_url=None,
     default_env_name=None,
     conda_env=None,
+    from_python=None,
 ):
     ############################################
     # Build CLI commands to start the server
@@ -584,6 +585,8 @@ def _start_server(
     if default_env_flag:
         logger.info(f"Creating runtime env for conda env: {conda_env}")
         flags.append(conda_env_flag)
+
+    flags.append(" --from-python" if from_python else "")
 
     # Check if screen or nohup are available
     screen = screen and _check_if_command_exists("screen")
@@ -769,6 +772,10 @@ def restart(
     conda_env: str = typer.Option(
         None, help="Name of conda env corresponding to default env if it is a CondaEnv."
     ),
+    from_python: bool = typer.Option(
+        False,
+        help="Whether HTTP server started from inside a Python call rather than CLI.",
+    ),
 ):
     """Restart the HTTP server on the cluster."""
     if name:
@@ -796,6 +803,7 @@ def restart(
         api_server_url=api_server_url,
         default_env_name=default_env_name,
         conda_env=conda_env,
+        from_python=from_python,
     )
 
 

--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -193,6 +193,11 @@ def run_setup_command(
     """
     if not cluster:
         return run_with_logs(cmd, stream_logs=stream_logs, require_outputs=True)[:2]
+    elif cluster.on_this_cluster():
+        cmd_prefix = cluster.default_env._run_cmd
+        cmd = f"{cmd_prefix} {cmd}" if cmd_prefix else cmd
+        return run_with_logs(cmd, stream_logs=stream_logs, require_outputs=True)[:2]
+
     return cluster._run_commands_with_ssh(
         [cmd], stream_logs=stream_logs, env_vars=env_vars
     )[0]

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -846,6 +846,7 @@ class Cluster(Resource):
                 if self.default_env.config().get("resource_subtype", None) == "CondaEnv"
                 else ""
             )
+            + " --from-python"
         )
 
         if self.on_this_cluster():

--- a/runhouse/resources/packages/package.py
+++ b/runhouse/resources/packages/package.py
@@ -102,7 +102,10 @@ class Package(Resource):
                         install_target = self.to(cluster).install_target
                     else:
                         install_target = self.install_target
+
                     if not install_target.exists_in_system():
+                        return None
+                    elif "requirements.txt" not in install_target.ls(full_paths=False):
                         return None
 
                     reqs = (


### PR DESCRIPTION
note that runhouse start/restart should be called from inside the working dir on the cluster to properly install those requirements