### PR TITLE
Fix imports in examples

### DIFF
--- a/examples/langchain-rag-ec2/langchain_rag.py
+++ b/examples/langchain-rag-ec2/langchain_rag.py
@@ -1,6 +1,6 @@
-# # Deploy a Langchain RAG as a service on AWS EC2
+# # Deploy a LangChain RAG as a service on AWS EC2
 
-# This is an example of easily deploying [Langchain's Quickstart RAG app](https://python.langchain.com/docs/use_cases/question_answering/quickstart)
+# This is an example of easily deploying [LangChain's Quickstart RAG app](https://python.langchain.com/docs/use_cases/question_answering/quickstart)
 # as a service on AWS EC2 using Runhouse.
 
 # ## Setup credentials and dependencies
@@ -36,7 +36,7 @@ from typing import List
 
 import runhouse as rh
 
-# Next, we define a class that will hold the Langchain App and allow us to send requests to it.
+# Next, we define a class that will hold the LangChain app and allow us to send requests to it.
 # You'll notice this class inherits from `rh.Module`.
 # This is a Runhouse class that allows you to
 # run code in your class on a remote machine.

--- a/examples/llama3-vllm-gcp/llama3_vllm_gcp.py
+++ b/examples/llama3-vllm-gcp/llama3_vllm_gcp.py
@@ -15,7 +15,7 @@
 # ```
 # Install the required dependencies:
 # ```shell
-# $ pip install "runhouse[gcp] asyncio"
+# $ pip install "runhouse[gcp]" asyncio
 # ```
 #
 # We'll be launching a GCP instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to

--- a/examples/parallel-hf-embedding-ec2/parallel_hf_embedding_ec2.py
+++ b/examples/parallel-hf-embedding-ec2/parallel_hf_embedding_ec2.py
@@ -13,7 +13,7 @@
 # ```
 # Install the required dependencies:
 # ```shell
-# $ pip install "runhouse[aws]" bs4
+# $ pip install "runhouse[aws]" torch beautifulsoup4 tqdm
 # ```
 #
 # We'll be launching an AWS EC2 instance via [SkyPilot](https://github.com/skypilot-org/skypilot), so we need to

--- a/examples/parallel-hf-embedding-ec2/requirements.txt
+++ b/examples/parallel-hf-embedding-ec2/requirements.txt
@@ -1,2 +1,4 @@
+beautifulsoup4
 runhouse[aws]
-bs4
+torch
+tqdm


### PR DESCRIPTION
Noticed some errors being reported for missing modules, likely from some missing/incorrect `pip install` scripts in the examples