### PR TITLE
Check ips for ondemand clusters when loading from Den

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -42,6 +42,7 @@ from runhouse.logger import logger
 from runhouse.resources.envs.utils import _get_env_from
 from runhouse.resources.hardware.utils import (
     _current_cluster,
+    _run_ssh_command,
     _unnamed_default_env_name,
     ServerConnectionType,
 )
@@ -1174,18 +1175,13 @@ class Cluster(Resource):
         Example:
             >>> rh.cluster("rh-cpu").ssh()
         """
-        from runhouse.resources.hardware.sky_ssh_runner import SkySSHRunner, SshMode
-
         creds = self.creds_values
-        runner = SkySSHRunner(
-            ip=self.address,
+        _run_ssh_command(
+            address=self.address,
             ssh_user=creds["ssh_user"],
-            port=self.ssh_port,
+            ssh_port=self.ssh_port,
             ssh_private_key=creds["ssh_private_key"],
             docker_user=self.docker_user,
-        )
-        subprocess.run(
-            runner._ssh_base_command(ssh_mode=SshMode.INTERACTIVE, port_forward=None)
         )
 
     def _ping(self, timeout=5, retry=False):

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -166,6 +166,21 @@ class Cluster(Resource):
                 "Run `cluster.restart_server()` to restart the Runhouse server on the new default env."
             )
 
+    @classmethod
+    def from_name(cls, name, dryrun=False, alt_options=None, _resolve_children=True):
+        cluster = super().from_name(
+            name=name,
+            dryrun=dryrun,
+            alt_options=alt_options,
+            _resolve_children=_resolve_children,
+        )
+        if hasattr(cluster, "_update_from_sky_status"):
+            try:
+                cluster._update_from_sky_status(dryrun=True)
+            except:
+                pass
+        return cluster
+
     def save_config_to_cluster(
         self,
         node: str = None,

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -291,6 +291,8 @@ class OnDemandCluster(Cluster):
         """
         if self.on_this_cluster():
             return True
+        if self._ping(retry=False):
+            return True
         self._update_from_sky_status(dryrun=False)
         return self.address is not None
 

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 
 from enum import Enum
 from pathlib import Path
@@ -10,6 +11,8 @@ from runhouse.constants import (
     RESERVED_SYSTEM_NAMES,
 )
 from runhouse.resources.envs.utils import _get_env_from, run_setup_command
+from runhouse.resources.hardware.sky.command_runner import SshMode
+from runhouse.resources.hardware.sky_ssh_runner import SkySSHRunner
 
 
 class ServerConnectionType(str, Enum):
@@ -129,3 +132,23 @@ def detect_cuda_version_or_cpu(cluster: "Cluster" = None):
     if run_setup_command("nvidia-smi", cluster=cluster)[0] == 0:
         return cuda_version
     return "cpu"
+
+
+def _run_ssh_command(
+    address: str,
+    ssh_user: str,
+    ssh_port: int,
+    ssh_private_key: str,
+    docker_user: str,
+):
+    runner = SkySSHRunner(
+        ip=address,
+        ssh_user=ssh_user,
+        port=ssh_port,
+        ssh_private_key=ssh_private_key,
+        docker_user=docker_user,
+    )
+    ssh_command = runner._ssh_base_command(
+        ssh_mode=SshMode.INTERACTIVE, port_forward=None
+    )
+    subprocess.run(ssh_command)


### PR DESCRIPTION
when loading on demand cluster from name (Den), if different IPs are found in the local sky db (refresh=False), then update the IPs. the local IPs should be more recent than the saved IPs

note: it is possible the cluster was autodowned but still in the local db, in this case the local IPs will still be used but won't work (calling up_if_not or _ping will correct this, but this is to avoid calling refresh in the constructor). 

note: we do not resave the cluster either