### PR TITLE
Handle login error missing private_key key

### DIFF
--- a/runhouse/resources/secrets/provider_secrets/ssh_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/ssh_secret.py
@@ -87,10 +87,14 @@ class SSHSecret(ProviderSecret):
             return self
 
         priv_key_path.parent.mkdir(parents=True, exist_ok=True)
-        priv_key_path.write_text(values["private_key"])
-        priv_key_path.chmod(0o600)
-        pub_key_path.write_text(values["public_key"])
-        pub_key_path.chmod(0o600)
+        private_key = values.get("private_key")
+        if private_key is not None:
+            priv_key_path.write_text(private_key)
+            priv_key_path.chmod(0o600)
+        public_key = values.get("public_key")
+        if public_key is not None:
+            pub_key_path.write_text(public_key)
+            pub_key_path.chmod(0o600)
 
         new_secret = copy.deepcopy(self)
         new_secret._values = None


### PR DESCRIPTION
Handling secret syncing more gracefully to resolve this error from running `runhouse login`
```
Retrieve your token 🔑 here to use 🏃 🏠 Runhouse for secrets and artifact management: https://run.house/account#token
Token: 
Download your Runhouse config to your local .rh folder? [Y/n]: y
Download secrets from Vault to your local Runhouse environment? [y/N]: y
Upload your local .rh config to Runhouse? [y/N]: y
Upload your local enabled provider secrets to Vault? [y/N]: y
INFO | 2024-06-07 16:13:03.070479 | Loaded Runhouse config from /Users/matthewkandler/.rh/config.yaml
yINFO | 2024-06-07 16:13:03.655838 | Saving config for ssh-sky-key to Den
INFO | 2024-06-07 16:13:03.784929 | Saving secrets for ssh-sky-key to Vault
INFO | 2024-06-07 16:13:04.464916 | Loading down secrets for ssh-sky-key into ~/.ssh
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matthewkandler/miniconda3/envs/llama3-rh/lib/python3.9/site-packages/runhouse/rns/login.py", line 142, in login
    _login_download_secrets(from_cli=from_cli)
  File "/Users/matthewkandler/miniconda3/envs/llama3-rh/lib/python3.9/site-packages/runhouse/rns/login.py", line 165, in _login_download_secrets
    secret.write(path=download_path)
  File "/Users/matthewkandler/miniconda3/envs/llama3-rh/lib/python3.9/site-packages/runhouse/resources/secrets/provider_secrets/provider_secret.py", line 128, in write
    return self._write_to_file(path, values=self.values, overwrite=overwrite)
  File "/Users/matthewkandler/miniconda3/envs/llama3-rh/lib/python3.9/site-packages/runhouse/resources/secrets/provider_secrets/ssh_secret.py", line 90, in _write_to_file
    priv_key_path.write_text(values["private_key"])
KeyError: 'private_key'
```