### PR TITLE
Fix some distributed bugs

### DIFF
--- a/runhouse/resources/distributed/pytorch_distributed.py
+++ b/runhouse/resources/distributed/pytorch_distributed.py
@@ -1,5 +1,5 @@
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import List, Optional
+from typing import List
 
 from runhouse.resources.distributed.supervisor import Supervisor
 
@@ -29,7 +29,7 @@ class PyTorchDistributed(Supervisor):
             raise RuntimeError(f"Failed to find available port on head rank: {stdout}")
         return stdout
 
-    def forward(self, item, timeout: Optional[int] = None, *args, **kwargs):
+    def forward(self, item, *args, **kwargs):
         port = self._port or self._find_available_port_on_head_node()
 
         def run_on_replica(replica, rank):

--- a/runhouse/resources/distributed/supervisor.py
+++ b/runhouse/resources/distributed/supervisor.py
@@ -57,6 +57,8 @@ class Supervisor(Module):
                 else:
                     run_async = is_coroutine_function
 
+                args = args or []
+
                 if run_async:
                     return client_call_wrapper(
                         client,
@@ -67,10 +69,9 @@ class Supervisor(Module):
                         run_name=kwargs.pop("run_name", None),
                         stream_logs=kwargs.pop("stream_logs", True),
                         remote=kwargs.pop("remote", False),
-                        data={"args": [item] + (args or []), "kwargs": kwargs},
+                        data={"args": [item] + list(args), "kwargs": kwargs},
                     )
                 else:
-                    args = args or []
                     return client_call_wrapper(
                         client,
                         system,

--- a/runhouse/resources/module.py
+++ b/runhouse/resources/module.py
@@ -719,7 +719,7 @@ class Module(Resource):
                     new_create_process_params["compute"] = {
                         "node_idx": i // replicas_per_node
                     }
-                self.system.create_process(**new_create_process_params)
+                self.system.ensure_process_created(**new_create_process_params)
 
             new_module = copy.copy(self)
             new_module.local.name = name


### PR DESCRIPTION
* use `ensure_process_created` instead of `create_process` for replicas - now can rerun distributed scripts
* remove `timeout` from pytorch distributed forward - was not being used + caused issue with unnamed args in forward (`train_ddp(10)` in basic distributed was passing in the 10 to the `timeout` arg and reporting that `epochs` arg was missing)