### PR TITLE
ensure k8s rsync helper is included in installed package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include runhouse/builtins/*
+include runhouse/resources/hardware/kubernetes/*


### PR DESCRIPTION
In the launcher we were failing to rsync with the cluster, bc the bash script was missing 

```
ERROR | 2024-12-04 08:01:21 | [sky_handler.py:handle_exception:324] | Command chmod +x /usr/local/lib/python3.9/site-packages/runhouse/resources/hardware/kubernetes/rsync_helper.sh &&  rsync -Pavz --ignore-existing --filter='dir-merge,- .gitignore' -e /usr/local/lib/python3.9/site-packages/runhouse/resources/hardware/kubernetes/rsync_helper.sh '/tmp/tmpgoc4d6ws/config.yaml' poppy-k8s-eks-cpu-4-cd9f-head@default:'/home/sky/.rh/' failed with return code 1.

root@launcher-app-5c87f894b9-v9hfm:/tmp/tmpgoc4d6ws# chmod +x /usr/local/lib/python3.9/site-packages/runhouse/resources/hardware/kubernetes/rsync_helper.sh &&  rsync -Pavz --ignore-existing --filter='dir-merge,- .gitignore' -e /usr/local/lib/python3.9/site-packages/runhouse/resources/hardware/kubernetes/rsync_helper.sh '/tmp/tmpgoc4d6ws/config.yaml' poppy-k8s-eks-cpu-4-cd9f-head@default:'/home/sky/.rh/'
chmod: cannot access '/usr/local/lib/python3.9/site-packages/runhouse/resources/hardware/kubernetes/rsync_helper.sh': No such file or directory
```