### PR TITLE
reorder teardown sequence

### DIFF
--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -579,8 +579,15 @@ class OnDemandCluster(Cluster):
         Example:
             >>> rh.ondemand_cluster("rh-cpu").teardown()
         """
+        if self.launcher_type == LauncherType.DEN:
+            logger.info("Tearing down cluster with Den.")
+            DenLauncher.teardown(cluster=self, verbose=verbose)
+        else:
+            logger.info("Tearing down cluster locally via Sky.")
+            LocalLauncher.teardown(cluster=self, verbose=verbose)
+
         try:
-            # Update Den with the cluster's status before tearing down
+            # Update Den with terminated cluster status
             cluster_status_data = self.status()
             status_data = {
                 "status": ResourceServerStatus.terminated,
@@ -601,13 +608,6 @@ class OnDemandCluster(Cluster):
 
         except Exception as e:
             logger.warning(e)
-
-        if self.launcher_type == LauncherType.DEN:
-            logger.info("Tearing down cluster with Den.")
-            DenLauncher.teardown(cluster=self, verbose=verbose)
-        else:
-            logger.info("Tearing down cluster locally via Sky.")
-            LocalLauncher.teardown(cluster=self, verbose=verbose)
 
     def teardown_and_delete(self, verbose: bool = True):
         """Teardown cluster and delete it from configs.


### PR DESCRIPTION
Teardown the cluster itself before updating Den. Two main reasons for this: 
- if there's an exception with the teardown proper we shouldn't update the DB 
- previously we were only updating the status of the runhouse daemon, but now we also update the status of the cluster itself. doing so means that if we update the DB first, the teardown will fail bc the cluster is marked as already "stopped" 