### PR TITLE
add option to skip writing secret down to rh config

### DIFF
--- a/runhouse/resources/secrets/provider_secrets/api_key_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/api_key_secret.py
@@ -21,11 +21,17 @@ class ApiKeySecret(ProviderSecret):
         path: str = None,
         env_vars: Dict = None,
         overwrite: bool = False,
+        write_config: bool = True,
     ):
         if not file or path:
             env = True
         super().write(
-            file=file, env=env, path=path, env_vars=env_vars, overwrite=overwrite
+            file=file,
+            env=env,
+            path=path,
+            env_vars=env_vars,
+            overwrite=overwrite,
+            write_config=write_config,
         )
 
     def to(

--- a/runhouse/resources/secrets/provider_secrets/aws_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/aws_secret.py
@@ -26,7 +26,13 @@ class AWSSecret(ProviderSecret):
     def from_config(config: dict, dryrun: bool = False, _resolve_children: bool = True):
         return AWSSecret(**config, dryrun=dryrun)
 
-    def _write_to_file(self, path: str, values: Dict, overwrite: bool = False):
+    def _write_to_file(
+        self,
+        path: str,
+        values: Dict,
+        overwrite: bool = False,
+        write_config: bool = True,
+    ):
         new_secret = copy.deepcopy(self)
 
         if not _check_file_for_mismatches(
@@ -50,7 +56,9 @@ class AWSSecret(ProviderSecret):
             full_path = create_local_dir(path)
             with open(full_path, "w+") as f:
                 parser.write(f)
-            new_secret._add_to_rh_config(path)
+
+            if write_config:
+                new_secret._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/azure_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/azure_secret.py
@@ -29,6 +29,7 @@ class AzureSecret(ProviderSecret):
         path: str = None,
         values: Dict = None,
         overwrite: bool = False,
+        write_config: bool = True,
     ):
         new_secret = copy.deepcopy(self)
         if not _check_file_for_mismatches(
@@ -48,7 +49,9 @@ class AzureSecret(ProviderSecret):
             full_path = create_local_dir(path)
             with open(full_path, "w") as f:
                 parser.write(f)
-            new_secret._add_to_rh_config(path)
+
+            if write_config:
+                new_secret._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/gcp_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/gcp_secret.py
@@ -26,7 +26,13 @@ class GCPSecret(ProviderSecret):
     def from_config(config: dict, dryrun: bool = False, _resolve_children: bool = True):
         return GCPSecret(**config, dryrun=dryrun)
 
-    def _write_to_file(self, path: str, values: Dict = None, overwrite: bool = False):
+    def _write_to_file(
+        self,
+        path: str,
+        values: Dict = None,
+        overwrite: bool = False,
+        write_config: bool = True,
+    ):
         new_secret = copy.deepcopy(self)
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
@@ -34,7 +40,9 @@ class GCPSecret(ProviderSecret):
             Path(path).parent.mkdir(parents=True, exist_ok=True)
             with open(path, "w+") as f:
                 json.dump(values, f, indent=4)
-            new_secret._add_to_rh_config(path)
+
+            if write_config:
+                new_secret._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/github_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/github_secret.py
@@ -24,7 +24,13 @@ class GitHubSecret(ProviderSecret):
     def from_config(config: dict, dryrun: bool = False, _resolve_children: bool = True):
         return GitHubSecret(**config, dryrun=dryrun)
 
-    def _write_to_file(self, path: str, values: Dict = None, overwrite: bool = False):
+    def _write_to_file(
+        self,
+        path: str,
+        values: Dict = None,
+        overwrite: bool = False,
+        write_config: bool = True,
+    ):
         new_secret = copy.deepcopy(self)
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
@@ -40,7 +46,9 @@ class GitHubSecret(ProviderSecret):
             Path(full_path).parent.mkdir(parents=True, exist_ok=True)
             with open(full_path, "w") as yaml_file:
                 yaml.dump(config, yaml_file, default_flow_style=False)
-            new_secret._add_to_rh_config(path)
+
+            if write_config:
+                new_secret._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/huggingface_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/huggingface_secret.py
@@ -25,7 +25,13 @@ class HuggingFaceSecret(ProviderSecret):
     def from_config(config: dict, dryrun: bool = False, _resolve_children: bool = True):
         return HuggingFaceSecret(**config, dryrun=dryrun)
 
-    def _write_to_file(self, path: str, values: Dict = None, overwrite: bool = False):
+    def _write_to_file(
+        self,
+        path: str,
+        values: Dict = None,
+        overwrite: bool = False,
+        write_config: bool = True,
+    ):
         new_secret = copy.deepcopy(self)
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
@@ -34,7 +40,9 @@ class HuggingFaceSecret(ProviderSecret):
             full_path = create_local_dir(path)
             with open(full_path, "a") as f:
                 f.write(token)
-            new_secret._add_to_rh_config(path)
+
+            if write_config:
+                new_secret._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/lambda_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/lambda_secret.py
@@ -22,7 +22,13 @@ class LambdaSecret(ProviderSecret):
     def from_config(config: dict, dryrun: bool = False, _resolve_children: bool = True):
         return LambdaSecret(**config, dryrun=dryrun)
 
-    def _write_to_file(self, path: str, values: Dict = None, overwrite: bool = False):
+    def _write_to_file(
+        self,
+        path: str,
+        values: Dict = None,
+        overwrite: bool = False,
+        write_config: bool = True,
+    ):
         new_secret = copy.deepcopy(self)
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
@@ -31,7 +37,9 @@ class LambdaSecret(ProviderSecret):
             full_path = create_local_dir(path)
             with open(full_path, "w+") as f:
                 f.write(data)
-            new_secret._add_to_rh_config(path)
+
+            if write_config:
+                new_secret._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/provider_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/provider_secret.py
@@ -109,6 +109,7 @@ class ProviderSecret(Secret):
         file: bool = False,
         env: bool = False,
         overwrite: bool = False,
+        write_config: bool = True,
     ):
         if not self.values:
             raise ValueError("Could not determine values to write down.")
@@ -119,7 +120,9 @@ class ProviderSecret(Secret):
 
         if file or path:
             path = path or self.path or self._DEFAULT_CREDENTIALS_PATH
-            return self._write_to_file(path, values=self.values, overwrite=overwrite)
+            return self._write_to_file(
+                path, values=self.values, overwrite=overwrite, write_config=write_config
+            )
         elif env or env_vars:
             env_vars = env_vars or self.env_vars or self._DEFAULT_ENV_VARS
             return self._write_to_env(env_vars, values=self.values, overwrite=overwrite)
@@ -206,7 +209,9 @@ class ProviderSecret(Secret):
         system.call(key, "_write_to_file", path=path, values=values)
         return path
 
-    def _write_to_file(self, path: str, values: Any, overwrite: bool = False):
+    def _write_to_file(
+        self, path: str, values: Any, overwrite: bool = False, write_config: bool = True
+    ):
         new_secret = copy.deepcopy(self)
         if not _check_file_for_mismatches(
             path, self._from_path(path), values, overwrite
@@ -214,7 +219,9 @@ class ProviderSecret(Secret):
             full_path = create_local_dir(path)
             with open(full_path, "w") as f:
                 json.dump(values, f, indent=4)
-            self._add_to_rh_config(path)
+
+            if write_config:
+                self._add_to_rh_config(path)
 
         new_secret._values = None
         new_secret.path = path

--- a/runhouse/resources/secrets/provider_secrets/ssh_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/ssh_secret.py
@@ -63,7 +63,13 @@ class SSHSecret(ProviderSecret):
             folder=folder,
         )
 
-    def _write_to_file(self, path: str, values: Dict = None, overwrite: bool = False):
+    def _write_to_file(
+        self,
+        path: str,
+        values: Dict = None,
+        overwrite: bool = False,
+        write_config: bool = True,
+    ):
         priv_key_path = path
 
         priv_key_path = Path(os.path.expanduser(priv_key_path))
@@ -95,10 +101,12 @@ class SSHSecret(ProviderSecret):
         new_secret = copy.deepcopy(self)
         new_secret._values = None
         new_secret.path = path
-        try:
-            new_secret._add_to_rh_config(val=path)
-        except TypeError:
-            pass
+
+        if write_config:
+            try:
+                new_secret._add_to_rh_config(val=path)
+            except TypeError:
+                pass
 
         return new_secret
 


### PR DESCRIPTION
Needed for the new [launcher service](https://github.com/run-house/runhouse-launcher), where we use the secrets APIs to save down SSH keys in a temp env/directory for the user. In this case we don't need to persist the config value in the RH config, so adding an option to skip. Shouldn't disrupt any existing OSS APIs 
