### PR TITLE
Add DockerRegistrySecret

### DIFF
--- a/docs/api/python/secrets.rst
+++ b/docs/api/python/secrets.rst
@@ -94,6 +94,15 @@ LambdaSecret Class
    .. autoattribute:: _DEFAULT_CREDENTIALS_PATH
 
 
+DockerRegistrySecret Class
+--------------------------
+.. autoclass:: runhouse.resources.secrets.provider_secrets.docker_secret.DockerRegistrySecret
+    :show-inheritance:
+
+    .. autoattribute:: _PROVIDER
+    .. autoattribute:: _DEFAULT_ENV_VARS
+
+
 SSHSecret Class
 ---------------
 .. autoclass:: runhouse.resources.secrets.provider_secrets.ssh_secret.SSHSecret

--- a/runhouse/resources/secrets/provider_secrets/docker_secret.py
+++ b/runhouse/resources/secrets/provider_secrets/docker_secret.py
@@ -1,0 +1,20 @@
+from runhouse.resources.secrets.provider_secrets.provider_secret import ProviderSecret
+
+
+class DockerRegistrySecret(ProviderSecret):
+    """
+    .. note::
+        To create a DockerRegistrySecret, please use the factory method
+        :func:`provider_secret` with ``provider="docker"``.
+    """
+
+    _PROVIDER = "docker"
+    _DEFAULT_ENV_VARS = {
+        "username": "SKYPILOT_DOCKER_USERNAME",
+        "password": "SKYPILOT_DOCKER_PASSWORD",
+        "server": "SKYPILOT_DOCKER_SERVER",
+    }
+
+    @staticmethod
+    def from_config(config: dict, dryrun: bool = False, _resolve_children: bool = True):
+        return DockerRegistrySecret(**config, dryrun=dryrun)

--- a/runhouse/resources/secrets/provider_secrets/providers.py
+++ b/runhouse/resources/secrets/provider_secrets/providers.py
@@ -2,6 +2,9 @@ from runhouse.resources.secrets.provider_secrets.anthropic_secret import Anthrop
 from runhouse.resources.secrets.provider_secrets.aws_secret import AWSSecret
 from runhouse.resources.secrets.provider_secrets.azure_secret import AzureSecret
 from runhouse.resources.secrets.provider_secrets.cohere_secret import CohereSecret
+from runhouse.resources.secrets.provider_secrets.docker_secret import (
+    DockerRegistrySecret,
+)
 from runhouse.resources.secrets.provider_secrets.gcp_secret import GCPSecret
 from runhouse.resources.secrets.provider_secrets.github_secret import GitHubSecret
 from runhouse.resources.secrets.provider_secrets.huggingface_secret import (
@@ -29,6 +32,7 @@ _str_to_provider_class = {
     "huggingface": HuggingFaceSecret,
     "kubernetes": KubeConfigSecret,
     "lambda": LambdaSecret,
+    "docker": DockerRegistrySecret,
     # SSH secrets
     "ssh": SSHSecret,
     "sky": SkySecret,


### PR DESCRIPTION
Values for storing and mapping env vars necessary to load docker images from private registry or ecr. 

- `rh.provider_secret("docker")` will extract values from `SKYPILOT_DOCKER_USERNAME/PASSWORD/SERVER` env vars
- can also create a dict mapping "username" "password" "server" to values and pass that in to `rh.provider_secret(provider="docker", values=values)`
- `_map_env_vars` implemented in later PR can be used to get mapping of sky env var to value
