### PR TITLE
Fix env installations that contain a provider secret.

### DIFF
--- a/runhouse/resources/envs/env.py
+++ b/runhouse/resources/envs/env.py
@@ -135,10 +135,7 @@ class Env(Resource):
         for secret in self.secrets:
             if isinstance(secret, str):
                 secret = Secret.from_name(secret)
-            if hasattr(secret, "path") and secret.path:
-                new_secrets.append(secret.to(system=system))
-            else:
-                new_secrets.append(secret.to(system=system, env=self))
+            new_secrets.append(secret.to(system=system, env=self))
         return new_secrets
 
     def _install_reqs(self, cluster: Cluster = None, reqs: List = None):
@@ -207,7 +204,6 @@ class Env(Resource):
         system = _get_cluster_from(system)
         new_env = copy.deepcopy(self)
         new_env.reqs, new_env.working_dir = self._reqs_to(system, path, mount)
-        new_env.secrets = self._secrets_to(system)
 
         if isinstance(system, Cluster):
             key = (
@@ -225,6 +221,9 @@ class Env(Resource):
             else:
                 system.call(key, "_install_reqs", reqs=new_env.reqs)
                 system.call(key, "_run_setup_cmds", setup_cmds=new_env.setup_cmds)
+
+            # Secrets are resources that go in the env, so put them in after the env is created
+            new_env.secrets = self._secrets_to(system)
 
         return new_env
 

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -308,3 +308,9 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
 
         res = cluster.run([cmd], env=env)
         assert res[0][0] == 0
+
+    @pytest.mark.level("local")
+    def test_env_to_with_provider_secret(self, cluster):
+        os.environ["HF_TOKEN"] = "test_hf_token"
+        env = rh.env(name="hf_env", secrets=["huggingface"])
+        env.to(cluster)


### PR DESCRIPTION
In [this commit](https://github.com/run-house/runhouse/commit/63a520f6dc7a1d81fd4994ddf309ffe8164431f1#diff-b592e248986d5900342d41f0f6edc4a51527b0aa247c5bae9c24aef9dba58c45L183) we started sending all provider secrets to the env they were a part of, rather than to the base/default env. 

This requires that they are sent after the env servlet is created. This is broken in latest release (0.0.28).