### PR TITLE
update release pre-check and drop py3.7 support

### DIFF
--- a/.github/workflows/release_precheck.yaml
+++ b/.github/workflows/release_precheck.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Checkout repository
@@ -26,12 +26,11 @@ jobs:
     - name: Create Conda environment
       run: conda create --yes --name test-env python=${{ matrix.python-version }}
 
-    - name: Install current package in editable mode and importlib_metadata for python 3.7
+    - name: Install current package in editable mode
       run: |
         source $CONDA/etc/profile.d/conda.sh
         conda activate test-env
         pip install -e .
-        pip install importlib_metadata
 
     - name: Test package import
       run: |


### PR DESCRIPTION
Our current Ray version is no longer supported for python 3.7 (https://github.com/ray-project/ray/issues/39395)