### PR TITLE
use cluster status instead of runhouse daemon status for cluster CLI commands

### DIFF
--- a/runhouse/cli_utils.py
+++ b/runhouse/cli_utils.py
@@ -145,7 +145,7 @@ def condense_resource_type(resource_type: str):
 
 
 class StatusType(str, Enum):
-    server = ("sever",)
+    server = "server"
     cluster = "cluster"
 
 
@@ -417,10 +417,11 @@ def print_cloud_properties(cluster_config: dict):
 
 
 def print_status(status_data: dict, current_cluster) -> None:
+    """Prints the status of the cluster to the console"""
+
     from runhouse.globals import rns_client
     from runhouse.main import console
 
-    """Prints the status of the cluster to the console"""
     cluster_config = status_data.get("cluster_config")
     servlet_processes = status_data.get("env_servlet_processes")
 

--- a/runhouse/constants.py
+++ b/runhouse/constants.py
@@ -108,7 +108,7 @@ INCREASED_INTERVAL = 1 * HOUR
 
 # Constants runhouse cluster list
 LAST_ACTIVE_AT_TIMEFRAME = 24 * HOUR
-MAX_CLUSTERS_DISPLAY = 50
+MAX_CLUSTERS_DISPLAY = 200
 
 # in seconds
 TIME_UNITS = {"s": SECOND, "m": MINUTE, "h": HOUR, "d": DAY}

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -249,8 +249,7 @@ def cluster_list(
     cluster_status: Optional[ClustersListStatus] = typer.Option(
         None,
         "--status",
-        help="Cluster status to filter on. Supported filter values: 'running', 'terminated' (cluster is not live), "
-        "'down' (Runhouse server is down, but the cluster might be live).",
+        help="Cluster status to filter on. Supported filter values: 'up', 'stopped', 'init', 'unknown'.",
     ),
 ):
     """
@@ -262,7 +261,7 @@ def cluster_list(
 
         ``$ runhouse cluster list --all``
 
-        ``$ runhouse cluster list --status terminated``
+        ``$ runhouse cluster list --status up``
 
         ``$ runhouse cluster list --since 15m``
 
@@ -284,7 +283,7 @@ def cluster_list(
         [
             den_cluster
             for den_cluster in den_clusters
-            if den_cluster.get("Status") == "running"
+            if den_cluster.get("Status").lower() == "up"
         ]
         if den_clusters
         else None
@@ -439,7 +438,7 @@ def cluster_down(
             raise typer.Exit(0)
 
     if remove_all:
-        running_den_clusters = Cluster.list(status=ClustersListStatus.running).get(
+        running_den_clusters = Cluster.list(status=ClustersListStatus.UP).get(
             "den_clusters"
         )
 

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -2279,16 +2279,18 @@ class Cluster(Resource):
         cls,
         show_all: bool = False,
         since: Optional[str] = None,
-        status: Optional[ClustersListStatus] = None,
+        status: Optional[Union[ClustersListStatus, str]] = None,
     ) -> Dict[str, List[Dict]]:
         """
-        Returns user's runhouse clusters saved in Den and locally via Sky. If filters are provided, only clusters that are matching the
-        filters are returned. If no filters are provided, clusters that were active in the last 24 hours are returned.
+        Loads Runhouse clusters saved in Den and locally via Sky. If filters are provided, only clusters that
+        are matching the filters are returned. If no filters are provided, all running clusters will be returned.
 
         Args:
-            show_all (bool, optional): Whether to list all clusters saved in Den. Maximum of 50 will be listed. (Default: False).
-            since (str, optional): Clusters that were active in the specified time period will be returned. Value can be in seconds, minutes, hours or days.
-            status (ResourceServerStatus, optional): Clusters with the provided status will be returned.
+            show_all (bool, optional): Whether to list all clusters saved in Den. Maximum of 200 will be listed.
+                (Default: False).
+            since (str, optional): Currently running clusters that were active in the specified time period will
+                be returned. Value can be in seconds, minutes, hours or days.
+            status (ClustersListStatus or str, optional): Clusters with the provided status will be returned.
 
         Examples:
             >>> Cluster.list(since="75s")

--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -28,7 +28,7 @@ from runhouse.globals import configs, obj_store, rns_client
 from runhouse.logger import get_logger
 from runhouse.resources.hardware.utils import (
     LauncherType,
-    ResourceServerStatus,
+    RunhouseDaemonStatus,
     ServerConnectionType,
     up_cluster_helper,
 )
@@ -583,10 +583,10 @@ class OnDemandCluster(Cluster):
             >>> rh.ondemand_cluster("rh-cpu").teardown()
         """
         try:
-            # Update Den with the cluster's status before tearing down
+            # Update Den with the runhouse server status on the cluster before tearing down
             cluster_status_data = self.status()
             status_data = {
-                "status": ResourceServerStatus.terminated,
+                "status": RunhouseDaemonStatus.terminated,
                 "resource_type": self.__class__.__base__.__name__.lower(),
                 "data": cluster_status_data,
             }

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -287,7 +287,7 @@ class ClusterServlet:
     # Periodic Cluster Checks APIs
     ##############################################
     async def asave_status_metrics_to_den(self, status: dict):
-        from runhouse.resources.hardware.utils import ResourceServerStatus
+        from runhouse.resources.hardware.utils import RunhouseDaemonStatus
 
         # making a copy so the status won't be modified with pop, since it will be returned after sending to den.
         # (status is passed as pointer).
@@ -295,7 +295,7 @@ class ClusterServlet:
         servlet_processes = status_copy.pop("env_servlet_processes")
 
         status_data = {
-            "status": ResourceServerStatus.running,
+            "status": RunhouseDaemonStatus.running,
             "resource_type": status_copy.get("cluster_config").pop(
                 "resource_type", "cluster"
             ),

--- a/tests/fixtures/docker_cluster_fixtures.py
+++ b/tests/fixtures/docker_cluster_fixtures.py
@@ -19,7 +19,6 @@ from runhouse.constants import (
     EMPTY_DEFAULT_ENV_NAME,
 )
 from runhouse.globals import rns_client
-from runhouse.resources.hardware.utils import ResourceServerStatus
 from tests.conftest import init_args
 
 from tests.constants import TESTING_LOG_LEVEL
@@ -109,7 +108,7 @@ def build_and_run_image(
         all=True,
         filters={
             "ancestor": f"runhouse:{image_name}",
-            "status": ResourceServerStatus.running,
+            "status": "running",
             "name": container_name,
         },
     )

--- a/tests/test_resources/test_clusters/test_on_demand_cluster.py
+++ b/tests/test_resources/test_clusters/test_on_demand_cluster.py
@@ -9,7 +9,7 @@ import requests
 import runhouse as rh
 
 from runhouse.globals import rns_client
-from runhouse.resources.hardware.utils import ResourceServerStatus
+from runhouse.resources.hardware.utils import RunhouseDaemonStatus
 
 import tests.test_resources.test_clusters.test_cluster
 from tests.constants import TESTING_AUTOSTOP_INTERVAL
@@ -299,6 +299,6 @@ class TestOnDemandCluster(tests.test_resources.test_clusters.test_cluster.TestCl
         # The latest status info is the first element in the list returned by the endpoint.
         get_status_data = get_status_data_resp.json()["data"][0]
         assert get_status_data["resource_type"] == cluster_config.get("resource_type")
-        assert get_status_data["status"] == ResourceServerStatus.terminated
+        assert get_status_data["status"] == RunhouseDaemonStatus.terminated
 
         assert cluster.is_up()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ import yaml
 
 from runhouse.globals import rns_client
 
-from runhouse.resources.hardware.utils import ResourceServerStatus
+from runhouse.resources.hardware.utils import ClustersListStatus
 from runhouse.servers.http.http_utils import CreateProcessParams
 from runhouse.servers.obj_store import get_cluster_servlet, ObjStore, RaySetupOption
 
@@ -181,12 +181,13 @@ def remove_config_keys(config, keys_to_skip):
     return config
 
 
-def set_cluster_status(cluster: rh.Cluster, status: ResourceServerStatus):
+def set_cluster_status(cluster: rh.Cluster, status: ClustersListStatus):
     cluster_uri = rh.globals.rns_client.format_rns_address(cluster.rns_address)
     headers = rh.globals.rns_client.request_headers()
     api_server_url = rh.globals.rns_client.api_server_url
 
-    # updating the resource collection as well, because the cluster.list() gets the info from the resource
+    # updating the resource collection as well, because the `cluster.list()` gets the info from the resource
+    # Note: the resource collection stores the status of the cluster, not the Runhouse daemon running on the cluster
     status_data_resource = {
         "status": status,
         "status_last_checked": datetime.utcnow().isoformat(),


### PR DESCRIPTION
@mkandler work in progress but relates to the other refactorings going on in den / launcher