### PR TITLE
Remove resource conversion check for secrets

### DIFF
--- a/tests/test_resources/test_secrets/test_secret.py
+++ b/tests/test_resources/test_secrets/test_secret.py
@@ -1,8 +1,6 @@
-import json
 import os
 
 import pytest
-import requests
 
 import runhouse as rh
 
@@ -211,24 +209,3 @@ class TestSecret(tests.test_resources.test_resource.TestResource):
         else:
             cluster.sync_secrets([secret])
             assert cluster.get(secret.name)
-
-    @pytest.mark.level("unit")
-    def test_convert_secret_resource(self, test_secret):
-        from runhouse.rns.login import _convert_secrets_resource
-
-        name = test_secret.name
-        values = test_secret.values
-
-        # original format that secrets were saved into vault
-        requests.put(
-            f"{rns_client.api_server_url}/{rh.Secret.USER_ENDPOINT}/{name}",
-            data=json.dumps(values),
-            headers=rns_client.request_headers(),
-        )
-
-        _convert_secrets_resource([name], headers=rns_client.request_headers())
-        assert rh.secret(name=name)
-
-        rh.secret(name=name).delete()
-        with pytest.raises(Exception):
-            rh.secret(name=name)


### PR DESCRIPTION
added for backwards compatibility 6 months ago. secrets should already be converted to resources by now for any semi active user
