### PR TITLE
update error handling when serializing data

### DIFF
--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -118,7 +118,10 @@ def serialize_data(data: Any, serialization: Optional[str]):
         try:
             return json.dumps(data)
         except TypeError:
-            data["error"] = str(data["error"])
+            if not isinstance(data, dict):
+                # If data is not a dict (ex: a `TypeError` object)
+                return json.dumps({"error": str(data)})
+            data["error"] = str(data)
             return json.dumps(data)
     elif serialization == "pickle":
         return pickle_b64(data)


### PR DESCRIPTION
Looks like an edge case, but seeing this when trying to call an HTTP URL of a function on a cluster: 

```  
  File "/opt/conda/lib/python3.10/site-packages/runhouse/servers/http/http_server.py", line 99, in wrapper
    raise e
  File "/opt/conda/lib/python3.10/site-packages/runhouse/servers/http/http_server.py", line 95, in wrapper
    res = await func(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/runhouse/servers/http/http_server.py", line 492, in get_call
    "error": serialize_data(e, serialization),
  File "/opt/conda/lib/python3.10/site-packages/runhouse/servers/http/http_utils.py", line 121, in serialize_data
    data["error"] = str(data["error"])
TypeError: 'TypeError' object is not subscriptable```