### PR TITLE
add manual server connection attempt if ping with threading fails

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -142,7 +142,7 @@ class Cluster(Resource):
                 )
             if not self._http_client:
                 raise ConnectionError(
-                    f"Error occured trying to form connection for cluster {self.name}."
+                    f"Error occurred trying to form connection for cluster {self.name}."
                 )
 
             try:
@@ -1264,6 +1264,12 @@ class Cluster(Resource):
 
         if retry:
             return self._ping(retry=False)
+
+        # Try to initialize the http client directly if the ssh threading call failed
+        self.connect_server_client()
+        if self._http_client:
+            return True
+
         return False
 
     def _copy_certs_to_cluster(self):
@@ -1421,7 +1427,6 @@ class Cluster(Resource):
 
             # set env vars after log statement
             command = f"{env_var_prefix} {command}" if env_var_prefix else command
-
             if not pwd:
                 ssh_mode = (
                     SshMode.INTERACTIVE


### PR DESCRIPTION
Try to initialize the http client synchronously if the threading ssh call fails as part of the cluster `_ping.` 

```
 Exception: Could not reach cluster k8s-cpu (['10.0.164.189']). Is it up?
```

In this case the k8s pod was up, and initializing the http client directly worked

Saw this in [CI](https://github.com/run-house/runhouse/actions/runs/10437082520/job/28902856013) and also reproduced it locally