### PR TITLE
cluster list: display unknown last_active_time as None

### DIFF
--- a/runhouse/cli_utils.py
+++ b/runhouse/cli_utils.py
@@ -101,13 +101,11 @@ def create_output_table(
 
 def add_cluster_as_table_row(table: Table, rh_cluster: dict):
     """Adding an info of a single cluster to the output table."""
-    last_active = rh_cluster.get("Last Active (UTC)")
-    last_active = last_active if last_active != "01/01/1970, 00:00:00" else "Unknown"
     table.add_row(
         rh_cluster.get("Name"),
         rh_cluster.get("Cluster Type"),
         rh_cluster.get("Status"),
-        last_active,
+        rh_cluster.get("Last Active (UTC)"),
     )
 
     return table
@@ -117,9 +115,12 @@ def add_clusters_to_output_table(table: Table, clusters: List[Dict]):
     """Adding clusters info to the output table."""
     for rh_cluster in clusters:
         last_active_at = rh_cluster.get("Last Active (UTC)")
-        last_active_at_no_offset = str(last_active_at).split("+")[
-            0
-        ]  # The split is required to remove the offset (according to UTC)
+        if not last_active_at:  # case when last_active_at == None
+            last_active_at_no_offset = last_active_at
+        else:
+            last_active_at_no_offset = str(last_active_at).split("+")[
+                0
+            ]  # The split is required to remove the offset (according to UTC)
         rh_cluster["Last Active (UTC)"] = last_active_at_no_offset
         rh_cluster["Status"] = StatusColors.get_status_color(rh_cluster.get("Status"))
 


### PR DESCRIPTION
Before we displayed the Last Active as unknown: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jgyZx8QY4kPzsqPq1fYd/d1df780a-4930-4079-96c9-744d2a236ee7.png)

With the introduced change we just display the Last Active as None (empty): 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jgyZx8QY4kPzsqPq1fYd/0281fe53-6f07-4207-a0b9-a5eff57a4718.png)

Cluster.list() pythonic output:
![image](https://github.com/user-attachments/assets/e0b37750-310d-4e2d-a585-89cc71d2b782)


