### PR TITLE
conda_env in local Docker cluster

### DIFF
--- a/docker/slim/public-key-auth-conda/Dockerfile
+++ b/docker/slim/public-key-auth-conda/Dockerfile
@@ -1,0 +1,64 @@
+# Debian based image (should work for Ubuntu as well) using public key authentication
+FROM continuumio/miniconda3:22.11.1
+
+ARG RUNHOUSE_PATH
+ARG RUNHOUSE_VERSION
+
+WORKDIR /app
+
+# Create the password file directory
+RUN mkdir -p /app/ssh
+
+# Install the required packages
+RUN apt-get update --allow-insecure-repositories && \
+    apt-get install -y --no-install-recommends gcc python3-dev openssh-server rsync supervisor screen wget curl sudo ufw git awscli && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# COPY local Runhouse package into the image if provided
+COPY $RUNHOUSE_PATH /app/runhouse
+
+# If using a local version of runhouse, install it from the local directory
+RUN if [ -d "/app/runhouse" ]; then pip install -U -e '/app/runhouse[opentelemetry]'; else pip install -U 'runhouse[opentelemetry]==$RUNHOUSE_VERSION'; fi
+
+# Create the privilege separation directory required by sshd
+RUN mkdir -p /run/sshd
+
+# Create a user for SSH access and add to sudo group
+RUN useradd -m rh-docker-user && echo "rh-docker-user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/rh-docker-user
+
+# Create .ssh directory for the user
+RUN mkdir -p /home/rh-docker-user/.ssh
+
+# Copy the public key into the image using Docker Build Secrets
+RUN --mount=type=secret,id=ssh_key,dst=/tmp/id_rsa.pub \
+    cp /tmp/id_rsa.pub /home/rh-docker-user/.ssh/authorized_keys && \
+    chown -R rh-docker-user:rh-docker-user /home/rh-docker-user/.ssh && \
+    chmod 700 /home/rh-docker-user/.ssh && \
+    chmod 600 /home/rh-docker-user/.ssh/authorized_keys
+
+# Update SSHD Configuration to allow public key authentication and disable password and root login
+RUN echo "PasswordAuthentication no" >> /etc/ssh/sshd_config && \
+    echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && \
+    echo "PubkeyAuthentication yes" >> /etc/ssh/sshd_config
+
+# Create supervisord configuration file
+RUN echo "[supervisord]" > /etc/supervisor/conf.d/supervisord.conf && \
+    echo "nodaemon=true" >> /etc/supervisor/conf.d/supervisord.conf && \
+    echo "user=root" >> /etc/supervisor/conf.d/supervisord.conf && \
+    echo "[program:sshd]" >> /etc/supervisor/conf.d/supervisord.conf && \
+    echo "command=/usr/sbin/sshd -D" >> /etc/supervisor/conf.d/supervisord.conf && \
+    echo "stdout_logfile=/var/log/sshd.log" >> /etc/supervisor/conf.d/supervisord.conf && \
+    echo "stderr_logfile=/var/log/sshd.err" >> /etc/supervisor/conf.d/supervisord.conf
+
+# Runhouse server port
+EXPOSE 32300
+# HTTPS port
+EXPOSE 443
+# HTTP port
+EXPOSE 80
+# SSH port
+EXPOSE 22
+
+# Run supervisord as the main process to manage the others
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/tests/fixtures/docker_cluster_fixtures.py
+++ b/tests/fixtures/docker_cluster_fixtures.py
@@ -457,6 +457,7 @@ def docker_cluster_pk_http_exposed(request, test_rns_folder):
     - Public key authentication
     - Den auth disabled (to mimic VPC)
     - Caddy set up on startup to forward Runhouse HTTP Server to port 80
+    - Default conda_env with Python 3.11 and Ray 2.30.0
     """
     import os
 
@@ -472,11 +473,25 @@ def docker_cluster_pk_http_exposed(request, test_rns_folder):
     # Ports to use on the Docker VM such that they don't conflict
     local_ssh_port = BASE_LOCAL_SSH_PORT + 3
     local_client_port = LOCAL_HTTP_SERVER_PORT + 3
+    default_env = rh.conda_env(
+        reqs=[
+            "ray==2.30.0",
+            "pytest",
+            "httpx",
+            "pytest_asyncio",
+            "pandas",
+            "numpy<=1.26.4",
+        ],
+        conda_env={"dependencies": ["python=3.11"], "name": "default_env"},
+        env_vars={"OMP_NUM_THREADS": "8"},
+        working_dir=None,
+        name="default_env",
+    )
 
     local_cluster, cleanup = set_up_local_cluster(
-        image_name="keypair",
+        image_name="keypair-conda",
         container_name="rh-pk-http-port-fwd",
-        dir_name="public-key-auth",
+        dir_name="public-key-auth-conda",
         keypath=str(
             Path(
                 rh.configs.get("default_keypair", DEFAULT_KEYPAIR_KEYPATH)
@@ -495,6 +510,7 @@ def docker_cluster_pk_http_exposed(request, test_rns_folder):
             "server_port": DEFAULT_HTTP_PORT,
             "client_port": local_client_port,
             "den_auth": False,
+            "default_env": default_env,
         },
     )
     # Yield the cluster


### PR DESCRIPTION
Add a new dockerfile with miniconda installed to be able to test conda default_env in a local docker cluster. Unfortunately changing the dockerfile to use the miniconda base image did not work for the other local clusters which don't use conda default env, not for lack of trying. Ideally we can consolidate these somehow soon.