### PR TITLE
Compare resources in config without rns_address

### DIFF
--- a/runhouse/resources/resource.py
+++ b/runhouse/resources/resource.py
@@ -206,6 +206,12 @@ class Resource:
 
         def str_dict_or_resource_to_str(val):
             if isinstance(val, Resource):
+                if not val.rns_address and val.name and config.get("name"):
+                    # If rns_address is missing, try current resource folder
+                    _, folder = rns_client.split_rns_name_and_path(
+                        rns_client.resolve_rns_path(config.get("name"))
+                    )
+                    return f"{folder}/{val.name}"
                 return val.rns_address
             elif isinstance(val, dict):
                 # This can either be a sub-resource which hasn't been converted to a resource yet, or an


### PR DESCRIPTION
Originally I was going to update the `def rns_client` method to use the `rns_client.current_folder` when `_rns_folder` is missing but I think this is more acutely solving the issue I was having.

Case:
- Define an `env` with a name without a folder
- Define a cluster with `default_env=env`
- Save
- When re-running the script, env wasn't recognized because the `_compare_config_with_alt_options` method looks at `rns_address` which is None for a newly defined env (without loading or saving to Den)

The `current_folder` solution could fail in a case where you define a cluster name as `/<ORG_NAME>/gpu` since the current folder would NOT match the folder applied to the env after saving (which would be the save as the cluster, `<ORG_NAME>`...

Maybe this is not a problem in a post-image world