### PR TITLE
Add up_if_not to clusters in examples

### DIFF
--- a/examples/llama2-13b-ec2/llama2_ec2.py
+++ b/examples/llama2-13b-ec2/llama2_ec2.py
@@ -92,7 +92,7 @@ class HFChatModel(rh.Module):
 # the script code will run when Runhouse attempts to run code remotely.
 # :::
 if __name__ == "__main__":
-    gpu = rh.cluster(name="rh-a10x", instance_type="A10G:1", provider="aws")
+    gpu = rh.cluster(name="rh-a10x", instance_type="A10G:1", provider="aws").up_if_not()
 
     # Next, we define the environment for our module. This includes the required dependencies that need
     # to be installed on the remote machine, as well as any secrets that need to be synced up from local to remote.

--- a/examples/llama2-fine-tuning-with-lora/llama2_fine_tuning.py
+++ b/examples/llama2-fine-tuning-with-lora/llama2_fine_tuning.py
@@ -220,8 +220,9 @@ class FineTuner(rh.Module):
 # the script code will run when Runhouse attempts to run code remotely.
 # :::
 if __name__ == "__main__":
-    cluster = rh.cluster(name="rh-a10x", instance_type="A10G:1", provider="aws")
-
+    cluster = rh.cluster(
+        name="rh-a10x", instance_type="A10G:1", provider="aws"
+    ).up_if_not()
     # Next, we define the environment for our module. This includes the required dependencies that need
     # to be installed on the remote machine, as well as any secrets that need to be synced up from local to remote.
     # Passing `huggingface` to the `secrets` parameter will load the Hugging Face token we set up earlier.

--- a/examples/llama3-8b-ec2/llama3_ec2.py
+++ b/examples/llama3-8b-ec2/llama3_ec2.py
@@ -108,7 +108,7 @@ class HFChatModel(rh.Module):
 if __name__ == "__main__":
     gpu = rh.cluster(
         name="rh-a10x", instance_type="A10G:1", memory="32+", provider="aws"
-    )
+    ).up_if_not()
 
     # Next, we define the environment for our module. This includes the required dependencies that need
     # to be installed on the remote machine, as well as any secrets that need to be synced up from local to remote.

--- a/examples/llama3-fine-tuning-lora/llama3_fine_tuning.py
+++ b/examples/llama3-fine-tuning-lora/llama3_fine_tuning.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
         instance_type="A10G:1",
         memory="32+",
         provider="aws",
-    )
+    ).up_if_not()
 
     # Next, we define the environment for our module. This includes the required dependencies that need
     # to be installed on the remote machine, as well as any secrets that need to be synced up from local to remote.

--- a/examples/llama3-vllm-gcp/llama3_vllm_gcp.py
+++ b/examples/llama3-vllm-gcp/llama3_vllm_gcp.py
@@ -106,7 +106,7 @@ async def main():
         # open_ports=[443], # Expose HTTPS port to public
         # server_connection_type="tls", # Specify how runhouse communicates with this cluster
         # den_auth=False, # No authentication required to hit this cluster (NOT recommended)
-    )
+    ).up_if_not()
 
     # We'll set an `autostop_mins` of 30 for this example. If you'd like your cluster to run indefinitely, set `autostop_mins=-1`.
     # You can use SkyPilot in the terminal to manage your active clusters with `sky status` and `sky down <cluster_id>`.


### PR DESCRIPTION
check_server no longer automatically ups a cluster if it is down (but will raise an error instead). upping and checking that a cluster is up should be something the user should handle themselves
