### PR TITLE
load cluster token from Den instead of generating client side

### DIFF
--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -562,9 +562,7 @@ def status(
         current_cluster = cluster_or_local  # cluster_or_local = rh.here
 
     try:
-        cluster_status = current_cluster.status(
-            resource_address=current_cluster.rns_address, send_to_den=send_to_den
-        )
+        cluster_status = current_cluster.status(send_to_den=send_to_den)
 
     except ValueError:
         console.print("Failed to load status for cluster.")

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -832,11 +832,10 @@ class Cluster(Resource):
                 system=self,
             )
 
-    def status(self, resource_address: str = None, send_to_den: bool = False):
+    def status(self, send_to_den: bool = False):
         """Load the status of the Runhouse daemon running on a cluster.
 
         Args:
-            resource_address (str, optional):
             send_to_den (bool, optional): Whether to send and update the status in Den. Only applies to
                 clusters that are saved to Den. (Default: ``False``)
         """
@@ -848,7 +847,6 @@ class Cluster(Resource):
         else:
             status, den_resp_status_code = self.call_client_method(
                 "status",
-                resource_address=resource_address or self.rns_address,
                 send_to_den=send_to_den,
             )
 
@@ -1041,7 +1039,7 @@ class Cluster(Resource):
             user_config = yaml.safe_dump(
                 {
                     "token": rns_client.cluster_token(
-                        rns_client.token, rns_client.username
+                        resource_address=rns_client.username
                     ),
                     "username": rns_client.username,
                     "default_folder": rns_client.default_folder,
@@ -1174,7 +1172,6 @@ class Cluster(Resource):
             method_to_call,
             module_name,
             method_name,
-            resource_address=self.rns_address,
             stream_logs=stream_logs,
             data={"args": args, "kwargs": kwargs},
             run_name=run_name,

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -155,11 +155,16 @@ class ClusterServlet:
     ) -> Union[str, None]:
         # If the token in this request matches that of the owner of the cluster,
         # they have access to everything
-        if configs.token and (
-            configs.token == token
-            or rns_client.cluster_token(configs.token, resource_uri) == token
-        ):
-            return ResourceAccess.WRITE
+        config_token = configs.token
+        if config_token:
+            if config_token == token:
+                return ResourceAccess.WRITE
+
+            if resource_uri and rns_client.validate_cluster_token(
+                cluster_token=token, cluster_uri=resource_uri
+            ):
+                return ResourceAccess.WRITE
+
         return self._auth_cache.lookup_access_level(token, resource_uri)
 
     async def aget_username(self, token: str) -> str:

--- a/runhouse/servers/http/auth.py
+++ b/runhouse/servers/http/auth.py
@@ -85,13 +85,14 @@ async def averify_cluster_access(
     from runhouse.globals import configs, obj_store
 
     # The logged-in user always has full access to the cluster. This is especially important if they flip on
-    # Den Auth without saving the cluster. We may need to generate a subtoken here to check.
+    # Den Auth without saving the cluster. Note: The token saved in the cluster config is a hashed cluster token,
+    # which may match the token provided in the request headers.
     if configs.token:
         if configs.token == token:
             return True
-        if (
-            cluster_uri
-            and rns_client.cluster_token(configs.token, cluster_uri) == token
+
+        if cluster_uri and rns_client.validate_cluster_token(
+            cluster_token=token, cluster_uri=cluster_uri
         ):
             return True
 

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -522,13 +522,14 @@ class ObjStore:
         # The logged-in user always has full access to the cluster and its resources. This is especially
         # important if they flip on Den Auth without saving the cluster.
 
-        # configs.token is the token stored on the cluster itself
-        if configs.token:
-            if configs.token == token:
+        # configs.token is the token stored on the cluster itself, which is itself a hashed subtoken
+        config_token = configs.token
+        if config_token:
+            if config_token == token:
                 return True
-            if (
-                resource_uri
-                and rns_client.cluster_token(configs.token, resource_uri) == token
+
+            if resource_uri and rns_client.validate_cluster_token(
+                cluster_token=token, cluster_uri=resource_uri
             ):
                 return True
 

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -425,13 +425,17 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         remote_assume_caller_and_get_token.share(
             users=["info@run.house"], notify_users=False
         )
+        current_username = rh.configs.username
+        current_den_token = rh.configs.token
 
         with friend_account():
             unassumed_token, assumed_token = remote_assume_caller_and_get_token()
             # "Local token" is the token the cluster accesses in rh.configs.token; this is what will be used
             # in subsequent rns_client calls
             assert assumed_token == rh.globals.rns_client.cluster_token(
-                rh.configs.token, cluster.rns_address
+                cluster.rns_address,
+                username=current_username,
+                den_token=current_den_token,
             )
             assert unassumed_token != rh.configs.token
 

--- a/tests/test_servers/test_http_server.py
+++ b/tests/test_servers/test_http_server.py
@@ -611,7 +611,8 @@ class TestHTTPServerDockerDenAuthOnly:
 
         import requests
 
-        with friend_account():  # Test accounts with Den auth are created under test_account
+        with friend_account():
+            # Test accounts with Den auth are created under test_account
             res = requests.get(
                 f"{rns_client.api_server_url}/resource",
                 headers=rns_client.request_headers(cluster.rns_address),


### PR DESCRIPTION
- generate cluster tokens in Den instead of client side. tokens are now OIDC compliant, and required for enabling telemetry
- prevent regenerating the cluster tokens unnecessarily on the client side
- ping new den API on clusters in order to validate the token received