### PR TITLE
Fix Module serialization across disperate python versions

### DIFF
--- a/runhouse/resources/distributed/dask_distributed.py
+++ b/runhouse/resources/distributed/dask_distributed.py
@@ -32,3 +32,9 @@ class DaskDistributed(Supervisor):
 
     def __call__(self, *args, **kwargs):
         return self.call(*args, **kwargs)
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        # Dask client can't be serialized
+        state["_dask_client"] = None
+        return state

--- a/runhouse/resources/future_module.py
+++ b/runhouse/resources/future_module.py
@@ -50,7 +50,7 @@ class FutureModule(Module, Awaitable):
         return self._future.exception()
 
     def __getstate__(self):
-        state = self.__dict__.copy()
+        state = super().__getstate__()
         state["_future"] = None
         return state
 
@@ -83,7 +83,7 @@ class GeneratorModule(Module, Generator):
         return self._future.throw(__typ, __val, __tb)
 
     def __getstate__(self):
-        state = self.__dict__.copy()
+        state = super().__getstate__()
         state["_future"] = None
         return state
 
@@ -117,6 +117,6 @@ class AsyncGeneratorModule(Module, AsyncIterable):
         return self._future.throw(__typ, __val, __tb)
 
     def __getstate__(self):
-        state = self.__dict__.copy()
+        state = super().__getstate__()
         state["_future"] = None
         return state

--- a/tests/test_resources/test_modules/test_module.py
+++ b/tests/test_resources/test_modules/test_module.py
@@ -241,6 +241,8 @@ def construct_and_use_calculator_module(mod_name):
 
 def nested_call_logs_stream_helper(slow_numpy_array):
     vals = []
+    print("Starting nested call")
+    time.sleep(1)
     for i in range(3):
         time.sleep(1)
         val = slow_numpy_array.print_and_log(i)


### PR DESCRIPTION
This looks like a quick change but is acutally a big deal. It enables serialization and deserialization of Modules objects across dramatically different Python environments. The `__reduce__` method ensures Module subclasses are pickled as base Module objects, preventing deserialization errors when pickle attempts to locate the Module subclasses in remote environments. 