### PR TITLE
Skip status teardown test for now

### DIFF
--- a/tests/test_resources/test_clusters/test_on_demand_cluster.py
+++ b/tests/test_resources/test_clusters/test_on_demand_cluster.py
@@ -206,6 +206,8 @@ class TestOnDemandCluster(tests.test_resources.test_clusters.test_cluster.TestCl
     # Status tests
     ####################################################################################################
 
+    # TODO: Affects cluster state, causes other tests to fail with ssh connection errors
+    @pytest.mark.skip()
     @pytest.mark.level("minimal")
     def test_set_status_after_teardown(self, cluster, mocker):
         mock_function = mocker.patch("sky.down")


### PR DESCRIPTION
test fails and then causes several future tests to fail. may not be mocked properly and causing cluster state to be affected during the teardown call. skip for now for more accurate nightly release tests

cc @BelSasha 