### PR TITLE
Revert "Only send to Den if the `configs.token` is set."

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -75,9 +75,7 @@ class ClusterServlet:
             autostop_thread = threading.Thread(target=self.update_autostop, daemon=True)
             autostop_thread.start()
 
-        # Only send for clusters that have den_auth enabled and if we are logged in with a user's token
-        # to authenticate the request
-        if self.cluster_config.get("den_auth", False) and configs.token:
+        if self.cluster_config and self.cluster_config.get("den_auth", False):
             logger.debug("Creating send_status_info_to_den thread.")
             post_status_thread = threading.Thread(
                 target=self.send_status_info_to_den, daemon=True


### PR DESCRIPTION
Reverts run-house/runhouse#832