### PR TITLE
[breaking] Change `locate_working_dir` to be breadth-first.

### DIFF
--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -10,6 +10,7 @@ import yaml
 from runhouse.constants import CONDA_INSTALL_CMDS, EMPTY_DEFAULT_ENV_NAME
 from runhouse.globals import rns_client
 from runhouse.resources.resource import Resource
+from runhouse.utils import locate_working_dir
 
 
 def _process_reqs(reqs):
@@ -26,10 +27,7 @@ def _process_reqs(reqs):
             else:
                 # if package refers to a local path package
                 path = Path(package.split(":")[-1]).expanduser()
-                if (
-                    path.is_absolute()
-                    or (rns_client.locate_working_dir() / path).exists()
-                ):
+                if path.is_absolute() or (locate_working_dir() / path).exists():
                     package = Package.from_string(package)
         elif isinstance(package, dict):
             package = Package.from_config(package)

--- a/runhouse/resources/folders/folder.py
+++ b/runhouse/resources/folders/folder.py
@@ -17,6 +17,7 @@ from runhouse.resources.hardware import _current_cluster, _get_cluster_from, Clu
 from runhouse.resources.resource import Resource
 from runhouse.rns.top_level_rns_fns import exists
 from runhouse.rns.utils.api import generate_uuid
+from runhouse.utils import locate_working_dir
 
 fsspec.register_implementation("ssh", sshfs.SSHFileSystem)
 # SSHFileSystem is not yet builtin.
@@ -79,7 +80,7 @@ class Folder(Resource):
             if system != "file"
             else path
             if Path(path).expanduser().is_absolute()
-            else str(Path(rns_client.locate_working_dir()) / path)
+            else str(Path(locate_working_dir()) / path)
         )
         self.data_config = data_config or {}
 
@@ -619,7 +620,7 @@ class Folder(Resource):
 
     @staticmethod
     def _path_relative_to_rh_workdir(path):
-        rh_workdir = Path(rns_client.locate_working_dir())
+        rh_workdir = Path(locate_working_dir())
         try:
             return str(Path(path).relative_to(rh_workdir))
         except ValueError:

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -18,6 +18,7 @@ from runhouse.resources.envs.utils import run_with_logs
 
 from runhouse.rns.utils.api import ResourceAccess, ResourceVisibility
 from runhouse.servers.http.certs import TLSCertConfig
+from runhouse.utils import locate_working_dir
 
 # Filter out DeprecationWarnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -1553,7 +1554,7 @@ class Cluster(Resource):
                 from runhouse.resources.packages.package import Package
 
                 if sync_package_on_close == "./":
-                    sync_package_on_close = rns_client.locate_working_dir()
+                    sync_package_on_close = locate_working_dir()
                 pkg = Package.from_string("local:" + sync_package_on_close)
                 self._rsync(source=f"~/{pkg.name}", dest=pkg.local_path, up=False)
             if not persist:

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -28,6 +28,7 @@ from runhouse.rns.utils.api import ResourceAccess, ResourceVisibility
 from runhouse.rns.utils.names import _generate_default_name
 from runhouse.servers.http import HTTPClient
 from runhouse.servers.http.http_utils import CallParams
+from runhouse.utils import locate_working_dir
 
 logger = logging.getLogger(__name__)
 
@@ -1052,7 +1053,7 @@ class Module(Resource):
                     local_path = (
                         Path(req).expanduser()
                         if Path(req).expanduser().is_absolute()
-                        else Path(rns_client.locate_working_dir()) / req
+                        else Path(locate_working_dir()) / req
                     )
 
             if local_path:

--- a/runhouse/resources/packages/package.py
+++ b/runhouse/resources/packages/package.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-from runhouse import globals
 from runhouse.resources.envs.utils import install_conda, run_setup_command
 from runhouse.resources.folders import Folder, folder
 from runhouse.resources.hardware.cluster import Cluster
@@ -14,6 +13,8 @@ from runhouse.resources.hardware.utils import (
     detect_cuda_version_or_cpu,
 )
 from runhouse.resources.resource import Resource
+from runhouse.utils import locate_working_dir
+
 
 INSTALL_METHODS = {"local", "reqs", "pip", "conda"}
 
@@ -421,7 +422,7 @@ class Package(Resource):
         abs_target = (
             Path(rel_target).expanduser()
             if Path(rel_target).expanduser().is_absolute()
-            else Path(globals.rns_client.locate_working_dir()) / rel_target
+            else Path(locate_working_dir()) / rel_target
         )
         if abs_target.exists():
             target = Folder(

--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -20,6 +20,7 @@ from runhouse.rns.utils.api import (
     remove_null_values_from_dict,
     ResourceAccess,
 )
+from runhouse.utils import locate_working_dir
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ class RNSClient:
         self._configs = configs
         self._prev_folders = []
 
-        self.rh_directory = str(Path(self.locate_working_dir()) / "rh")
+        self.rh_directory = str(Path(locate_working_dir()) / "rh")
         self.rh_builtins_directory = str(
             Path(importlib.util.find_spec("runhouse").origin).parent / "builtins"
         )
@@ -75,48 +76,6 @@ class RNSClient:
         self._current_folder = None
 
         self.session = requests.Session()
-
-    @classmethod
-    def find_parent_with_file(cls, dir_path, file, searched_dirs=None):
-        if Path(dir_path) == Path.home() or dir_path == Path("/"):
-            return None
-        if Path(dir_path, file).exists():
-            return str(dir_path)
-        else:
-            if searched_dirs is None:
-                searched_dirs = {
-                    dir_path,
-                }
-            else:
-                searched_dirs.add(dir_path)
-            parent_path = Path(dir_path).parent
-            if parent_path in searched_dirs:
-                return None
-            return cls.find_parent_with_file(
-                parent_path, file, searched_dirs=searched_dirs
-            )
-
-    @classmethod
-    def locate_working_dir(cls, cwd=os.getcwd()):
-        # Search for working_dir by looking up directory tree, in the following order:
-        # 1. Upward directory with rh/ subdirectory
-        # 2. Root git directory
-        # 3. Upward directory with requirements.txt
-        # 4. User's cwd
-
-        for search_target in [
-            ".git",
-            "setup.py",
-            "setup.cfg",
-            "pyproject.toml",
-            "rh",
-            "requirements.txt",
-        ]:
-            dir_with_target = cls.find_parent_with_file(cwd, search_target)
-            if dir_with_target is not None:
-                return dir_with_target
-        else:
-            return cwd
 
     @property
     def default_folder(self):

--- a/tests/test_den/test_rns.py
+++ b/tests/test_den/test_rns.py
@@ -3,28 +3,29 @@ from pathlib import Path
 import pytest
 
 import runhouse as rh
-from runhouse.globals import rns_client
+from runhouse.utils import locate_working_dir
 
 
+@pytest.mark.level("unit")
 def test_find_working_dir(tmp_path):
     starting_dir = Path(tmp_path, "subdir/subdir/subdir/subdir")
-    d = rns_client.locate_working_dir(cwd=str(starting_dir))
+    d = locate_working_dir(str(starting_dir))
     assert d in str(starting_dir)
 
     Path(tmp_path, "subdir/rh").mkdir(parents=True)
-    d = rns_client.locate_working_dir(str(starting_dir))
+    d = locate_working_dir(str(starting_dir))
     assert d == str(Path(tmp_path, "subdir"))
 
     Path(tmp_path, "subdir/rh").rmdir()
 
     Path(tmp_path, "subdir/subdir/.git").mkdir(exist_ok=True, parents=True)
-    d = rns_client.locate_working_dir(str(starting_dir))
+    d = locate_working_dir(str(starting_dir))
     assert d in str(Path(tmp_path, "subdir/subdir"))
 
     Path(tmp_path, "subdir/subdir/.git").rmdir()
 
     Path(tmp_path, "subdir/subdir/requirements.txt").write_text("....")
-    d = rns_client.locate_working_dir(str(starting_dir))
+    d = locate_working_dir(str(starting_dir))
     assert d in str(Path(tmp_path, "subdir/subdir"))
 
 


### PR DESCRIPTION
* Enabled unit test for search
* Moved these search functions out of `RNSClient` into normal helpers
* Changed to first breadth first for normal things indicating "projects" and then for the `rh` directory, which could be put... kind of anywhere. We should probably rid ourselves of depending on this.