### PR TITLE
Fix server stop for remote cluster

### DIFF
--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -1310,7 +1310,8 @@ class Cluster(Resource):
         if not cleanup_actors:
             cmd = cmd + " --no-cleanup-actors"
 
-        status_codes = self.run([cmd], require_outputs=False)
+        # run on node where server was started
+        status_codes = self.run([cmd], node=self.head_ip, require_outputs=False)
         assert status_codes[0] == 0
 
     @contextlib.contextmanager


### PR DESCRIPTION
I don't think we can run the server stop command through http, since server gets killed midway and we don't get the status back.