### PR TITLE
Fix cluster schedulers setup

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -82,7 +82,7 @@ class ClusterServlet:
 
         # Only send for clusters that have den_auth enabled and if we are logged in with a user's token
         # to authenticate the request
-        if self.cluster_config.get("den_auth", False) and configs.token:
+        if self.cluster_config.get("den_auth", False):
             logger.debug("Creating send_status_info_to_den thread.")
             post_status_thread = threading.Thread(
                 target=self.send_status_info_to_den, daemon=True


### PR DESCRIPTION
When the cluster is inited for the first time, when we check config.token we get false, because the config.yaml is set after the cluster servlet is up. 
Therefore this check is preventing from the schedulers to run, and we were forced to restart the server.
The config.yaml should be set properly later, so if there will be a problem with the config.token, the cluster schedulers will raise an error.
