### PR TITLE
Remove stopping of autostop when notebook is launched

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -1920,12 +1920,11 @@ class Cluster(Resource):
 
         try:
             jupyter_cmd = f"jupyter lab --port {port_fwd} --no-browser"
-            with self.pause_autostop():
-                self.install_packages(["jupyterlab"])
-                # TODO figure out why logs are not streaming here if we don't use ssh.
-                # When we do, it may be better to switch it back because then jupyter is killed
-                # automatically when the cluster is restarted (and the process is killed).
-                self.run(commands=[jupyter_cmd], stream_logs=True, node=self.head_ip)
+            self.install_packages(["jupyterlab"])
+            # TODO figure out why logs are not streaming here if we don't use ssh.
+            # When we do, it may be better to switch it back because then jupyter is killed
+            # automatically when the cluster is restarted (and the process is killed).
+            self.run(commands=[jupyter_cmd], stream_logs=True, node=self.head_ip)
 
         finally:
             if sync_package_on_close:


### PR DESCRIPTION
Also it removes dependence on skypilot for stopping of autostop -- IDK maybe we want to update pausing of autostop to reflect on Den but it might be too complex. 

Just don't launch a cluster with autostop? This is the only place we use it I think.