### PR TITLE
Fix bug in starting example code block

### DIFF
--- a/examples/llama2-fine-tuning-with-lora/llama2_fine_tuning.py
+++ b/examples/llama2-fine-tuning-with-lora/llama2_fine_tuning.py
@@ -6,7 +6,6 @@
 #
 # ## Setup credentials and dependencies
 #
-# ```
 # Install the required dependencies:
 # ```shell
 # $ pip install runhouse[aws]


### PR DESCRIPTION
Noticed an extra `"```"` causing the fine tuning example to render incorrectly. Quick fix.