### PR TITLE
Change `pointers` to store absolute path and work with `.to`.

### DIFF
--- a/runhouse/resources/functions/aws_lambda_factory.py
+++ b/runhouse/resources/functions/aws_lambda_factory.py
@@ -87,11 +87,15 @@ def aws_lambda_fn(
 
     # extract function pointers, path to code and arg names from callable function.
     handler_function_name = fn.__name__
-    fn_pointers, req_to_add = Function._extract_pointers(
-        fn, reqs=[] if env is None else env.reqs
+    fn_pointers = Function._extract_pointers(fn)
+    (
+        local_path_containing_function,
+        should_add,
+    ) = Function._get_local_path_containing_module(
+        fn_pointers[0], reqs=[] if env is None else env.reqs
     )
-    if req_to_add and env is not None:
-        env.reqs = [req_to_add] + env.reqs
+    if should_add and env is not None:
+        env.reqs = [str(local_path_containing_function)] + env.reqs
     paths_to_code = [extract_module_path(fn)]
     if name is None:
         name = fn.__name__

--- a/runhouse/resources/functions/function_factory.py
+++ b/runhouse/resources/functions/function_factory.py
@@ -67,9 +67,13 @@ def function(
 
     fn_pointers = None
     if callable(fn):
-        fn_pointers, req_to_add = Function._extract_pointers(fn, reqs=env.reqs)
-        if req_to_add:
-            env.reqs = [req_to_add] + env.reqs
+        fn_pointers = Function._extract_pointers(fn)
+        (
+            local_path_containing_module,
+            should_add,
+        ) = Function._get_local_path_containing_module(fn_pointers[0], env.reqs)
+        if should_add:
+            env.reqs = [str(local_path_containing_module)] + env.reqs
         if fn_pointers[1] == "notebook":
             fn_pointers = Function._handle_nb_fn(
                 fn,


### PR DESCRIPTION
Only change the module pointers to the `remote_import_path` when actually running `.to`. 

In that case, we generate the `remote_import_path` relative to whatever env it is being `.to` into.