### PR TITLE
Add support for ondemand cluster default creds

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -15,6 +15,8 @@ import requests
 import yaml
 
 from runhouse.resources.hardware.utils import (
+    _setup_creds_from_dict,
+    _setup_default_creds,
     ClustersListStatus,
     get_clusters_from_den,
     get_running_and_not_running_clusters,
@@ -277,65 +279,25 @@ class Cluster(Resource):
     def _setup_creds(self, ssh_creds: Union[Dict, "Secret", str]):
         """Setup cluster credentials from user provided ssh_creds"""
         from runhouse.resources.secrets import Secret
-        from runhouse.resources.secrets.provider_secrets.sky_secret import SkySecret
-        from runhouse.resources.secrets.provider_secrets.ssh_secret import SSHSecret
 
-        if not hasattr(self, "_creds"):
-            self._creds = None
-
-        if not ssh_creds:
-            return
-        elif isinstance(ssh_creds, Secret):
+        if isinstance(ssh_creds, Secret):
             self._creds = ssh_creds
             return
         elif isinstance(ssh_creds, str):
             self._creds = Secret.from_name(ssh_creds)
             return
 
-        creds = (
-            copy.copy(ssh_creds) if isinstance(ssh_creds, Dict) else (ssh_creds or {})
-        )
-        private_key_path = (
-            creds["ssh_private_key"] if "ssh_private_key" in creds else None
-        )
-        self.ssh_properties["ssh_private_key"] = private_key_path
-        password = creds.pop("password") if "password" in creds else None
+        if not ssh_creds:
+            from runhouse.resources.hardware.on_demand_cluster import OnDemandCluster
 
-        if private_key_path:
-            key = os.path.basename(private_key_path)
-
-            if password:
-                # extract ssh values and create ssh secret
-                values = (
-                    SSHSecret.extract_secrets_from_path(private_key_path)
-                    if private_key_path
-                    else {}
-                )
-                values["password"] = password
-                self._creds = SSHSecret(
-                    name=f"{self.name}-ssh-secret",
-                    provider="ssh",
-                    key=key,
-                    path=private_key_path,
-                    values=values,
-                )
-            else:
-                # set as standard SSH secret
-                constructor = SkySecret if key == "sky-key" else SSHSecret
-                self._creds = constructor(
-                    name=f"ssh-{key}", key=key, path=private_key_path
-                )
-        elif password:
-            self._creds = Secret(
-                name=f"{self.name}-ssh-secret", values={"password": password}
+            cluster_subtype = (
+                "OnDemandCluster" if isinstance(self, OnDemandCluster) else "Cluster"
             )
-
-        # save non secret values to `_ssh_properties` field
-        if isinstance(creds, Dict):
-            self.ssh_properties = creds
-
-        if self.den_auth or rns_client.autosave_resources():
-            self.save()
+            self._creds = _setup_default_creds(cluster_subtype)
+        elif isinstance(ssh_creds, Dict):
+            creds, ssh_properties = _setup_creds_from_dict(ssh_creds, self.name)
+            self._creds = creds
+            self.ssh_properties = ssh_properties
 
     def _should_save_creds(self, folder: str = None) -> bool:
         """Checks whether to save the creds associated with the cluster.
@@ -447,15 +409,19 @@ class Cluster(Resource):
                 "ssh_properties",
             ],
         )
-        creds = self._resource_string_for_subconfig(self._creds, condensed)
+        creds = (
+            self._resource_string_for_subconfig(self._creds, condensed)
+            if hasattr(self, "_creds") and self._creds
+            else None
+        )
+        if creds:
+            if "loaded_secret_" in creds:
+                # user A shares cluster with user B, with "write" permissions. If user B will save the cluster to Den, we
+                # would NOT like that the loaded secret will overwrite the original secret that was created and shared by
+                # user A.
+                creds = creds.replace("loaded_secret_", "")
+            config["creds"] = creds
 
-        # user A shares cluster with user B, with "write" permissions. If user B will save the cluster to Den, we
-        # would NOT like that the loaded secret will overwrite the original secret that was created and shared by
-        # user A.
-        if creds and "loaded_secret_" in creds:
-            creds = creds.replace("loaded_secret_", "")
-
-        config["creds"] = creds
         config["api_server_url"] = rns_client.api_server_url
 
         if self._default_env:

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -396,7 +396,7 @@ class OnDemandCluster(Cluster):
                 ssh_values = backend_utils.ssh_credential_from_yaml(
                     yaml_path, ssh_user=handle.ssh_user
                 )
-                if not self.creds_values:
+                if not self.creds_values or not self.ssh_properties:
                     self._setup_creds(ssh_values)
 
             # Add worker IPs if multi-node cluster - keep the head node as the first IP

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -1,6 +1,8 @@
+import copy
 import datetime
 import hashlib
 import json
+import os
 import re
 import subprocess
 
@@ -134,6 +136,75 @@ def _get_cluster_from(system, dryrun=False):
 
 def _unnamed_default_env_name(cluster_name):
     return f"{cluster_name}_default_env"
+
+
+def _setup_default_creds(cluster_type: str):
+    from runhouse.resources.secrets import Secret
+
+    default_ssh_key = rns_client.default_ssh_key
+    if cluster_type == "OnDemandCluster":
+        try:
+            sky_secret = Secret.from_name("sky")
+            return sky_secret
+        except ValueError:
+            if default_ssh_key:
+                # copy over default key to sky-key for launching use
+                default_secret = Secret.from_name(default_ssh_key)
+                sky_secret = default_secret._write_to_file("~/.ssh/sky-key")
+                return sky_secret
+            else:
+                return None
+    elif default_ssh_key:
+        return Secret.from_name(default_ssh_key)
+    return None
+
+
+def _setup_creds_from_dict(ssh_creds: Dict, cluster_name: str):
+    from runhouse.resources.secrets import Secret
+    from runhouse.resources.secrets.provider_secrets.sky_secret import SkySecret
+    from runhouse.resources.secrets.provider_secrets.ssh_secret import SSHSecret
+
+    creds = copy.copy(ssh_creds)
+    ssh_properties = {}
+    cluster_secret = None
+
+    private_key_path = creds["ssh_private_key"] if "ssh_private_key" in creds else None
+    password = creds.pop("password") if "password" in creds else None
+
+    if private_key_path:
+        key = os.path.basename(private_key_path)
+
+        if password:
+            # extract ssh values and create ssh secret
+            values = (
+                SSHSecret.extract_secrets_from_path(private_key_path)
+                if private_key_path
+                else {}
+            )
+            values["password"] = password
+            cluster_secret = SSHSecret(
+                name=f"{cluster_name}-ssh-secret",
+                provider="ssh",
+                key=key,
+                path=private_key_path,
+                values=values,
+            )
+        else:
+            # set as standard SSH secret
+            constructor = SkySecret if key == "sky-key" else SSHSecret
+            cluster_secret = constructor(
+                name=f"ssh-{key}", key=key, path=private_key_path
+            )
+    elif password:
+        cluster_secret = Secret(
+            name=f"{cluster_name}-ssh-secret", values={"password": password}
+        )
+
+    # keep track of non secret/password values in ssh_properties
+    if isinstance(creds, Dict):
+        ssh_properties = creds
+
+    return cluster_secret, ssh_properties
 
 
 def detect_cuda_version_or_cpu(cluster: "Cluster" = None, node: Optional[str] = None):

--- a/runhouse/resources/secrets/provider_secrets/ssh_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/ssh_secret.py
@@ -83,6 +83,8 @@ class SSHSecret(ProviderSecret):
         priv_key_path = Path(os.path.expanduser(priv_key_path))
         pub_key_path = Path(f"{os.path.expanduser(priv_key_path)}.pub")
 
+        values = values or self.values
+
         if priv_key_path.exists() and pub_key_path.exists():
             if values == self._from_path(path=path):
                 logger.info(f"Secrets already exist in {path}. Skipping.")
@@ -109,6 +111,7 @@ class SSHSecret(ProviderSecret):
         new_secret = copy.deepcopy(self)
         new_secret._values = None
         new_secret.path = path
+        new_secret.name = f"ssh-{os.path.basename(path)}"
 
         if write_config:
             try:


### PR DESCRIPTION
perform some extra setup to allow for using your own default creds for ondemand clusters.
* if ~/.ssh/sky-key exists: do nothing, sky will launch with those creds
* if ~/.ssh/sky-key does not exist and default_ssh_key exists, copy those creds to ~/.ssh/sky-key so sky can launch with those creds
* if neither exists, do nothing. sky will create the creds when it launches

note that this does not support passing in custom `ssh_creds` for ondemand_clusters. it's only for the case of defaulting the sky-key to your default key if you have a default key but no sky key.