### PR TITLE
log 'no logs were sent to den' as debug

### DIFF
--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -301,7 +301,9 @@ class ClusterServlet:
                         prev_end_log_line=prev_end_log_line,
                     )
                     if not logs_resp_status_code:
-                        logger.warning("There were no logs to send to Den.")
+                        logger.debug(
+                            f"No logs were generated in the past {interval_size} minute(s), logs were not sent to Den."
+                        )
 
                     elif logs_resp_status_code == 200:
                         logger.debug("Successfully sent cluster logs to Den.")


### PR DESCRIPTION
Sometimes clusters do not generate logs between two consecutive cluster checks. Therefore, no logs were sent to Den, and we were logging the following info message: 'There were no logs to send to Den'. In the next cluster check run, we spotted that a new log line was generated ('There were no logs to send to Den'), and it was sent to Den. This is the reason the following log preview was displayed in the UI:
![image](https://github.com/user-attachments/assets/1ecb2c39-8b8a-4f81-98f0-b7a1bedcb4cd)

(Notice that every two log lines are sent in 2 minutes apart, which makes sense) 

This is a bit odd and unintuitive, therefore I made 2 changes to the way we are logging that 'no logs were sent to Den':
1.   I updated the log message to be more precise: "No logs were generated in the past {interval_size} minute(s), logs were not sent to Den."
2. We are logging this message in debug mode. Only if the user explicitly sets the logs level of the cluster to be DEBUG, this log will be streamed to the server.log file and will be sent to Den. 

 