### PR TITLE
create `run_name` for `get_call` http route if not specified

### DIFF
--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -421,8 +421,9 @@ class HTTPServer:
         # Default argument to json doesn't allow a user to pass in a serialization string if they want
         # But, if they didn't pass anything, we want it to be `json` by default.
         serialization = serialization or "json"
-
         try:
+            if run_name is None:
+                run_name = f"{key}_{method_name}_{serialization}_{remote}"
 
             # The types need to be explicitly specified as parameters first so that
             # we can cast Query params to the right type.


### PR DESCRIPTION
We're not setting a `run_name` on the `get_call` endpoint. This comes up when [calling a function via CURL](https://github.com/run-house/runhouse/actions/runs/10487756209/job/29048800796).

This update creates a run name if not provided in the request
