### PR TITLE
persist k8s namespace and context in ondemand cluster config

### DIFF
--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -208,7 +208,9 @@ def kubernetes_cluster(
             UserWarning,
         )
 
-    if namespace is not None:  # check if user passed a user-defined namespace
+    if namespace is not None and launcher_type == "local":
+        # Set the context only if launching locally
+        # check if user passed a user-defined namespace
         cmd = f"kubectl config set-context --current --namespace={namespace}"
         try:
             process = subprocess.run(
@@ -254,7 +256,8 @@ def kubernetes_cluster(
         except subprocess.CalledProcessError as e:
             logger.info(f"Error copying kubeconfig: {e}")
 
-    if context is not None:  # check if user passed a user-defined context
+    if context is not None and launcher_type == "local":
+        # check if user passed a user-defined context
         try:
             cmd = f"kubectl config use-context {context}"  # set user-defined context as current context
             subprocess.run(cmd, shell=True, check=True)
@@ -268,6 +271,8 @@ def kubernetes_cluster(
         provider="kubernetes",
         launcher_type=launcher_type,
         server_connection_type=server_connection_type,
+        namespace=namespace,
+        context=context,
         **kwargs,
     )
     c.set_connection_defaults()

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -129,6 +129,8 @@ class OnDemandCluster(Cluster):
             **kwargs.get("launched_properties", {}),
         }
         self._docker_user = None
+        self._namespace = kwargs.get("namespace")
+        self._context = kwargs.get("context")
 
         # Checks if state info is in local sky db, populates if so.
         if not dryrun and not self.ips and not self.creds_values:
@@ -222,7 +224,13 @@ class OnDemandCluster(Cluster):
         compute_properties.pop("ips")
         if compute_properties:
             config["compute_properties"] = compute_properties
+
         config["autostop_mins"] = self._autostop_mins
+        if self._namespace is not None:
+            config["namespace"] = self._namespace
+        if self._context is not None:
+            config["context"] = self._context
+
         return config
 
     def endpoint(self, external: bool = False):


### PR DESCRIPTION
Required for setting context and/or namespace remotely for the den launcher