### PR TITLE
Fix server status

### DIFF
--- a/runhouse/cli_utils.py
+++ b/runhouse/cli_utils.py
@@ -28,6 +28,7 @@ from runhouse.constants import (
 )
 
 from runhouse.logger import get_logger
+from runhouse.servers.obj_store import ObjStoreError
 
 logger = get_logger(__name__)
 
@@ -501,8 +502,13 @@ def get_cluster_or_local(cluster_name: str = None):
             raise typer.Exit(1)
         return current_cluster
 
-    cluster_or_local = rh.here
-    if cluster_or_local == "file" and not cluster_name:
+    try:
+        cluster_or_local = rh.here
+    except ObjStoreError:
+        console.print("Could not connect to Runhouse server. Is it up?")
+        raise typer.Exit(1)
+
+    if cluster_or_local == "file":
         # If running outside the cluster must specify a cluster name
         console.print(
             "Please specify a `cluster_name` or run [reset][bold italic]`runhouse server start`[/bold italic] to start "

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -9,7 +9,6 @@ from typing import Optional
 import ray
 
 import requests
-
 import typer
 import yaml
 from rich.console import Console
@@ -52,6 +51,8 @@ from runhouse.resources.hardware import (
     kill_actors,
 )
 from runhouse.resources.hardware.utils import ClusterStatus
+
+from runhouse.servers.obj_store import ObjStoreError
 
 SKY_LIVE_CLUSTERS_MSG = (
     "Live on-demand clusters created via Sky may exist that are not saved in Den. "
@@ -973,16 +974,14 @@ def server_status(
     """Check the HTTP server status on the cluster."""
     logger.debug("Checking the server status.")
     current_cluster = get_cluster_or_local(cluster_name=cluster_name)
-    if current_cluster._is_server_up():
+    try:
         status = current_cluster.status()
         console.print(f"[reset]{BULLET_UNICODE} server pid: {status.get('server_pid')}")
         print_cluster_config(
             cluster_config=status.get("cluster_config"), status_type=StatusType.server
         )
-    else:
-        console.print(
-            "Server is down. To check the status of the cluster, run [italic bold]`runhouse cluster status`"
-        )
+    except (ObjStoreError, ConnectionError):
+        console.print("Could not connect to Runhouse server. Is it up?")
 
 
 @app.callback(invoke_without_command=True, help="Runhouse CLI")

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -1310,7 +1310,8 @@ class Cluster(Resource):
         if not cleanup_actors:
             cmd = cmd + " --no-cleanup-actors"
 
-        status_codes = self.run([cmd], require_outputs=False)
+        # run on node where server was started
+        status_codes = self.run([cmd], node=self.head_ip, require_outputs=False)
         assert status_codes[0] == 0
 
     @contextlib.contextmanager

--- a/runhouse/resources/hardware/cluster.py
+++ b/runhouse/resources/hardware/cluster.py
@@ -571,15 +571,6 @@ class Cluster(Resource):
         """
         return self.on_this_cluster() or self._ping()
 
-    def _is_server_up(self) -> bool:
-        try:
-            self.client.check_server()
-            return True
-        except ValueError:
-            return False
-        except ConnectionError:
-            return False
-
     def up_if_not(self, verbose: bool = True):
         """Bring up the cluster if it is not up. No-op if cluster is already up.
         This only applies to on-demand clusters, and has no effect on self-managed clusters.


### PR DESCRIPTION
* we can't call `_is_server_up` for `rh.here` since we can't call/create a client or check is_up from on the cluster. instead, checking if an obj store error or connection error is being thrown to detect if server is down, unless there's a better approach for on the cluster (rh.here)
* if server is down, we log and ask the user to run `runhouse cluster status` but that itself will fail if the server is down? or is that not supposed to be the case?