### PR TITLE
Remove defaulting `working_dir` to `./`.

### DIFF
--- a/runhouse/resources/envs/env_factory.py
+++ b/runhouse/resources/envs/env_factory.py
@@ -34,7 +34,7 @@ def env(
         env_vars (Dict or str): Dictionary of environment variables, or relative path to .env file containing
             environment variables. (Default: {})
         working_dir (str or Path): Working directory of the environment, to be loaded onto the system.
-            (Default: "./")
+            (Default: None)
         compute (Dict): Logical compute resources to be used by this environment, passed through to the
             cluster scheduler (generally Ray). Only use this if you know what you're doing.
             Example: ``{"cpus": 1, "gpus": 1}``. (Default: {})
@@ -62,8 +62,6 @@ def env(
         [reqs, conda_env, setup_cmds, env_vars, secrets, working_dir, compute]
     ):
         return Env.from_name(name, dryrun)
-
-    working_dir = working_dir or "./"
 
     reqs = _process_reqs(reqs or [])
     conda_yaml = _get_conda_yaml(conda_env)
@@ -99,7 +97,7 @@ def conda_env(
     name: Optional[str] = None,
     setup_cmds: List[str] = None,
     env_vars: Optional[Dict] = {},
-    working_dir: Optional[Union[str, Path]] = "./",
+    working_dir: Optional[Union[str, Path]] = None,
     secrets: List[Union[str, "Secret"]] = [],
     compute: Optional[Dict] = {},
     dryrun: bool = False,
@@ -116,7 +114,7 @@ def conda_env(
         env_vars (Dict or str): Dictionary of environment variables, or relative path to .env file containing
             environment variables. (Default: {})
         working_dir (str or Path): Working directory of the environment, to be loaded onto the system.
-            (Default: "./")
+            (Default: None)
         compute (Dict): Logical compute resources to be used by this environment, passed through to the
             cluster scheduler (generally Ray). Only use this if you know what you're doing.
             Example: ``{"cpus": 1, "gpus": 1}``. (Default: {})

--- a/runhouse/resources/envs/utils.py
+++ b/runhouse/resources/envs/utils.py
@@ -51,7 +51,7 @@ def _get_env_from(env):
     if isinstance(env, List):
         if len(env) == 0:
             return Env(reqs=env, working_dir=None)
-        return Env(reqs=env, working_dir="./")
+        return Env(reqs=env)
     elif isinstance(env, Dict):
         return Env.from_config(env)
     elif isinstance(env, str) and EMPTY_DEFAULT_ENV_NAME not in env:

--- a/runhouse/resources/functions/aws_lambda.py
+++ b/runhouse/resources/functions/aws_lambda.py
@@ -310,7 +310,6 @@ class LambdaFunction(Function):
             env = Env(
                 reqs=[],
                 env_vars={"HOME": cls.HOME_DIR},
-                working_dir="./",
             )
 
         if isinstance(env, Env) and "HOME" not in env.env_vars.keys():

--- a/runhouse/resources/functions/function_factory.py
+++ b/runhouse/resources/functions/function_factory.py
@@ -66,7 +66,7 @@ def function(
         )
 
     if not isinstance(env, Env):
-        env = _get_env_from(env) or Env(working_dir="./")
+        env = _get_env_from(env) or Env()
 
     fn_pointers = None
     if callable(fn):

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -80,12 +80,9 @@ class Module(Resource):
 
             # When creating a module as a subclass of rh.Module, we need to collect pointers here
             if not self._env:
-                self._env = (
-                    self._system.default_env if self._system else Env(working_dir="./")
-                )
+                self._env = self._system.default_env if self._system else Env()
             # If we're creating pointers, we're also local to the class definition and package, so it should be
             # set as the workdir (we can do this in a fancier way later)
-            self._env.working_dir = self._env.working_dir or "./"
             pointers, req_to_add = Module._extract_pointers(
                 self.__class__, reqs=self._env.reqs
             )
@@ -1332,8 +1329,6 @@ def module(
             env = _get_env_from(_default_env_if_on_cluster())
         if not env:
             env = Env()
-
-        env.working_dir = env.working_dir or "./"
 
     cls_pointers, working_dir_to_add = Module._extract_pointers(cls, env.reqs)
     if working_dir_to_add is not None:

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -209,9 +209,9 @@ class HTTPServer:
         )
 
         if default_env_name == EMPTY_DEFAULT_ENV_NAME:
-            from runhouse import env
+            from runhouse.resources.envs import Env
 
-            default_env = env(name=default_env_name, working_dir="./")
+            default_env = Env(name=default_env_name)
             data = (default_env.config(condensed=False), {}, False)
             obj_store.put_resource(
                 serialized_data=data, serialization=None, env_name=default_env_name

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -245,9 +245,9 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
     @pytest.mark.level("local")
     @pytest.mark.clustertest
     def test_cluster_delete_env(self, cluster):
-        env1 = rh.env(reqs=[], working_dir="./", name="env1").to(cluster)
-        env2 = rh.env(reqs=[], working_dir="./", name="env2").to(cluster)
-        env3 = rh.env(reqs=[], working_dir="./", name="env3")
+        env1 = rh.env(reqs=["pytest"], name="env1").to(cluster)
+        env2 = rh.env(reqs=["pytest"], name="env2").to(cluster)
+        env3 = rh.env(reqs=["pytest"], name="env3")
 
         cluster.put("k1", "v1", env=env1.name)
         cluster.put("k2", "v2", env=env2.name)

--- a/tests/test_resources/test_envs/test_env.py
+++ b/tests/test_resources/test_envs/test_env.py
@@ -114,9 +114,6 @@ class TestEnv(tests.test_resources.test_resource.TestResource):
             assert isinstance(env.conda_yaml, Dict)
             assert set(["dependencies", "name"]).issubset(set(env.conda_yaml.keys()))
 
-        if "working_dir" not in args:
-            assert env.working_dir == "./"
-
         if "name" not in args:
             assert not env.name
 


### PR DESCRIPTION
If you pass working_dir as ./, it'll still work and run the detection algorithm. However, omit it by default, as when the module or function is actually sent to the env, then the working_dir is automatically added based on the file where the code was. 
