### PR TITLE
fix cluster CI tests

### DIFF
--- a/runhouse/cli_utils.py
+++ b/runhouse/cli_utils.py
@@ -260,7 +260,7 @@ def print_envs_info(servlet_processes: Dict[str, Dict[str, Any]], current_cluste
         env_process_info = servlet_processes[env_name]
 
         # sometimes the env itself is not a resource (key) inside the env's servlet.
-        if len(resources_in_env) == 0:
+        if len(resources_in_env) == 0 or env_name not in resources_in_env.keys():
             env_type = "runhouse.Env"
         else:
             env_type = condense_resource_type(

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -395,12 +395,12 @@ def parse_filters(since: str, cluster_status: Union[str, ClusterStatus]):
 def get_clusters_from_den(cluster_filters: dict, force: bool):
     get_clusters_params = {"resource_type": "cluster", "folder": rns_client.username}
 
-    if (
-        "cluster_status" in cluster_filters
-        and cluster_filters["cluster_status"] == ClusterStatus.TERMINATED
+    if "cluster_status" in cluster_filters and any(
+        cluster_filters.get("cluster_status") == daemon_status
+        for daemon_status in RunhouseDaemonStatus
     ):
         # Include the relevant daemon status for the filter
-        cluster_filters["daemon_status"] = RunhouseDaemonStatus.TERMINATED
+        cluster_filters["daemon_status"] = cluster_filters.get("cluster_status")
 
     # If "all" filter is specified load all clusters (no filters are added to get_clusters_params)
     if cluster_filters and "all" not in cluster_filters.keys():


### PR DESCRIPTION
This PR includes some changes that unblocks cluster CI tests.

Later on should add fixes / changes to:
1. cluster status cli output, now that we have processes instead of envs
2. cluster list cli output, now that we have daemon status and cluster status separated

But those should be in separate PRs, since those are more "fundamental" changes. 