### PR TITLE
Set sky secret on den clusters

### DIFF
--- a/runhouse/resources/hardware/launcher_utils.py
+++ b/runhouse/resources/hardware/launcher_utils.py
@@ -192,6 +192,7 @@ class DenLauncher(Launcher):
     def up(cls, cluster, verbose: bool = True, force: bool = False):
         """Launch the cluster via Den."""
         sky_secret = cls.sky_secret()
+        cluster._creds = sky_secret
 
         payload = {
             "cluster_config": {


### PR DESCRIPTION
Fixes an issue where the SSH creds on the cluster locally weren't matching up with the sky secret assigned by the launcher
