### PR TITLE
Move `_generate_default_name` into general utilities.

### DIFF
--- a/runhouse/resources/blobs/blob.py
+++ b/runhouse/resources/blobs/blob.py
@@ -6,7 +6,8 @@ from runhouse.resources.envs.utils import _get_env_from
 from runhouse.resources.hardware import _current_cluster, _get_cluster_from, Cluster
 
 from runhouse.resources.module import Module
-from runhouse.rns.utils.names import _generate_default_name, _generate_default_path
+from runhouse.rns.utils.names import _generate_default_path
+from runhouse.utils import generate_default_name
 
 
 class Blob(Module):
@@ -56,7 +57,7 @@ class Blob(Module):
 
         system = _get_cluster_from(system)
         if (not system or isinstance(system, Cluster)) and not path:
-            self.name = self.name or _generate_default_name(prefix="blob")
+            self.name = self.name or generate_default_name(prefix="blob")
             # TODO [DG] if system is the same, bounces off the laptop for no reason. Change to write through a
             #  call_module_method rpc (and same for similar file cases)
             return super().to(system, env)
@@ -184,7 +185,7 @@ def blob(
 
     if (not system or isinstance(system, Cluster)) and not path:
         # Blobs must be named, or we don't have a key for the kv store
-        name = name or _generate_default_name(prefix="blob")
+        name = name or generate_default_name(prefix="blob")
         new_blob = Blob(name=name, dryrun=dryrun).to(system, env)
         if data is not None:
             new_blob.data = data
@@ -194,7 +195,7 @@ def blob(
 
     from runhouse.resources.blobs.file import File
 
-    name = name or _generate_default_name(prefix="file")
+    name = name or generate_default_name(prefix="file")
     new_blob = File(
         name=name,
         path=path,

--- a/runhouse/resources/blobs/file.py
+++ b/runhouse/resources/blobs/file.py
@@ -6,7 +6,7 @@ from runhouse.resources.blobs.blob import Blob, blob
 from runhouse.resources.envs import _get_env_from, Env
 from runhouse.resources.folders import Folder, folder
 from runhouse.resources.hardware import _current_cluster, _get_cluster_from, Cluster
-from runhouse.rns.utils.names import _generate_default_name
+from runhouse.utils import generate_default_name
 
 
 class File(Blob):
@@ -103,7 +103,7 @@ class File(Blob):
         env = _get_env_from(env or self.env)
 
         if (not system or isinstance(system, Cluster)) and not path:
-            name = self.name or _generate_default_name(prefix="blob")
+            name = self.name or generate_default_name(prefix="blob")
             data_backup = self.fetch()
             new_blob = Blob(name=name).to(system, env)
             new_blob.data = data_backup

--- a/runhouse/resources/hardware/sagemaker/sagemaker_cluster.py
+++ b/runhouse/resources/hardware/sagemaker/sagemaker_cluster.py
@@ -41,7 +41,7 @@ from runhouse.rns.utils.api import (
     relative_file_path,
     resolve_absolute_path,
 )
-from runhouse.rns.utils.names import _generate_default_name
+from runhouse.utils import generate_default_name
 
 
 ####################################################################################################
@@ -948,7 +948,7 @@ class SageMakerCluster(Cluster):
         # NOTE: underscores not allowed for training job name - must match: ^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,62}
         self.estimator.fit(
             wait=False,
-            job_name=self.job_name or _generate_default_name(self.name, sep="-"),
+            job_name=self.job_name or generate_default_name(self.name, sep="-"),
         )
 
     def _load_base_command_for_ssm_session(self) -> str:

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -24,11 +24,11 @@ from runhouse.resources.hardware import (
 from runhouse.resources.packages import Package
 from runhouse.resources.resource import Resource
 from runhouse.rns.utils.api import ResourceAccess, ResourceVisibility
-from runhouse.rns.utils.names import _generate_default_name
 from runhouse.servers.http import HTTPClient
 from runhouse.servers.http.http_utils import CallParams
 from runhouse.utils import (
     client_call_wrapper,
+    generate_default_name,
     get_module_import_info,
     locate_working_dir,
 )
@@ -420,9 +420,9 @@ class Module(Resource):
         return state
 
     def default_name(self):
-        return (
-            self._pointers[2] if self._pointers else None
-        ) or _generate_default_name(prefix=self.__class__.__qualname__.lower())
+        return (self._pointers[2] if self._pointers else None) or generate_default_name(
+            prefix=self.__class__.__qualname__.lower()
+        )
 
     def to(
         self,
@@ -1402,7 +1402,7 @@ def module(
             env.reqs = [str(local_path_containing_module)] + env.reqs
 
     name = name or (
-        cls_pointers[2] if cls_pointers else _generate_default_name(prefix="module")
+        cls_pointers[2] if cls_pointers else generate_default_name(prefix="module")
     )
 
     module_subclass = _module_subclass_factory(cls, cls_pointers)

--- a/runhouse/resources/secrets/secret.py
+++ b/runhouse/resources/secrets/secret.py
@@ -12,7 +12,7 @@ from runhouse.resources.hardware import _get_cluster_from, Cluster
 from runhouse.resources.resource import Resource
 from runhouse.resources.secrets.utils import _delete_vault_secrets, load_config
 from runhouse.rns.utils.api import load_resp_content, read_resp_data
-from runhouse.rns.utils.names import _generate_default_name
+from runhouse.utils import generate_default_name
 
 
 class Secret(Resource):
@@ -346,7 +346,7 @@ class Secret(Resource):
         """
 
         new_secret = copy.deepcopy(self)
-        new_secret.name = name or self.name or _generate_default_name(prefix="secret")
+        new_secret.name = name or self.name or generate_default_name(prefix="secret")
 
         system = _get_cluster_from(system)
         if system.on_this_cluster():

--- a/runhouse/rns/utils/names.py
+++ b/runhouse/rns/utils/names.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 from pathlib import Path
 
 from runhouse.globals import configs, rns_client
 from runhouse.resources.hardware.utils import _get_cluster_from
+from runhouse.utils import generate_default_name
 
 DEFAULT_LOCAL_FOLDER = f"{Path.cwd()}/"
 DEFAULT_CLUSTER_FS_FOLDER = (
@@ -11,20 +11,6 @@ DEFAULT_CLUSTER_FS_FOLDER = (
 DEFAULT_BLOB_STORAGE_FOLDER = (
     configs.get("default_blob_storage_folder", "runhouse") + "/"
 )
-
-
-def _generate_default_name(prefix: str = None, precision: str = "s", sep="_") -> str:
-    """Name of the Run's parent folder which contains the Run's data (config, stdout, stderr, etc).
-    If a name is provided, prepend that to the current timestamp to complete the folder name."""
-    if precision == "d":
-        timestamp_key = f"{datetime.now().strftime('%Y%m%d')}"
-    elif precision == "s":
-        timestamp_key = f"{datetime.now().strftime(f'%Y%m%d{sep}%H%M%S')}"
-    elif precision == "ms":
-        timestamp_key = f"{datetime.now().strftime(f'%Y%m%d{sep}%H%M%S_%f')}"
-    if prefix is None:
-        return timestamp_key
-    return f"{prefix}{sep}{timestamp_key}"
 
 
 def _generate_default_path(cls, name, system):
@@ -38,7 +24,7 @@ def _generate_default_path(cls, name, system):
 
     system = _get_cluster_from(system)
 
-    name = name or _generate_default_name(prefix=cls.RESOURCE_TYPE)
+    name = name or generate_default_name(prefix=cls.RESOURCE_TYPE)
     if system == rns_client.DEFAULT_FS or "here":
         base_folder = DEFAULT_LOCAL_FOLDER
     elif isinstance(system, Cluster):

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -29,7 +29,6 @@ from runhouse.constants import (
 from runhouse.globals import configs, obj_store, rns_client
 from runhouse.logger import logger
 from runhouse.rns.utils.api import resolve_absolute_path, ResourceAccess
-from runhouse.rns.utils.names import _generate_default_name
 from runhouse.servers.caddy.config import CaddyConfig
 from runhouse.servers.http.auth import averify_cluster_access
 from runhouse.servers.http.certs import TLSCertConfig
@@ -66,7 +65,7 @@ from runhouse.servers.obj_store import (
     ObjStoreError,
     RaySetupOption,
 )
-from runhouse.utils import sync_function
+from runhouse.utils import generate_default_name, sync_function
 
 app = FastAPI(docs_url=None, redoc_url=None)
 
@@ -320,7 +319,7 @@ class HTTPServer:
         params = params or CallParams()
 
         try:
-            params.run_name = params.run_name or _generate_default_name(
+            params.run_name = params.run_name or generate_default_name(
                 prefix=key if method_name == "__call__" else f"{key}_{method_name}",
                 precision="ms",  # Higher precision because we see collisions within the same second
                 sep="@",

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -18,7 +18,12 @@ from runhouse.logger import logger
 
 from runhouse.rns.defaults import req_ctx
 from runhouse.rns.utils.api import ResourceVisibility
-from runhouse.utils import arun_in_thread, LogToFolder, sync_function
+from runhouse.utils import (
+    arun_in_thread,
+    generate_default_name,
+    LogToFolder,
+    sync_function,
+)
 
 
 class RaySetupOption(str, Enum):
@@ -1265,11 +1270,9 @@ class ObjStore:
             else None
         )
 
-        from runhouse.rns.utils.names import _generate_default_name
-
         # Make sure there's a run_name (if called through the HTTPServer there will be, but directly
         # through the ObjStore there may not be)
-        run_name = run_name or _generate_default_name(
+        run_name = run_name or generate_default_name(
             prefix=key if method_name == "__call__" else f"{key}_{method_name}",
             precision="ms",  # Higher precision because we see collisions within the same second
             sep="@",
@@ -1515,7 +1518,6 @@ class ObjStore:
     ) -> str:
         from runhouse.resources.module import Module
         from runhouse.resources.resource import Resource
-        from runhouse.rns.utils.names import _generate_default_name
 
         state = state or {}
         # Resolve any sub-resources which are string references to resources already sent to this cluster.
@@ -1540,7 +1542,7 @@ class ObjStore:
         for attr, val in state.items():
             setattr(resource, attr, val)
 
-        name = resource.name or _generate_default_name(prefix=resource.RESOURCE_TYPE)
+        name = resource.name or generate_default_name(prefix=resource.RESOURCE_TYPE)
         if isinstance(resource, Module):
             resource.rename(name)
         else:

--- a/runhouse/utils.py
+++ b/runhouse/utils.py
@@ -24,6 +24,7 @@ import sys
 import threading
 
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional, Type, Union
 
@@ -454,3 +455,22 @@ class LogToFolder:
 
         path_to_ext = f"{self.directory}/{self.name}" + ext
         return path_to_ext
+
+
+####################################################################################################
+# Name generation
+####################################################################################################
+
+
+def generate_default_name(prefix: str = None, precision: str = "s", sep="_") -> str:
+    """Name of the Run's parent folder which contains the Run's data (config, stdout, stderr, etc).
+    If a name is provided, prepend that to the current timestamp to complete the folder name."""
+    if precision == "d":
+        timestamp_key = f"{datetime.now().strftime('%Y%m%d')}"
+    elif precision == "s":
+        timestamp_key = f"{datetime.now().strftime(f'%Y%m%d{sep}%H%M%S')}"
+    elif precision == "ms":
+        timestamp_key = f"{datetime.now().strftime(f'%Y%m%d{sep}%H%M%S_%f')}"
+    if prefix is None:
+        return timestamp_key
+    return f"{prefix}{sep}{timestamp_key}"


### PR DESCRIPTION
Since this doesn't rely on any Runhouse utilities, we can move it to the generic utils file and use it more easily.
