### PR TITLE
Fix k8 nightly release tests failures

### DIFF
--- a/runhouse/resources/hardware/on_demand_cluster.py
+++ b/runhouse/resources/hardware/on_demand_cluster.py
@@ -523,6 +523,9 @@ class OnDemandCluster(Cluster):
                     _, current_context = kubernetes.config.list_kube_config_contexts()
                     self.compute_properties["kube_context"] = current_context["name"]
 
+                self._kube_namespace = self.compute_properties.get("kube_namespace")
+                self._kube_context = self.compute_properties.get("kube_context")
+
     def _update_from_sky_status(self, dryrun: bool = False):
         # Try to get the cluster status from SkyDB
         if self.is_shared:

--- a/tests/fixtures/on_demand_cluster_fixtures.py
+++ b/tests/fixtures/on_demand_cluster_fixtures.py
@@ -183,9 +183,10 @@ def ondemand_k8s_cluster(request, test_rns_folder):
 
     # Note: Cannot specify both `instance_type` and any of `memory`, `disk_size`, `num_cpus`, or `gpus`
     args = {
-        "name": "k8s-cpu",
+        "name": f"{test_rns_folder}-k8s-cpu",
         "provider": "kubernetes",
         "instance_type": "CPU:1",
+        "den_auth": True,
     }
 
     cluster = setup_test_cluster(args, request, test_rns_folder=test_rns_folder)

--- a/tests/test_resources/test_clusters/test_on_demand_cluster.py
+++ b/tests/test_resources/test_clusters/test_on_demand_cluster.py
@@ -261,8 +261,8 @@ class TestOnDemandCluster(tests.test_resources.test_clusters.test_cluster.TestCl
             cluster.compute_properties["internal_ips"] = []
             assert not cluster._ping(retry=False)
 
-        if cluster.compute_properties.get("cloud") == "kubernetes":
-            # kubernetes does not use ips in command runner
+        if not cluster.compute_properties.get("cloud") == "kubernetes":
+            # kubernetes does not use ips in command runner, so this test is relevant only for not k8 clusters.
             cluster.compute_properties["ips"] = ["00.00.000.11"]
             assert not cluster._ping(retry=False)
 


### PR DESCRIPTION
Tests that are still fails:
1. `test_autostop_call_updated` - both in CI and locally
2. `test_autostop_function_running` - both in CI and locally. 

Need further investigation, based on Q1 priorities. 