### PR TITLE
unblock k8s test in CI

### DIFF
--- a/.github/workflows/nightly_release_testing.yaml
+++ b/.github/workflows/nightly_release_testing.yaml
@@ -7,149 +7,149 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
-  not-cluster-tests:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-
-      - name: Setup Release Testing
-        uses: ./.github/workflows/setup_release_testing
-        with:
-          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
-          KUBECONFIG: ${{ secrets.KUBECONFIG }}
-          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
-          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
-          API_SERVER_URL: ${{ env.API_SERVER_URL }}
-
-      - name: Run not cluster tests
-        env:
-          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
-          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
-        run: pytest --level release tests -k "not cluster" --detached
-        timeout-minutes: 180
-
-      - name: Teardown all clusters
-        if: always()
-        run: |
-          sky status
-          sky down --all -y
-          sky status
-
-  cluster-tests:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-
-      - name: Setup Release Testing
-        uses: ./.github/workflows/setup_release_testing
-        with:
-          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
-          KUBECONFIG: ${{ secrets.KUBECONFIG }}
-          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
-          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
-          API_SERVER_URL: ${{ env.API_SERVER_URL }}
-
-      - name: Run cluster and not on-demand tests
-        env:
-          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
-          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
-        run: pytest --level release tests -k "cluster and not ondemand" --detached
-        timeout-minutes: 180
-
-      - name: Teardown all cluster-tests clusters
-        if: always()
-        run: |
-          sky status
-          sky down --all -y
-          sky status
-
-  ondemand-aws-tests:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-
-      - name: Setup Release Testing
-        uses: ./.github/workflows/setup_release_testing
-        with:
-          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
-          KUBECONFIG: ${{ secrets.KUBECONFIG }}
-          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
-          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
-          API_SERVER_URL: ${{ env.API_SERVER_URL }}
-
-      - name: Run on-demand aws tests
-        env:
-          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
-          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
-        run: pytest --level release tests -k "ondemand_aws_cluster" --detached
-        timeout-minutes: 180
-
-      - name: Teardown all ondemand-aws-tests clusters
-        if: always()
-        run: |
-          sky status
-          sky down --all -y
-          sky status
-
-  ondemand-gcp-tests:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-
-      - name: Setup Release Testing
-        uses: ./.github/workflows/setup_release_testing
-        with:
-          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          KUBECONFIG: ${{ secrets.KUBECONFIG }}
-          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
-          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
-          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
-          API_SERVER_URL: ${{ env.API_SERVER_URL }}
-
-      - name:  Run on-demand gcp tests
-        env:
-          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
-          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
-        run: pytest --level release tests -k "ondemand_gcp_cluster" --detached
-        timeout-minutes: 180
-
-      - name: Teardown all ondemand-gcp-tests clusters
-        if: always()
-        run: |
-          sky status
-          sky down --all -y
-          sky status
+#  not-cluster-tests:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Release Testing
+#        uses: ./.github/workflows/setup_release_testing
+#        with:
+#          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
+#          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+#          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+#          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+#          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
+#          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
+#          API_SERVER_URL: ${{ env.API_SERVER_URL }}
+#
+#      - name: Run not cluster tests
+#        env:
+#          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+#          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+#          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
+#          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
+#        run: pytest --level release tests -k "not cluster" --detached
+#        timeout-minutes: 180
+#
+#      - name: Teardown all clusters
+#        if: always()
+#        run: |
+#          sky status
+#          sky down --all -y
+#          sky status
+#
+#  cluster-tests:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Release Testing
+#        uses: ./.github/workflows/setup_release_testing
+#        with:
+#          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
+#          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+#          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+#          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+#          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
+#          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
+#          API_SERVER_URL: ${{ env.API_SERVER_URL }}
+#
+#      - name: Run cluster and not on-demand tests
+#        env:
+#          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+#          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+#          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
+#          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
+#        run: pytest --level release tests -k "cluster and not ondemand" --detached
+#        timeout-minutes: 180
+#
+#      - name: Teardown all cluster-tests clusters
+#        if: always()
+#        run: |
+#          sky status
+#          sky down --all -y
+#          sky status
+#
+#  ondemand-aws-tests:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Release Testing
+#        uses: ./.github/workflows/setup_release_testing
+#        with:
+#          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
+#          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+#          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+#          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+#          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
+#          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
+#          API_SERVER_URL: ${{ env.API_SERVER_URL }}
+#
+#      - name: Run on-demand aws tests
+#        env:
+#          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+#          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+#          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
+#          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
+#        run: pytest --level release tests -k "ondemand_aws_cluster" --detached
+#        timeout-minutes: 180
+#
+#      - name: Teardown all ondemand-aws-tests clusters
+#        if: always()
+#        run: |
+#          sky status
+#          sky down --all -y
+#          sky status
+#
+#  ondemand-gcp-tests:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Release Testing
+#        uses: ./.github/workflows/setup_release_testing
+#        with:
+#          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+#          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+#          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+#          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
+#          CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
+#          CI_ACCOUNT_USERNAME: ${{ secrets.CI_ACCOUNT_USERNAME }}
+#          API_SERVER_URL: ${{ env.API_SERVER_URL }}
+#
+#      - name:  Run on-demand gcp tests
+#        env:
+#          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+#          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+#          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_TOKEN }}
+#          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
+#        run: pytest --level release tests -k "ondemand_gcp_cluster" --detached
+#        timeout-minutes: 180
+#
+#      - name: Teardown all ondemand-gcp-tests clusters
+#        if: always()
+#        run: |
+#          sky status
+#          sky down --all -y
+#          sky status
 
   kubernetes-tests:
     runs-on: ubuntu-latest
@@ -165,6 +165,8 @@ jobs:
         with:
           KUBECONFIG: ${{ secrets.KUBECONFIG }}
           AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
+          DEV_AWS_ACCESS_KEY: ${{ secrets.DEV_AWS_ACCESS_KEY }}
+          DEV_AWS_SECRET_KEY: ${{ secrets.DEV_AWS_SECRET_KEY }}
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}
@@ -183,10 +185,10 @@ jobs:
   check-cluster-status:
     if: always()
     needs:
-      - not-cluster-tests
-      - cluster-tests
-      - ondemand-aws-tests
-      - ondemand-gcp-tests
+#      - not-cluster-tests
+#      - cluster-tests
+#      - ondemand-aws-tests
+#      - ondemand-gcp-tests
       - kubernetes-tests
     runs-on: ubuntu-latest
     permissions:
@@ -201,6 +203,8 @@ jobs:
         with:
           KUBECONFIG: ${{ secrets.KUBECONFIG }}
           AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
+          DEV_AWS_ACCESS_KEY: ${{ secrets.DEV_AWS_ACCESS_KEY }}
+          DEV_AWS_SECRET_KEY: ${{ secrets.DEV_AWS_SECRET_KEY }}
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           CI_ACCOUNT_TOKEN: ${{ secrets.CI_ACCOUNT_TOKEN }}

--- a/.github/workflows/setup_release_testing/action.yaml
+++ b/.github/workflows/setup_release_testing/action.yaml
@@ -6,6 +6,11 @@ inputs:
   AWS_OSS_ROLE_ARN:
     description: 'AWS OSS Role ARN'
     required: false
+  DEV_AWS_ACCESS_KEY:
+    description: 'AWS Access Key ID'
+    required: false
+  DEV_AWS_SECRET_KEY:
+    description: 'AWS Secret Access Key'
   GCP_SERVICE_ACCOUNT_KEY:
     description: 'GCP Service Account Key'
     required: false
@@ -31,25 +36,52 @@ runs:
     - name: Check out repository code
       uses: actions/checkout@v3
 
+    - name: Setup Kubeconfig
+      run: |
+        mkdir -p $HOME/.kube
+        echo "${{ inputs.KUBECONFIG }}" > $HOME/.kube/config
+        export KUBECONFIG=$HOME/.kube/config
+        kubectl config view
+        sudo apt-get update
+        sudo apt-get install -y socat netcat
+      shell: bash
+
+#    - name: Configure & Authenticate to AWS
+#      uses: aws-actions/configure-aws-credentials@v2
+#      with:
+#        role-to-assume: ${{ inputs.AWS_OSS_ROLE_ARN }}
+#        aws-region: us-east-1
+#        duration-seconds: 10800  # 3 hours (prevent auth errors for longer running jobs)
+#        audience: sts.amazonaws.com
+
     - name: Configure & Authenticate to AWS
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: ${{ inputs.AWS_OSS_ROLE_ARN }}
-        aws-region: us-east-1
-
-    - name: Write AWS credentials to file
       run: |
-        mkdir -p ~/.aws
-        echo "[default]" > ~/.aws/credentials
-        echo "aws_access_key_id=$AWS_ACCESS_KEY_ID" >> ~/.aws/credentials
-        echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> ~/.aws/credentials
-        echo "aws_session_token=$AWS_SESSION_TOKEN" >> ~/.aws/credentials
+        aws configure set aws_access_key_id ${{ inputs.DEV_AWS_ACCESS_KEY }}
+        aws configure set aws_secret_access_key ${{ inputs.DEV_AWS_SECRET_KEY }}
+        aws configure set default.region us-east-1
       shell: bash
 
-    - name: Verify AWS credentials
-      run: |
-        aws sts get-caller-identity
-      shell: bash
+
+#    - name: Write AWS credentials to file
+#      run: |
+#        mkdir -p ~/.aws
+#        echo "[default]" > ~/.aws/credentials
+#        echo "aws_access_key_id=$AWS_ACCESS_KEY_ID" >> ~/.aws/credentials
+#        echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> ~/.aws/credentials
+#        echo "aws_session_token=$AWS_SESSION_TOKEN" >> ~/.aws/credentials
+#      shell: bash
+
+#    - name: Verify AWS credentials
+#      run: |
+#        aws sts get-caller-identity
+#      shell: bash
+
+#    - name: Validate Kubernetes access
+#      run: |
+#        kubectl get nodes
+#        kubectl describe clusterrolebinding oss-role-binding
+#        kubectl describe configmap aws-auth -n kube-system
+#      shell: bash
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v1
@@ -62,14 +94,6 @@ runs:
       with:
         project_id: ${{ inputs.GCP_PROJECT_ID }}
         service_account_key: ${{ inputs.GCP_SERVICE_ACCOUNT_KEY }}
-
-    - name: Setup Kubeconfig
-      run: |
-        mkdir -p $HOME/.kube
-        echo "${{ inputs.KUBECONFIG }}" > $HOME/.kube/config
-        sudo apt-get update
-        sudo apt-get install -y socat netcat
-      shell: bash
 
     - name: Install & check skypilot configuration
       run: |


### PR DESCRIPTION
We should be able to assume the `oss-role` for authenticating with the cluster and running the tests, but reverting until that's sorted 