### PR TITLE
Newer setuptools version breaking import from `pkg_resources`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=58.0"]
+requires = ["setuptools>=58.0, < 70"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography
+python-dotenv
 fastapi
 fsspec<=2023.5.0
 opentelemetry-api
@@ -12,7 +12,10 @@ pyopenssl>=23.3.0
 ray[default] >= 2.2.0, <= 2.6.3, != 2.6.0
 rich
 sentry-sdk
+setuptools < 70.0.0
 sshfs >= 2023.1.0, <= 2023.4.1
 typer
 uvicorn
 wheel
+apispec
+httpx

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ install_requires = [
     "ray[default] >= 2.2.0, <= 2.6.3, != 2.6.0",
     "rich",
     "sentry-sdk",
+    "setuptools < 70.0.0",  # Bug in setuptools 70.0.0: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863 noqa
     "sshfs >= 2023.1.0, <= 2023.4.1",
     "typer",
     "uvicorn",


### PR DESCRIPTION
See issue: https://github.com/aws-neuron/aws-neuron-sdk/issues/893.
