### PR TITLE
fix sky key secret creation so it won't break release testing locally

### DIFF
--- a/runhouse/constants.py
+++ b/runhouse/constants.py
@@ -112,3 +112,5 @@ ITALIC_BOLD = "\x1B[3m\x1B[1m"
 RESET_FORMAT = "\x1B[0m"
 
 SKY_VENV = "~/skypilot-runtime"
+
+SSH_SKY_SECRET_NAME = "ssh-sky-key"

--- a/runhouse/resources/hardware/launcher_utils.py
+++ b/runhouse/resources/hardware/launcher_utils.py
@@ -107,16 +107,19 @@ class Launcher:
 
     @classmethod
     def sky_secret(cls):
-        secrets_name = "ssh-sky-key"
+        from runhouse.constants import SSH_SKY_SECRET_NAME
+
         try:
-            sky_secret = rh.secret(secrets_name)
+            sky_secret = rh.secret(SSH_SKY_SECRET_NAME)
         except ValueError:
             # Create a new default key pair required for the Den launcher and save it to Den
             from runhouse import provider_secret
 
             default_ssh_path, _ = generate_ssh_keys()
             logger.info(f"Saved new SSH key to path: {default_ssh_path} ")
-            sky_secret = provider_secret(provider="sky", path=default_ssh_path)
+            sky_secret = provider_secret(
+                provider="sky", path=default_ssh_path, name=SSH_SKY_SECRET_NAME
+            )
             sky_secret.save()
 
         secret_values = sky_secret.values

--- a/tests/fixtures/on_demand_cluster_fixtures.py
+++ b/tests/fixtures/on_demand_cluster_fixtures.py
@@ -19,7 +19,10 @@ def restart_server(request):
     return request.config.getoption("--restart-server")
 
 
-def setup_test_cluster(args, request, setup_base=False):
+def setup_test_cluster(args, request, test_rns_folder, setup_base=False):
+    rh.constants.SSH_SKY_SECRET_NAME = (
+        f"{test_rns_folder}-{rh.constants.SSH_SKY_SECRET_NAME}"
+    )
     cluster = rh.ondemand_cluster(**args)
     init_args[id(cluster)] = args
     cluster.up_if_not()

--- a/tests/fixtures/static_cluster_fixtures.py
+++ b/tests/fixtures/static_cluster_fixtures.py
@@ -7,7 +7,10 @@ from tests.utils import setup_test_base
 
 
 @pytest.fixture(scope="session")
-def static_cpu_pwd_cluster():
+def static_cpu_pwd_cluster(test_rns_folder):
+    rh.constants.SSH_SKY_SECRET_NAME = (
+        f"{test_rns_folder}-{rh.constants.SSH_SKY_SECRET_NAME}"
+    )
     sky_cluster = rh.cluster(
         "aws-cpu-password", instance_type="CPU:4", provider="aws"
     ).save()


### PR DESCRIPTION
The problem:
`ssh-sky-key` is not being deleted during den clean up (which makes sense, it should not have). Therefore, there might be a mismatch between the `ssh-sky-key` values saved as a den secret, and the local` ssh-sky-key` values. (For example the `ssh-sky-key` values saved in den might belong to user A who created and saved this secret for `den_tester` and the local values might belong to user B who is running release testing with `den_tester`). This is the explanation to the following issue I was seeing:

```
ERROR tests/test_resources/test_modules/test_module.py::TestModule::test_module_from_factory[static_cpu_pwd_cluster_den_launcher] - ConnectionError: Could not reach testing-b83cbcb4-14fb-4c7b-ae13-7c73b62b8d2c-20241211-173742-den-aws-cpu-password 44.204.57.6. Is cluster up?
```

```
(base) sashabelousovrh@Alexandras-MacBook-Pro runhouse % runhouse server status /den_tester/testing-e91feebf-072b-4350-bb67-f75750c1fdcf-20241211-175620-den-aws-cpu-password

INFO | 2024-12-11 17:58:46 | runhouse.resources.hardware.cluster:1832 | Running command on testing-e91feebf-072b-4350-bb67-f75750c1fdcf-20241211-175620-den-aws-cpu-password: echo "hello"
INFO | 2024-12-11 17:58:47 | runhouse.resources.hardware.cluster:1832 | Running command on testing-e91feebf-072b-4350-bb67-f75750c1fdcf-20241211-175620-den-aws-cpu-password: echo "hello"
Cluster /den_tester/testing-e91feebf-072b-4350-bb67-f75750c1fdcf-20241211-175620-den-aws-cpu-password is not up. If it's an on-demand cluster, you can run `runhouse cluster up 
/den_tester/testing-e91feebf-072b-4350-bb67-f75750c1fdcf-20241211-175620-den-aws-cpu-password` to bring it up automatically.
```

The fix probably should be creating a new `ssh-sky-key` each time we are creating a cluster using the test cluster fixtures. This way we could parallelly run tests using den_tester (CI, few runhouse members running release tests locally etc), without getting the above error, since now the values of the local sky key and the one saved in den will match. 