### PR TITLE
Update cluster restart server so periodic cluster status checks won't fail

### DIFF
--- a/runhouse/resources/hardware/sky/command_runner.py
+++ b/runhouse/resources/hardware/sky/command_runner.py
@@ -30,6 +30,7 @@ GIT_EXCLUDE = '.git/info/exclude'
 # to get a total progress bar, but it requires rsync>=3.1.0 and Mac
 # OS has a default rsync==2.6.9 (16 years old).
 RSYNC_DISPLAY_OPTION = '-Pavz'
+RSYNC_IGNORE_EXISTING = '--ignore-existing'
 # Legend
 #   dir-merge: ignore file can appear in any subdir, applies to that
 #     subdir downwards
@@ -233,6 +234,7 @@ class CommandRunner:
             get_remote_home_dir: Callable[[], str] = lambda: '~',
             filter_options: Optional[str] = None,  # RH MODIFIED,
             return_cmd: bool = False,  # RH MODIFIED,
+            ignore_existing: bool = False # RH MODIFIED,
         ) -> None:
         """Builds the rsync command."""
         # Build command.
@@ -240,6 +242,9 @@ class CommandRunner:
         if prefix_command is not None:
             rsync_command.append(prefix_command)
         rsync_command += ['rsync', RSYNC_DISPLAY_OPTION]
+
+        if ignore_existing:
+            rsync_command += [RSYNC_IGNORE_EXISTING]
 
         # --filter
         addtl_filter_options = f" --filter='{filter_options}'" if filter_options else ""    # RH MODIFIED

--- a/runhouse/resources/hardware/sky_command_runner.py
+++ b/runhouse/resources/hardware/sky_command_runner.py
@@ -238,6 +238,7 @@ class SkySSHRunner(SSHCommandRunner):
         stream_logs: bool = True,
         max_retry: int = 1,
         return_cmd: bool = False,  # RH MODIFIED
+        ignore_existing: bool = False,  # RH MODIFIED
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 
@@ -282,6 +283,7 @@ class SkySSHRunner(SSHCommandRunner):
             max_retry=max_retry,
             filter_options=filter_options,
             return_cmd=return_cmd,
+            ignore_existing=ignore_existing,
         )
 
 
@@ -431,6 +433,7 @@ class SkyKubernetesRunner(KubernetesCommandRunner):
         max_retry: int = 1,
         filter_options: bool = False,  # RH MODIFIED
         return_cmd: bool = False,  # RH MODIFIED
+        ignore_existing: bool = False,  # RH MODIFIED
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
         Args:
@@ -481,4 +484,5 @@ class SkyKubernetesRunner(KubernetesCommandRunner):
             get_remote_home_dir=get_remote_home_dir,
             filter_options=filter_options,
             return_cmd=return_cmd,
+            ignore_existing=ignore_existing,
         )

--- a/runhouse/servers/cluster_servlet.py
+++ b/runhouse/servers/cluster_servlet.py
@@ -385,6 +385,9 @@ class ClusterServlet:
     async def aperiodic_cluster_checks(self):
         """Periodically check the status of the cluster, gather metrics about the cluster's utilization & memory,
         and save it to Den."""
+
+        logger.debug("started periodic cluster checks")
+
         disable_observability = os.getenv("disable_observability", False)
         while True:
             should_send_status_and_logs_to_den: bool = (
@@ -520,6 +523,9 @@ class ClusterServlet:
 
     async def _aperiodic_gpu_check(self):
         """periodically collects cluster gpu usage"""
+
+        logger.debug("Started gpu usage collection")
+
         pynvml.nvmlInit()  # init nvidia ml info collection
 
         while True:


### PR DESCRIPTION
Context: the config yaml needs to be on the cluster before we run the restart command, otherwise cluster servlet checks (damon activity, logs, etc.) will fail initially 

Potential options to discuss: 
- revert back to rsyncing instead of requiring an HTTP connection 
- decouple cluster servlet initialization from the server restart 
- polling / waiting mechanism where cluster servelt initialization only starts once the config has been sent to the cluster
- passing in config as server restart params 

**Dec 2nd**:
After talking to @carolineechen and @rohinb2, decided to revert back to rsyncing instead of requiring an HTTP connection (reverting PR #[1478](https://github.com/run-house/runhouse/pull/1478) ).
