### PR TITLE
Replace cluster internal_external_ips attribute with internal_ips

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -113,6 +113,7 @@ class Cluster(Resource):
         self._rpc_tunnel = None
 
         self.ips = ips
+        self.internal_ips = ips
         self._http_client = None
         self.den_auth = den_auth or False
         self.cert_config = TLSCertConfig(cert_path=ssl_certfile, key_path=ssl_keyfile)
@@ -142,10 +143,6 @@ class Cluster(Resource):
     @property
     def address(self):
         return self.head_ip
-
-    @property
-    def internal_ips(self):
-        return self.ips
 
     @property
     def client(self):
@@ -593,6 +590,7 @@ class Cluster(Resource):
         if not self.is_up():
             # Don't store stale IPs
             self.ips = None
+            self.internal_ips = None
             self.up()
         return self
 
@@ -645,6 +643,7 @@ class Cluster(Resource):
                     env_name=conda_env_name,
                     conda_yaml=self._default_env.conda_yaml,
                     cluster=self,
+                    node=node,
                 )
 
             self.install_packages(
@@ -1056,16 +1055,18 @@ class Cluster(Resource):
         return self._use_https and not (self._use_caddy and self.domain is not None)
 
     def _start_ray_workers(self, ray_port, env):
-        for host in self.ips:
-            if host == self.head_ip:
-                # This is the master node, skip
-                continue
+        internal_head_ip = self.internal_ips[0]
+        worker_ips = self.ips[
+            1:
+        ]  # Using external worker address here because we're running from local
+
+        for host in worker_ips:
             logger.info(
-                f"Starting Ray on worker {host} with head node at {self.head_ip}:{ray_port}."
+                f"Starting Ray on worker {host} with head node at {internal_head_ip}:{ray_port}."
             )
             self.run(
                 commands=[
-                    f"ray start --address={self.head_ip}:{ray_port} --disable-usage-stats",
+                    f"ray start --address={internal_head_ip}:{ray_port} --disable-usage-stats",
                 ],
                 node=host,
                 env=env,

--- a/runhouse/resources/hardware/launcher_utils.py
+++ b/runhouse/resources/hardware/launcher_utils.py
@@ -176,6 +176,7 @@ class DenLauncher(Launcher):
         for attribute in [
             "launched_properties",
             "ips",
+            "internal_ips",
             "stable_internal_external_ips",
             "ssh_properties",
             "client_port",

--- a/runhouse/servers/obj_store.py
+++ b/runhouse/servers/obj_store.py
@@ -369,12 +369,12 @@ class ObjStore:
     def get_internal_ips(self):
         """Get list of internal IPs of all nodes in the cluster."""
         cluster_config = self.get_cluster_config()
-        if "stable_internal_external_ips" in cluster_config:
+        if "internal_ips" in cluster_config:
+            return cluster_config["internal_ips"]
+        elif "stable_internal_external_ips" in cluster_config:
             return [
                 internal_ip
-                for internal_ip, external_ip in cluster_config[
-                    "stable_internal_external_ips"
-                ]
+                for internal_ip, _ in cluster_config["stable_internal_external_ips"]
             ]
         else:
             if not ray.is_initialized():

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -311,15 +311,6 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         on_cluster_config = remove_config_keys(on_cluster_config, keys_to_skip)
         local_cluster_config = remove_config_keys(local_cluster_config, keys_to_skip)
 
-        if local_cluster_config.get("stable_internal_external_ips", False):
-            cluster_ips = local_cluster_config.pop(
-                "stable_internal_external_ips", None
-            )[0]
-            on_cluster_ips = on_cluster_config.pop(
-                "stable_internal_external_ips", None
-            )[0]
-            assert tuple(cluster_ips) == tuple(on_cluster_ips)
-
         assert on_cluster_config == local_cluster_config
 
     @pytest.mark.level("local")

--- a/tests/test_resources/test_resource.py
+++ b/tests/test_resources/test_resource.py
@@ -6,7 +6,7 @@ import runhouse as rh
 from tests.conftest import init_args
 
 from tests.constants import TEST_ORG
-from tests.utils import friend_account, friend_account_in_org, remove_config_keys
+from tests.utils import friend_account, friend_account_in_org
 
 
 def load_shared_resource_config(resource_class_name, address):
@@ -105,17 +105,9 @@ class TestResource:
         # Test loading from name
         loaded_resource = saved_resource.__class__.from_name(saved_resource.rns_address)
 
-        if isinstance(saved_resource, rh.OnDemandCluster):
-            loaded_resource_config = remove_config_keys(
-                loaded_resource.config(), ["stable_internal_external_ips"]
-            )
-            saved_resource_config = remove_config_keys(
-                saved_resource.config(), ["stable_internal_external_ips"]
-            )
-            assert loaded_resource_config == saved_resource_config
-            # Changing the name doesn't work for OnDemandCluster, because the name won't match the local sky db
-            return
         assert loaded_resource.config() == saved_resource.config()
+        if isinstance(saved_resource, rh.OnDemandCluster):
+            return
 
         # Do everything inside a try/finally so we don't leave resources behind if the test fails
         try:


### PR DESCRIPTION
replace `self.internal_external_ips` with just `self.internal_ips` (`self.ips` already stores external ips). leave ability to load internal_external_ips from kwargs for backwards compatibility for now.