### PR TITLE
Keep secrets in user namespace, fix creds on den teardown

### DIFF
--- a/runhouse/resources/hardware/launcher_utils.py
+++ b/runhouse/resources/hardware/launcher_utils.py
@@ -243,13 +243,18 @@ class DenLauncher(Launcher):
     @classmethod
     def teardown(cls, cluster, verbose: bool = True):
         """Tearing down a cluster via Den."""
-        sky_secret = cls.sky_secret()
+        from runhouse.resources.secrets import Secret
+
+        ssh_creds = cluster._creds
+        if isinstance(ssh_creds, Secret):
+            ssh_creds = ssh_creds.rns_address
+
         cluster_name = cluster.rns_address or cluster.name
 
         payload = {
             "cluster_name": cluster_name,
             "delete_from_den": False,
-            "ssh_creds": sky_secret.rns_address,
+            "ssh_creds": ssh_creds,
             "verbose": verbose,
         }
 

--- a/runhouse/resources/secrets/secret_factory.py
+++ b/runhouse/resources/secrets/secret_factory.py
@@ -26,12 +26,16 @@ def secret(
     Example:
         >>> rh.secret("in_memory_secret", values={"secret_key": "secret_val"})
     """
+    from runhouse.globals import rns_client
+
     if provider:
         return provider_secret(
             name=name, provider=provider, values=values, dryrun=dryrun
         )
 
     if name and not values:
+        if "/" not in name and rns_client.username:
+            name = f"/{rns_client.username}/{name}"
         return Secret.from_name(name, load_from_den=load_from_den, dryrun=dryrun)
 
     if not values:


### PR DESCRIPTION
- Use the established SSH creds for cluster teardown
- Ensures secrets are saved to user's folder instead of `default_folder` (relevant for organizations)