### PR TITLE
Clarify setup in docs and den quick start

### DIFF
--- a/docs/tutorials/quick-start-den.rst
+++ b/docs/tutorials/quick-start-den.rst
@@ -1,23 +1,30 @@
 Den Quick Start
 ===============
 
-.. raw:: html
-
-    <p><a href="https://colab.research.google.com/github/run-house/notebooks/blob/stable/docs/quick-start-den.ipynb">
-    <img height="20px" width="117px" src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a></p>
-
 `Runhouse Den <https://www.run.house/dashboard>`__ lets you manage and
 track your infra, services, and resources (clusters, functions, secrets,
-etc). These resources can be easily reloaded from any environment, and
-ready to be used without additional setup, or even shared with another
-user or teammate. Then, in the Web UI, access, visualize, and manage
-your resources, along with version history.
+etc). These resources can be easily reloaded from any environment, are
+ready to be used without additional setup, and can even be shared with
+another user or teammate. Then, in the Den Web UI, you can access,
+visualize, and manage your resources along with version history.
+
+Installing Runhouse
+-------------------
+
+To use Runhouse to launch on-demand clusters, run the following
+installation command. This includes
+`SkyPilot <https://github.com/skypilot-org/skypilot>`__, which is used
+for launching fresh VMs through various cloud providers.
+
+.. code:: ipython3
+
+    !pip install "runhouse[sky]"
 
 Account Creation & Login
 ------------------------
 
 You can create an account on the `run.house <https://www.run.house>`__
-website, or by calling the login command in Python or CLI.
+website or by calling the login command in Python or CLI.
 
 To login on your dev environment, call ``rh.login()`` in Python or
 ``runhouse login`` in CLI.
@@ -43,7 +50,9 @@ Saving
 
 Let’s start by constructing some runhouse resources that we’d like to
 save down. These resources were first defined in our `Cloud Quick Start
-Tutorial <https://www.run.house/docs/tutorials/quick-start-cloud>`__.
+Tutorial <https://www.run.house/docs/tutorials/quick-start-cloud>`__. As
+a reminder, you may need to confirm that your cloud credentials are
+properly configured by running ``sky check``.
 
 .. code:: ipython3
 
@@ -52,29 +61,6 @@ Tutorial <https://www.run.house/docs/tutorials/quick-start-cloud>`__.
         instance_type="CPU:2+",
         provider="aws"
     )
-
-
-
-.. parsed-literal::
-    :class: code-output
-
-    Output()
-
-
-
-.. raw:: html
-
-    <pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"></pre>
-
-
-
-
-.. raw:: html
-
-    <pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">
-    </pre>
-
-
 
 .. code:: ipython3
 
@@ -86,7 +72,6 @@ Tutorial <https://www.run.house/docs/tutorials/quick-start-cloud>`__.
 
 
 .. parsed-literal::
-    :class: code-output
 
     INFO | 2024-05-16 03:51:58.483032 | Because this function is defined in a notebook, writing it out to /Users/donny/code/notebooks/docs/get_platform_fn.py to make it importable. Please make sure the function does not rely on any local variables, including imports (which should be moved inside the function body). This restriction does not apply to functions defined in normal Python files.
     INFO | 2024-05-16 03:51:58.493093 | Port 32300 is already in use. Trying next port.
@@ -98,7 +83,8 @@ Tutorial <https://www.run.house/docs/tutorials/quick-start-cloud>`__.
     INFO | 2024-05-16 03:52:01.252665 | Sending module get_platform of type <class 'runhouse.resources.functions.function.Function'> to rh-cluster
 
 
-You can save the resources we created above with:
+You can save the resources we created above to your Den account with the
+``save`` method:
 
 .. code:: ipython3
 
@@ -114,15 +100,20 @@ notebook, you can jump into your terminal, call ``runhouse login``, and
 then reconstruct and run the function on the cluster with the following
 Python script:
 
-::
+.. code:: python
 
-   """
    import runhouse as rh
 
    if __name__ == "__main__":
        reloaded_fn = rh.function(name="get_platform")
        print(reloaded_fn())
-   """
+
+The ``name`` used to reload the function is the method name by default.
+You can customize a function name using the following syntax:
+
+.. code:: python
+
+   remote_get_platform = rh.function(fn=get_platform, name="my_function").to(cluster)
 
 Sharing
 -------
@@ -135,7 +126,7 @@ which includes your username (``/your_username/get_platform``).
 
 .. code:: ipython3
 
-    remote_fn.share(
+    remote_get_platform.share(
         users=["teammate1@email.com"],
         access_level="write",
     )
@@ -145,7 +136,7 @@ Web UI
 
 After saving your resources, you can log in and see them on your `Den
 dashboard <https://www.run.house/dashboard>`__, labeled as
-``<username>/rh-cluster`` and ``<username>/get_platform``.
+``/<username>/rh-cluster`` and ``/<username>/get_platform``.
 
 Clicking into the resource provides information about your resource. You
 can view the resource metadata, previous versions, and activity, or add

--- a/examples/langchain-rag-ec2/README.md
+++ b/examples/langchain-rag-ec2/README.md
@@ -22,7 +22,7 @@ $ aws configure
 $ sky check
 ```
 
-We'll be hitting Open AI's API, so we need to set up our OpenAI API key:
+We'll be hitting OpenAI's API, so we need to set up our OpenAI API key:
 ```shell
 $ export OPENAI_API_KEY=<your openai key>
 ```

--- a/examples/langchain-rag-ec2/langchain_rag.py
+++ b/examples/langchain-rag-ec2/langchain_rag.py
@@ -12,7 +12,7 @@
 # ```
 # Install Runhouse, the only library needed to run this script locally:
 # ```shell
-# $ pip install "runhouse[aws]"
+# $ pip install runhouse[aws]
 # ```
 
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to
@@ -22,7 +22,7 @@
 # $ sky check
 # ```
 
-# We'll be hitting Open AI's API, so we need to set up our OpenAI API key:
+# We'll be hitting OpenAI's API, so we need to set up our OpenAI API key:
 # ```shell
 # $ export OPENAI_API_KEY=<your openai key>
 # ```

--- a/examples/llama2-13b-ec2/llama2_ec2.py
+++ b/examples/llama2-13b-ec2/llama2_ec2.py
@@ -1,8 +1,10 @@
-# # Deploy Llama2 13B Chat Model Inference on AWS EC2
+# # Deploy Llama 2 13B Chat Model Inference on AWS EC2
 
 # This example demonstrates how to deploy a
-# [LLama2 13B model from Hugging Face](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf)
+# [LLama 2 13B model from Hugging Face](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf)
 # on AWS EC2 using Runhouse.
+#
+# Make sure to sign the waiver on the model page so that you can access it.
 #
 # ## Setup credentials and dependencies
 #
@@ -11,9 +13,9 @@
 # $ conda create -n llama-demo-apps python=3.8
 # $ conda activate llama-demo-apps
 # ```
-# Install the few required dependencies:
+# Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws] torch
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to
@@ -22,7 +24,7 @@
 # $ aws configure
 # $ sky check
 # ```
-# We'll be downloading the Llama2 model from Hugging Face, so we need to set up our Hugging Face token:
+# We'll be downloading the Llama 2 model from Hugging Face, so we need to set up our Hugging Face token:
 # ```shell
 # $ export HF_TOKEN=<your huggingface token>
 # ```
@@ -106,7 +108,7 @@ if __name__ == "__main__":
             "safetensors>=0.3.1",
             "scipy",
         ],
-        secrets=["huggingface"],  # Needed to download Llama2
+        secrets=["huggingface"],  # Needed to download Llama 2
         name="llama2inference",
         working_dir="./",
     )

--- a/examples/llama2-fine-tuning-with-lora/llama2_fine_tuning.py
+++ b/examples/llama2-fine-tuning-with-lora/llama2_fine_tuning.py
@@ -1,15 +1,15 @@
-# # Fine Tune Llama2 with LoRA on AWS EC2
+# # Fine Tune Llama 2 with LoRA on AWS EC2
 
 # This example demonstrates fine tune a model using
-# [Llama2](https://huggingface.co/NousResearch/Llama-2-7b-chat-hf) and
+# [Llama 2](https://huggingface.co/NousResearch/Llama-2-7b-chat-hf) and
 # [LoRA](https://huggingface.co/docs/peft/main/en/conceptual_guides/lora) on AWS EC2 using Runhouse.
 #
 # ## Setup credentials and dependencies
 #
 # ```
-# Install the few required dependencies:
+# Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws]
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to

--- a/examples/llama2-with-tgi-aws-inferentia2/tgi_llama2_inferentia.py
+++ b/examples/llama2-with-tgi-aws-inferentia2/tgi_llama2_inferentia.py
@@ -1,5 +1,5 @@
-# # Deploy Llama2 7B Model with TGI on AWS Inferentia2
-# This example demonstrates how to deploy Llama2 7B with
+# # Deploy Llama 2 7B Model with TGI on AWS Inferentia2
+# This example demonstrates how to deploy Llama 2 7B with
 # [TGI](https://github.com/huggingface/optimum-neuron/tree/main/text-generation-inference) on AWS Inferentia2
 # using Runhouse, specifically with the [AWS Neuron SDK](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/).
 # It will launch and set up the hardware, deploy the TGI container, and show multiple ways to run inference with
@@ -8,10 +8,10 @@
 # ## Setup credentials and dependencies
 # Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws]
 # ```
 #
-# We'll be using [Llama2](https://huggingface.co/aws-neuron/Llama-2-7b-hf-neuron-budget), which is a gated
+# We'll be using [Llama 2](https://huggingface.co/aws-neuron/Llama-2-7b-hf-neuron-budget), which is a gated
 # model and requires a Hugging Face token in order to access it.
 #
 # To set up your Hugging Face token, run the following command in your local terminal:

--- a/examples/llama2-with-tgi-ec2/tgi_llama_ec2.py
+++ b/examples/llama2-with-tgi-ec2/tgi_llama_ec2.py
@@ -6,7 +6,7 @@
 # ## Setup credentials and dependencies
 # Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws]
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to make

--- a/examples/llama3-8b-ec2/llama3_ec2.py
+++ b/examples/llama3-8b-ec2/llama3_ec2.py
@@ -1,7 +1,7 @@
-# # Deploy Llama3 8B Chat Model Inference on AWS EC2
+# # Deploy Llama 3 8B Chat Model Inference on AWS EC2
 
 # This example demonstrates how to deploy a
-# [LLama3 8B model from Hugging Face](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)
+# [LLama 3 8B model from Hugging Face](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)
 # on AWS EC2 using Runhouse.
 #
 # Make sure to sign the waiver on the model page so that you can access it.
@@ -10,12 +10,12 @@
 #
 # Optionally, set up a virtual environment:
 # ```shell
-# $ conda create -n llama3-rh
+# $ conda create -n llama3-rh python=3.9.15
 # $ conda activate llama3-rh
 # ```
-# Install the few required dependencies:
+# Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws] torch
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to
@@ -24,7 +24,7 @@
 # $ aws configure
 # $ sky check
 # ```
-# We'll be downloading the Llama3 model from Hugging Face, so we need to set up our Hugging Face token:
+# We'll be downloading the Llama 3 model from Hugging Face, so we need to set up our Hugging Face token:
 # ```shell
 # $ export HF_TOKEN=<your huggingface token>
 # ```
@@ -125,7 +125,7 @@ if __name__ == "__main__":
             "safetensors",
             "scipy",
         ],
-        secrets=["huggingface"],  # Needed to download Llama3 from HuggingFace
+        secrets=["huggingface"],  # Needed to download Llama 3 from HuggingFace
         name="llama3inference",
         working_dir="./",
     )

--- a/examples/mistral-aws-inferentia2/mistral_inferentia.py
+++ b/examples/mistral-aws-inferentia2/mistral_inferentia.py
@@ -6,7 +6,7 @@
 # ## Setup credentials and dependencies
 # Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws]
 # ```
 #
 # We'll be launching an AWS Inferentia instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we

--- a/examples/mistral-with-tgi-ec2/tgi_mistral_ec2.py
+++ b/examples/mistral-with-tgi-ec2/tgi_mistral_ec2.py
@@ -9,7 +9,7 @@
 # ## Setup credentials and dependencies
 # Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install openai runhouse[aws]
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to make

--- a/examples/parallel-hf-embedding-ec2/parallel_hf_embedding_ec2.py
+++ b/examples/parallel-hf-embedding-ec2/parallel_hf_embedding_ec2.py
@@ -10,11 +10,10 @@
 # ```shell
 # $ conda create -n parallel-embed python=3.9.15
 # $ conda activate parallel-embed
-#
 # ```
-# Install the few required dependencies:
+# Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws] bs4
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to

--- a/examples/stable-diffusion-xl-aws-inferentia2/inf2_sdxl.py
+++ b/examples/stable-diffusion-xl-aws-inferentia2/inf2_sdxl.py
@@ -15,9 +15,9 @@
 # $ conda create -n rh-inf2 python=3.9.15
 # $ conda activate rh-inf2
 # ```
-# Install the few required dependencies:
+# Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws] Pillow
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to
@@ -26,7 +26,7 @@
 # $ aws configure
 # $ sky check
 # ```
-# We'll be downloading the Llama2 model from Hugging Face, so we need to set up our Hugging Face token:
+# We'll be downloading the Stable Diffusion model from Hugging Face, so we need to set up our Hugging Face token:
 # ```shell
 # $ export HF_TOKEN=<your huggingface token>
 # ```
@@ -179,7 +179,7 @@ if __name__ == "__main__":
             "optimum-neuron==0.0.20",
             "diffusers==0.27.2",
         ],
-        secrets=["huggingface"],  # Needed to download Llama2
+        secrets=["huggingface"],  # Needed to download model
         env_vars={"NEURON_RT_NUM_CORES": "2"},
     )
 

--- a/examples/stable-diffusion-xl-ec2/sdxl.py
+++ b/examples/stable-diffusion-xl-ec2/sdxl.py
@@ -11,9 +11,9 @@
 # $ conda create -n rh-sdxl python=3.9.15
 # $ conda activate rh-sdxl
 # ```
-# Install the few required dependencies:
+# Install the required dependencies:
 # ```shell
-# $ pip install -r requirements.txt
+# $ pip install runhouse[aws] Pillow
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to
@@ -22,7 +22,7 @@
 # $ aws configure
 # $ sky check
 # ```
-# We'll be downloading the Llama2 model from Hugging Face, so we need to set up our Hugging Face token:
+# We'll be downloading the Stable Diffusion model from Hugging Face, so we need to set up our Hugging Face token:
 # ```shell
 # $ export HF_TOKEN=<your huggingface token>
 # ```
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             "transformers==4.31.0",
             "accelerate==0.21.0",
         ],
-        secrets=["huggingface"],  # Needed to download Llama2
+        secrets=["huggingface"],  # Needed to download model
         env_vars={"NEURON_RT_NUM_CORES": "2"},
     )
 


### PR DESCRIPTION
Walked through the Llama 3 example and the Den Quick Start and caught a few things, notably:
- Missing python for conda setup
- Showing explicit pip install packages, in case you are on /examples and not in the repo
- Typos in model names
- Removed some empty code blocks on Den Quick Start + fixed an incorrect function variable name