### PR TITLE
Server cpu memory info display only relevant info

### DIFF
--- a/runhouse/rns/rns_client.py
+++ b/runhouse/rns/rns_client.py
@@ -27,9 +27,10 @@ from runhouse.utils import locate_working_dir
 # This is a copy of the Pydantic model that we use to validate in Den
 class ResourceStatusData(BaseModel):
     cluster_config: dict
-    system_cpu_usage: float
-    system_memory_usage: Dict[str, Any]
-    system_disk_usage: Dict[str, Any]
+    server_cpu_utilization: float
+    server_gpu_utilization: Optional[float]
+    server_memory_usage: Dict[str, Any]
+    server_gpu_usage: Optional[Dict[str, Any]]
     env_servlet_processes: Dict[str, Dict[str, Any]]
     server_pid: int
     runhouse_version: str

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -452,11 +452,22 @@ class ClusterServlet:
         # TODO: decide if we need this info at all: cpu_usage, memory_usage, disk_usage
         cpu_utilization = psutil.cpu_percent(interval=1)
 
-        # Fields: `available`, `percent`, `used`, `free`, `active`, `inactive`, `buffers`, `cached`, `shared`, `slab`
+        # A dictionary that match the keys of psutil.virtual_memory()._asdict() to match the keys we expect in Den.
+        relevant_memory_info = {
+            "available": "free_memory",
+            "percent": "percent",
+            "total": "total_memory",
+            "used": "used_memory",
+        }
+
+        # Fields: `total`, `available`, `percent`, `used`, `free`, `active`, `inactive`, `buffers`, `cached`, `shared`, `slab`
+        # according to psutil docs, percent = (total - available) / total * 100
         memory_usage = psutil.virtual_memory()._asdict()
 
-        # Fields: `total`, `used`, `free`, `percent`
-        disk_usage = psutil.disk_usage("/")._asdict()
+        memory_usage = {
+            relevant_memory_info[k]: memory_usage[k]
+            for k in relevant_memory_info.keys()
+        }
 
         server_pid: int = get_pid()
 
@@ -480,7 +491,6 @@ class ClusterServlet:
             "server_cpu_utilization": cpu_utilization,
             "server_gpu_utilization": gpu_utilization,
             "server_memory_usage": memory_usage,
-            "server_disk_usage": disk_usage,
             "server_gpu_usage": server_gpu_usage,
         }
         status_data = ResourceStatusData(**status_data)


### PR DESCRIPTION
cluster CI tests are expected to fail. Once we'll deploy the relevant version to den-prod, the tests will pass. (There is a stuck with den changes as well.)