### PR TITLE
Update gcp_secret.py to remove unnecessary default env vars

### DIFF
--- a/runhouse/resources/secrets/provider_secrets/gcp_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/gcp_secret.py
@@ -17,10 +17,6 @@ class GCPSecret(ProviderSecret):
 
     _PROVIDER = "gcp"
     _DEFAULT_CREDENTIALS_PATH = "~/.config/gcloud/application_default_credentials.json"
-    _DEFAULT_ENV_VARS = {
-        "client_id": "CLIENT_ID",
-        "client_secret": "CLIENT_SECRET",
-    }
 
     @staticmethod
     def from_config(config: dict, dryrun: bool = False, _resolve_children: bool = True):


### PR DESCRIPTION
A) The bug is we try env_vars = {env_vars[k]: self.values[k] for k in self.values} but
self.values is {'account': '', 'client_id': '', 'client_secret': '', 'quota_project_id': '', 'refresh_token': '', 'type': '', 'universe_domain': ''}

while env_vars is {'client_id': 'CLIENT_ID', 'client_secret': 'CLIENT_SECRET'} (from gcp_secret.py _DEFAULT_ENV_VARS )

Hence we get KeyError: 'account'

B) Setting these env vars aren't actually necessary at all for the GCP secrets to work. We are already correctly writing the credentials JSON to ~/.config. The only env variable we might want to set for gcloud auth is the path to the credentials config, but that's not done here.