### PR TITLE
Handle string system in package .to

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -604,7 +604,7 @@ def _start_server(
         flags.append(default_env_flag)
 
     conda_env_flag = f" --conda-env {conda_env}" if conda_env else ""
-    if default_env_flag:
+    if conda_env_flag:
         logger.info(f"Creating runtime env for conda env: {conda_env}")
         flags.append(conda_env_flag)
 

--- a/runhouse/resources/packages/package.py
+++ b/runhouse/resources/packages/package.py
@@ -162,6 +162,7 @@ class Package(Resource):
                     path = self.install_target.path
                 else:
                     path = self.to(cluster).install_target.path
+                    install_cmd = self._install_cmd(cluster=cluster)
 
                 if not path:
                     return

--- a/runhouse/resources/packages/package.py
+++ b/runhouse/resources/packages/package.py
@@ -336,8 +336,21 @@ class Package(Resource):
                 "`install_target` must be a Folder in order to copy the package to a system."
             )
 
+        if (
+            isinstance(self.install_target.system, str)
+            and not self.install_target.system == "file"
+        ):
+            self.install_target.system = _get_cluster_from(self.install_target.system)
+
+        install_system_name = (
+            self.install_target.system.name
+            if isinstance(self.install_target.system, Cluster)
+            else self.install_target.system
+        )
         system = _get_cluster_from(system)
-        if self.install_target.system == system:
+        system_name = system.name if isinstance(system, Cluster) else system
+
+        if system_name == install_system_name:
             return self
 
         if isinstance(system, Resource):

--- a/runhouse/rns/defaults.py
+++ b/runhouse/rns/defaults.py
@@ -236,7 +236,9 @@ class Defaults:
 
     def set_nested(self, key: str, value: Any, config_path: Optional[str] = None):
         """Set a config key that has multiple key/value pairs"""
-        self.defaults_cache.setdefault(key, {}).update(value)
+        if not self.defaults_cache.get(key):
+            self.defaults_cache.setdefault(key, {})
+        self.defaults_cache[key].update(value)
         self.save_defaults(config_path=config_path)
 
     def set_many(self, key_value_pairs: Dict, config_path: Optional[str] = None):


### PR DESCRIPTION
default env introduced non-expanded system objects to avoid infinitely recursive subconfigs. handle this when calling package.to()
