### PR TITLE
fix cluster list all pythonic test

### DIFF
--- a/tests/fixtures/resource_fixtures.py
+++ b/tests/fixtures/resource_fixtures.py
@@ -37,9 +37,13 @@ def saved_resource_pool():
                 pass
 
 
+def create_folder_path():
+    return f"testing-{uuid.uuid4()}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+
+
 @pytest.fixture(scope="session")
 def test_rns_folder():
-    folder_path = f"testing-{uuid.uuid4()}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    folder_path = create_folder_path()
     yield folder_path
     rns_client.delete_configs(folder_path)
 

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -32,6 +32,7 @@ from runhouse.utils import _process_env_vars
 
 import tests.test_resources.test_resource
 from tests.conftest import init_args
+from tests.fixtures.resource_fixtures import create_folder_path
 from tests.test_resources.test_envs.test_env import _get_env_var_value
 from tests.utils import (
     friend_account,
@@ -1018,8 +1019,12 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
             original_username=original_username,
         ):
             # create dummy terminated cluster - set the daemon status to terminated, which will also
-            # update the cluster status
-            terminated_cluster = rh.cluster(name="terminated-cluster", ips=None).save()
+            # update the cluster status. Making sure that its name is in the same format as all testing clusters
+            # (contains timestamp and uuid)
+            terminated_cluster = rh.cluster(
+                name=f"{create_folder_path()}_terminated-cluster",
+                server_connection_type="ssh",
+            ).save()
             set_daemon_and_cluster_status(
                 terminated_cluster,
                 daemon_status=RunhouseDaemonStatus.TERMINATED,


### PR DESCRIPTION
Fixing the `cluster list all pythonic test`, issue was found after we started running den clean up cron every midnight. 