### PR TITLE
Add intervals to gpu and cpu util calcs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ wheel
 apispec
 httpx
 pydantic >=2.5.0
+pynvml

--- a/runhouse/constants.py
+++ b/runhouse/constants.py
@@ -73,11 +73,23 @@ DOCKER_LOGIN_ENV_VARS = {
 # Constants for the status check
 DOUBLE_SPACE_UNICODE = "\u00A0\u00A0"
 BULLET_UNICODE = "\u2022"
+SECOND = 1
 MINUTE = 60
 HOUR = 3600
 DEFAULT_STATUS_CHECK_INTERVAL = 1 * MINUTE
 INCREASED_STATUS_CHECK_INTERVAL = 1 * HOUR
-STATUS_CHECK_DELAY = 1 * MINUTE
+GPU_COLLECTION_INTERVAL = 5 * SECOND
+
+# We collect gpu every GPU_COLLECTION_INTERVAL.
+# Meaning that in one minute we collect (MINUTE / GPU_COLLECTION_INTERVAL) gpu stats.
+# Currently, we save gpu info of the last 10 minutes or less.
+MAX_GPU_INFO_LEN = (MINUTE / GPU_COLLECTION_INTERVAL) * 10
+
+# If we just collect the gpu stats (and not send them to den), the gpu_info dictionary *will not* be reseted by the servlets.
+# Therefore, we need to cut the gpu_info size, so it doesn't consume too much cluster memory.
+# Currently, we reduce the size by half, meaning we only keep the gpu_info of the last (MAX_GPU_INFO_LEN / 2) minutes.
+REDUCED_GPU_INFO_LEN = MAX_GPU_INFO_LEN / 2
+
 
 # Constants Surfacing Logs to Den
 DEFAULT_LOG_SURFACING_INTERVAL = 2 * MINUTE

--- a/runhouse/utils.py
+++ b/runhouse/utils.py
@@ -26,6 +26,7 @@ import threading
 
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import Callable, Optional, Type, Union
 
@@ -601,3 +602,53 @@ def create_local_dir(path: Union[str, Path]):
     full_path = os.path.expanduser(path) if isinstance(path, str) else path.expanduser()
     Path(full_path).parent.mkdir(parents=True, exist_ok=True)
     return full_path
+
+
+####################################################################################################
+# Status collection utils
+####################################################################################################
+class ServletType(str, Enum):
+    env = "env"
+    cluster = "cluster"
+
+
+def get_gpu_usage(collected_gpus_info: dict, servlet_type: ServletType):
+
+    gpus_indices = list(collected_gpus_info.keys())
+
+    # how we retrieve total_gpu_memory:
+    # 1. getting the first gpu usage of the first gpu un the gpus list
+    # 2. getting the first gpu_info dictionary of the specific gpu (we collected the gpu info over time)
+    # 3. get total_memory value (it is the same across all envs)
+    total_gpu_memory = collected_gpus_info[gpus_indices[0]][0].get("total_memory")
+    total_used_memory, gpu_utilization_percent, free_memory = 0, 0, 0
+
+    if servlet_type == ServletType.cluster:
+        free_memory = collected_gpus_info[gpus_indices[0]][-1].get(
+            "free_memory"
+        )  # getting the latest free_memory value collected.
+
+    for gpu_index in gpus_indices:
+        collected_gpu_info = collected_gpus_info.get(gpu_index)
+        sum_used_memery = sum(
+            [gpu_info.get("used_memory") for gpu_info in collected_gpu_info]
+        )
+        total_used_memory = sum_used_memery / len(collected_gpu_info)  # average
+
+        if servlet_type == ServletType.cluster:
+            sum_cpu_util = sum(
+                [gpu_info.get("utilization_percent") for gpu_info in collected_gpu_info]
+            )
+            gpu_utilization_percent = sum_cpu_util / len(collected_gpu_info)  # average
+
+    total_used_memory = total_used_memory / len(gpus_indices)
+
+    gpu_usage = {"total_memory": total_gpu_memory, "used_memory": total_used_memory}
+
+    if servlet_type == ServletType.cluster:
+        gpu_utilization_percent = round(gpu_utilization_percent / len(gpus_indices), 2)
+        gpu_usage["free_memory"] = free_memory
+        gpu_usage["gpu_count"] = len(gpus_indices)
+        gpu_usage["utilization_percent"] = gpu_utilization_percent
+
+    return gpu_usage

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ install_requires = [
     "apispec",
     "httpx",
     "pydantic >= 2.5.0",  # required for ray >= 2.9.0 (https://github.com/ray-project/ray/releases?page=2)
+    "pynvml",
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the following

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -206,18 +206,19 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         ]  # getting the first element because the endpoint returns the status + response to den.
         assert status_data["cluster_config"]["resource_type"] == "cluster"
         assert status_data["env_servlet_processes"]
-        assert status_data["server_cpu_utilization"]
+        assert isinstance(status_data["server_cpu_utilization"], float)
         assert status_data["server_memory_usage"]
         assert not status_data.get("server_gpu_usage", None)
 
     @pytest.mark.level("local")
     @pytest.mark.clustertest
-    def test_cluster_request_timeout(self, cluster):
+    def test_cluster_request_timeout(self, docker_cluster_pk_ssh_no_auth):
+        cluster = docker_cluster_pk_ssh_no_auth
         with pytest.raises(requests.exceptions.ReadTimeout):
             cluster._http_client.request_json(
                 endpoint="/status",
                 req_type="get",
-                timeout=0.01,
+                timeout=0.005,
                 headers=rh.globals.rns_client.request_headers(),
             )
 


### PR DESCRIPTION
Updated a bit the runhouse status cli cmd output, now that we get CPU and GPU util properly:
![image](https://github.com/user-attachments/assets/0657a34e-2da1-4748-9643-6eb58db97748)
 
* We are printing GPU utilization% only on the server level, because we can't calculate it on the env level
* We are printing the CPU utilization% on the server level as well, not just on the env level. 