### PR TITLE
[old] Fix cluster factory bug with den_auth clusters not being saved.

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -1621,6 +1621,9 @@ class Cluster(Resource):
                 f"{RESERVED_SYSTEM_NAMES}."
             )
 
+        if self.den_auth:
+            self.save()
+
     def share(
         self,
         users: Union[str, List[str]] = None,

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -191,9 +191,6 @@ def cluster(
     )
     c.set_connection_defaults(**kwargs)
 
-    if den_auth:
-        c.save()
-
     return c
 
 
@@ -460,9 +457,6 @@ def ondemand_cluster(
     )
     c.set_connection_defaults()
 
-    if den_auth:
-        c.save()
-
     return c
 
 
@@ -662,8 +656,5 @@ def sagemaker_cluster(
         **kwargs,
     )
     sm.set_connection_defaults()
-
-    if den_auth:
-        sm.save()
 
     return sm

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -241,6 +241,9 @@ class OnDemandCluster(Cluster):
                         f"default: {DEFAULT_HTTP_PORT}."
                     )
 
+        if self.den_auth:
+            self.save()
+
     # ----------------- Launch/Lifecycle Methods -----------------
 
     def is_up(self) -> bool:

--- a/runhouse/resources/hardware/sagemaker/sagemaker_cluster.py
+++ b/runhouse/resources/hardware/sagemaker/sagemaker_cluster.py
@@ -395,6 +395,9 @@ class SageMakerCluster(Cluster):
                 "SageMaker Cluster currently requires a server host of `localhost` or `127.0.0.1`"
             )
 
+        if self.den_auth:
+            self.save()
+
     # -------------------------------------------------------
     # Cluster State & Lifecycle Methods
     # -------------------------------------------------------


### PR DESCRIPTION
Linear bug here: [RH-269 : Creating a `den_auth=True` cluster, bring it down, and then reusing it breaks](https://linear.app/runhouse/issue/RH-269/creating-a-den-auth=true-cluster-bring-it-down-and-then-reusing-it)

Fixed in this test.