### PR TITLE
upgrade ray + pydantic versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-dotenv
 fastapi
 pexpect
 pyopenssl>=23.3.0
-ray[default] >= 2.2.0, != 2.6.0
+ray[default] >= 2.9.0
 rich
 sentry-sdk
 setuptools < 70.0.0
@@ -11,3 +11,4 @@ uvicorn
 wheel
 apispec
 httpx
+pydantic >=2.5.0

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -1192,10 +1192,10 @@ class Module(Resource):
 
             module_method_params = create_model(
                 f"{method_name}_schema", **params
-            ).schema()
+            ).model_json_schema()
             module_method_params["title"] = "kwargs"
 
-            request_body_schema = CallParams.schema()
+            request_body_schema = CallParams.model_json_schema()
             request_body_schema["properties"]["data"] = {
                 "title": "data",
                 "type": "object",

--- a/runhouse/servers/http/http_client.py
+++ b/runhouse/servers/http/http_client.py
@@ -284,13 +284,13 @@ class HTTPClient:
     def folder_ls(self, path: Union[str, Path], full_paths: bool, sort: bool):
         folder_params = FolderLsParams(
             path=path, full_paths=full_paths, sort=sort
-        ).dict()
+        ).model_dump()
         return self.request_json(
             "/folder/method/ls", req_type="post", json_dict=folder_params
         )
 
     def folder_mkdir(self, path: Union[str, Path]):
-        folder_params = FolderParams(path=path).dict()
+        folder_params = FolderParams(path=path).model_dump()
         return self.request_json(
             "/folder/method/mkdir", req_type="post", json_dict=folder_params
         )
@@ -300,13 +300,15 @@ class HTTPClient:
     ):
         folder_params = FolderMvParams(
             path=path, dest_path=dest_path, overwrite=overwrite
-        ).dict()
+        ).model_dump()
         return self.request_json(
             "/folder/method/mv", req_type="post", json_dict=folder_params
         )
 
     def folder_get(self, path: Union[str, Path], encoding: str, mode: str):
-        folder_params = FolderGetParams(path=path, encoding=encoding, mode=mode).dict()
+        folder_params = FolderGetParams(
+            path=path, encoding=encoding, mode=mode
+        ).model_dump()
         return self.request_json(
             "/folder/method/get", req_type="post", json_dict=folder_params
         )
@@ -325,7 +327,7 @@ class HTTPClient:
             mode=mode,
             overwrite=overwrite,
             serialization=serialization,
-        ).dict()
+        ).model_dump()
         return self.request_json(
             "/folder/method/put", req_type="post", json_dict=folder_params
         )
@@ -333,13 +335,13 @@ class HTTPClient:
     def folder_rm(self, path: Union[str, Path], contents: List, recursive: bool):
         folder_params = FolderRmParams(
             path=path, recursive=recursive, contents=contents
-        ).dict()
+        ).model_dump()
         return self.request_json(
             "/folder/method/rm", req_type="post", json_dict=folder_params
         )
 
     def folder_exists(self, path: str):
-        folder_params = FolderParams(path=path).dict()
+        folder_params = FolderParams(path=path).model_dump()
         return self.request_json(
             "/folder/method/exists", req_type="post", json_dict=folder_params
         )
@@ -443,7 +445,7 @@ class HTTPClient:
                 stream_logs=stream_logs,
                 save=save,
                 remote=remote,
-            ).dict(),
+            ).model_dump(),
             stream=True,
             headers=rns_client.request_headers(resource_address),
             auth=self.auth,
@@ -562,7 +564,7 @@ class HTTPClient:
                 save=save,
                 remote=remote,
                 run_async=run_async,
-            ).dict(),
+            ).model_dump(),
             headers=rns_client.request_headers(resource_address),
         ) as res:
             if res.status_code != 200:
@@ -602,7 +604,7 @@ class HTTPClient:
                 serialized_data=serialize_data(value, "pickle"),
                 env_name=env,
                 serialization="pickle",
-            ).dict(),
+            ).model_dump(),
             err_str=f"Error putting object {key}",
         )
 
@@ -618,7 +620,7 @@ class HTTPClient:
                 serialized_data=serialize_data([config, state, dryrun], "pickle"),
                 env_name=env_name,
                 serialization="pickle",
-            ).dict(),
+            ).model_dump(),
             err_str=f"Error putting resource {resource.name or type(resource)}",
         )
 
@@ -638,7 +640,7 @@ class HTTPClient:
                     key=key,
                     serialization="pickle",
                     remote=remote,
-                ).dict(),
+                ).model_dump(),
                 err_str=f"Error getting object {key}",
             )
             if remote and isinstance(res, dict) and "resource_type" in res:
@@ -661,7 +663,7 @@ class HTTPClient:
         self.request_json(
             "rename",
             req_type="post",
-            json_dict=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            json_dict=RenameObjectParams(key=old_key, new_key=new_key).model_dump(),
             err_str=f"Error renaming object {old_key}",
         )
 
@@ -688,7 +690,7 @@ class HTTPClient:
         return self.request_json(
             "delete_object",
             req_type="post",
-            json_dict=DeleteObjectParams(keys=keys or []).dict(),
+            json_dict=DeleteObjectParams(keys=keys or []).model_dump(),
             err_str=f"Error deleting keys {keys}",
         )
 

--- a/runhouse/servers/http/http_server.py
+++ b/runhouse/servers/http/http_server.py
@@ -440,7 +440,7 @@ class HTTPServer:
             )
 
             query_params_remaining = dict(request.query_params)
-            call_params_dict = params.dict()
+            call_params_dict = params.model_dump()
             for k, v in dict(request.query_params).items():
                 # If one of the query_params matches an arg in CallParams, set it
                 # And also remove it from the query_params dict, so the rest

--- a/runhouse/servers/http/http_utils.py
+++ b/runhouse/servers/http/http_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Union
 import requests
 
 from fastapi import HTTPException
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 from ray import cloudpickle as pickle
 from ray.exceptions import RayTaskError
 
@@ -95,7 +95,7 @@ class OutputType:
 class FolderParams(BaseModel):
     path: str
 
-    @validator("path", pre=True, always=True)
+    @field_validator("path", mode="before")
     def convert_path_to_string(cls, v):
         return str(v) if v is not None else v
 
@@ -126,7 +126,7 @@ class FolderMvParams(FolderParams):
     dest_path: str
     overwrite: Optional[bool] = True
 
-    @validator("dest_path", pre=True, always=True)
+    @field_validator("dest_path", mode="before")
     def convert_path_to_string(cls, v):
         return str(v) if v is not None else v
 

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -1575,7 +1575,7 @@ class ObjStore:
             )
 
             active_fn_calls = [
-                call_info.dict()
+                call_info.model_dump()
                 for call_info in current_active_function_calls.values()
                 if call_info.key == k
             ]

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     "fastapi",
     "pexpect",
     "pyOpenSSL>=23.3.0",
-    "ray[default] >= 2.2.0, != 2.6.0",
+    "ray[default] >= 2.9.0",
     "async_timeout",  # Needed for ray<=2.9
     "rich",
     "sentry-sdk",
@@ -76,6 +76,7 @@ install_requires = [
     "wheel",
     "apispec",
     "httpx",
+    "pydantic >= 2.5.0",  # required for ray >= 2.9.0 (https://github.com/ray-project/ray/releases?page=2)
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the following

--- a/tests/test_servers/test_caddy.py
+++ b/tests/test_servers/test_caddy.py
@@ -364,7 +364,7 @@ class TestCaddyServerLocally:
                 serialized_data=serialize_data(test_list, "pickle"),
                 key=key,
                 serialization="pickle",
-            ).dict(),
+            ).model_dump(),
             headers=rns_client.request_headers(cluster.rns_address),
             verify=verify,
         )

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -65,7 +65,9 @@ class TestHTTPServerDocker:
         )
         response = http_client.post(
             "/resource",
-            json=PutResourceParams(serialized_data=data, serialization="pickle").dict(),
+            json=PutResourceParams(
+                serialized_data=data, serialization="pickle"
+            ).model_dump(),
             headers=rns_client.request_headers(cluster.rns_address),
         )
         assert response.status_code == 200
@@ -80,7 +82,7 @@ class TestHTTPServerDocker:
                 key=key,
                 serialized_data=serialize_data(test_list, "pickle"),
                 serialization="pickle",
-            ).dict(),
+            ).model_dump(),
             headers=rns_client.request_headers(cluster.rns_address),
         )
         assert response.status_code == 200
@@ -97,7 +99,7 @@ class TestHTTPServerDocker:
         new_key = "key2"
         response = http_client.post(
             "/rename",
-            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            json=RenameObjectParams(key=old_key, new_key=new_key).model_dump(),
             headers=rns_client.request_headers(cluster.rns_address),
         )
         assert response.status_code == 200
@@ -113,7 +115,7 @@ class TestHTTPServerDocker:
         key = "key2"
         response = http_client.post(
             url="/delete_object",
-            json=DeleteObjectParams(keys=[key]).dict(),
+            json=DeleteObjectParams(keys=[key]).model_dump(),
             headers=rns_client.request_headers(cluster.rns_address),
         )
         assert response.status_code == 200
@@ -649,7 +651,9 @@ class TestHTTPServerDockerDenAuthOnly:
         )
         response = http_client.post(
             "/resource",
-            json=PutResourceParams(serialized_data=data, serialization="pickle").dict(),
+            json=PutResourceParams(
+                serialized_data=data, serialization="pickle"
+            ).model_dump(),
             headers=INVALID_HEADERS,
         )
         assert response.status_code == 403
@@ -684,7 +688,7 @@ class TestHTTPServerDockerDenAuthOnly:
                 key="key1",
                 serialized_data=serialize_data(test_list, "pickle"),
                 serialization="pickle",
-            ).dict(),
+            ).model_dump(),
             headers=INVALID_HEADERS,
         )
         assert response.status_code == 403
@@ -696,7 +700,7 @@ class TestHTTPServerDockerDenAuthOnly:
         new_key = "key2"
         response = http_client.post(
             "/rename",
-            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            json=RenameObjectParams(key=old_key, new_key=new_key).model_dump(),
             headers=INVALID_HEADERS,
         )
         assert response.status_code == 403
@@ -754,7 +758,7 @@ class TestHTTPServerNoDocker:
                 "/resource",
                 json=PutResourceParams(
                     serialized_data=data, serialization="pickle"
-                ).dict(),
+                ).model_dump(),
                 headers=rns_client.request_headers(local_cluster.rns_address),
             )
             assert response.status_code == 200
@@ -768,7 +772,7 @@ class TestHTTPServerNoDocker:
                 key="key1",
                 serialized_data=serialize_data(test_list, "pickle"),
                 serialization="pickle",
-            ).dict(),
+            ).model_dump(),
             headers=rns_client.request_headers(local_cluster.rns_address),
         )
         assert response.status_code == 200
@@ -779,7 +783,7 @@ class TestHTTPServerNoDocker:
         new_key = "key2"
         response = client.post(
             "/rename",
-            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            json=RenameObjectParams(key=old_key, new_key=new_key).model_dump(),
             headers=rns_client.request_headers(local_cluster.rns_address),
         )
         assert response.status_code == 200
@@ -804,7 +808,7 @@ class TestHTTPServerNoDocker:
         key = "key"
         response = client.post(
             url="/delete_object",
-            json=DeleteObjectParams(keys=[key]).dict(),
+            json=DeleteObjectParams(keys=[key]).model_dump(),
             headers=rns_client.request_headers(local_cluster.rns_address),
         )
         assert response.status_code == 200
@@ -860,7 +864,7 @@ class TestHTTPServerNoDockerDenAuthOnly:
                 "/resource",
                 json=PutResourceParams(
                     serialized_data=data, serialization="pickle"
-                ).dict(),
+                ).model_dump(),
                 headers=INVALID_HEADERS,
             )
 
@@ -875,7 +879,7 @@ class TestHTTPServerNoDockerDenAuthOnly:
                 key="key1",
                 serialized_data=serialize_data(test_list, "pickle"),
                 serialization="pickle",
-            ).dict(),
+            ).model_dump(),
             headers=INVALID_HEADERS,
         )
         assert resp.status_code == 403
@@ -886,7 +890,7 @@ class TestHTTPServerNoDockerDenAuthOnly:
         new_key = "key2"
         resp = local_client_with_den_auth.post(
             "/rename",
-            json=RenameObjectParams(key=old_key, new_key=new_key).dict(),
+            json=RenameObjectParams(key=old_key, new_key=new_key).model_dump(),
             headers=INVALID_HEADERS,
         )
         assert resp.status_code == 403


### PR DESCRIPTION
Some pydantic docs for reference: 
 https://docs.pydantic.dev/2.8/migration/#validator-and-root_validator-are-deprecated
https://docs.pydantic.dev/latest/concepts/fields/#field-representation

Currently, we still using the pydantic.v1 validator, because Ray is installing pydantic < 1.10.0 (https://github.com/ray-project/ray/blob/master/release/requirements.txt). Not sure for how long we could use it thought: according to pydantic documentation looks like v1 deprecated methods will be completely deprecated after v3 is released. (https://docs.pydantic.dev/latest/version-policy/#pydantic-v2). So probably need to talk to ray about their plan (if such exists) to upgrade pydantic v1 to v2. 