### PR TITLE
Update cuda detection

### DIFF
--- a/runhouse/resources/packages/package.py
+++ b/runhouse/resources/packages/package.py
@@ -353,7 +353,6 @@ class Package(Resource):
         if not any("torch" in req for req in reqs_list):
             return f"-r {reqs_path}" + install_args
 
-        cuda_version_or_cpu = detect_cuda_version_or_cpu(cluster=cluster)
         for req in reqs_list:
             if (
                 "--index-url" in req or "--extra-index-url" in req
@@ -361,6 +360,7 @@ class Package(Resource):
                 return f"-r {reqs_path}" + install_args
 
         # add extra-index-url for torch if not found
+        cuda_version_or_cpu = detect_cuda_version_or_cpu(cluster=cluster)
         return f"-r {reqs_path} --extra-index-url {self._torch_index_url(cuda_version_or_cpu)}"
 
     def _install_cmd_for_torch(self, install_cmd, cluster=None):
@@ -370,6 +370,8 @@ class Package(Resource):
 
         torch_source_packages = ["torch", "torchvision", "torchaudio"]
         if not any([x in install_cmd for x in torch_source_packages]):
+            return install_cmd
+        if "+" in install_cmd or "--extra-index-url" in install_cmd:
             return install_cmd
 
         packages_to_install: list = self._packages_to_install_from_cmd(install_cmd)

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -28,7 +28,7 @@ from runhouse.constants import (
 from runhouse.globals import configs, obj_store, rns_client
 from runhouse.logger import get_logger
 from runhouse.resources.hardware import load_cluster_config_from_file
-from runhouse.resources.hardware.utils import detect_cuda_version_or_cpu
+from runhouse.resources.hardware.utils import is_gpu_cluster
 from runhouse.rns.rns_client import ResourceStatusData
 from runhouse.rns.utils.api import ResourceAccess
 from runhouse.servers.autostop_helper import AutostopHelper
@@ -61,7 +61,7 @@ class ClusterServlet:
         self.cluster_config: Optional[Dict[str, Any]] = (
             cluster_config if cluster_config else {}
         )
-        self.cluster_config["has_cuda"] = detect_cuda_version_or_cpu() != "cpu"
+        self.cluster_config["has_cuda"] = is_gpu_cluster()
 
         self._initialized_servlet_names: Set[str] = set()
         self._key_to_servlet_name: Dict[Any, str] = {}
@@ -135,7 +135,7 @@ class ClusterServlet:
 
     async def aset_cluster_config(self, cluster_config: Dict[str, Any]):
         if "has_cuda" not in cluster_config.keys():
-            cluster_config["has_cuda"] = detect_cuda_version_or_cpu() != "cpu"
+            cluster_config["has_cuda"] = is_gpu_cluster()
 
         self.cluster_config = cluster_config
 

--- a/runhouse/servers/servlet.py
+++ b/runhouse/servers/servlet.py
@@ -22,7 +22,7 @@ from runhouse.constants import (
 from runhouse.globals import obj_store
 from runhouse.logger import get_logger
 
-from runhouse.resources.hardware.utils import detect_cuda_version_or_cpu
+from runhouse.resources.hardware.utils import is_gpu_cluster
 
 from runhouse.servers.http.http_utils import (
     deserialize_data,
@@ -126,7 +126,7 @@ class Servlet:
             threading.Lock()
         )  # will be used when self.gpu_metrics will be updated by different threads.
 
-        if detect_cuda_version_or_cpu() != "cpu":
+        if is_gpu_cluster():
             logger.debug("Creating _periodic_gpu_check thread.")
             collect_gpu_thread = threading.Thread(
                 target=self._collect_env_gpu_usage, daemon=True


### PR DESCRIPTION
nvcc might not be installed by default (e.g. minimal updated sky images) -- use `/usr/local/bin/cuda/nvcc` as fallback and update code to skip the cuda version detection code if unnecessary