### PR TITLE
Nightly release run cluster list test separately for k8 and static clusters

### DIFF
--- a/.github/workflows/nightly_release_testing.yaml
+++ b/.github/workflows/nightly_release_testing.yaml
@@ -67,7 +67,7 @@ jobs:
           KITCHEN_TESTER_USERNAME: ${{ secrets.KITCHEN_TESTER_USERNAME }}
           ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_PROD_TOKEN }}
           ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
-        run: pytest --level release tests -k "clustertest and not ondemand and not multinode"
+        run: pytest --level release tests -k "clustertest and not ondemand and not multinode and not cluster_list"
         timeout-minutes: 60
 
   ondemand-aws-tests-local-launcher:
@@ -227,7 +227,39 @@ jobs:
           KITCHEN_TESTER_USERNAME: ${{ secrets.KITCHEN_TESTER_USERNAME }}
           ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_PROD_TOKEN }}
           ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
-        run: pytest --level release tests -k "ondemand_k8s_cluster"
+        run: pytest --level release tests -k "ondemand_k8s_cluster and not cluster_list"
+        timeout-minutes: 60
+
+  cluster-list-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Setup Release Testing
+        uses: ./.github/workflows/setup_release_testing
+        with:
+          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+          AWS_OSS_ROLE_ARN: ${{ secrets.AWS_OSS_ROLE_ARN }}
+          DEV_AWS_ACCESS_KEY: ${{ secrets.DEV_AWS_ACCESS_KEY }}
+          DEV_AWS_SECRET_KEY: ${{ secrets.DEV_AWS_SECRET_KEY }}
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          DEN_TESTER_TOKEN: ${{ secrets.DEN_TESTER_PROD_TOKEN }}
+          DEN_TESTER_USERNAME: ${{ secrets.DEN_TESTER_USERNAME }}
+          API_SERVER_URL: ${{ env.API_SERVER_URL }}
+          EKS_ARN: ${{ secrets.EKS_ARN }}
+
+      - name: Run cluster list tests
+        env:
+          KITCHEN_TESTER_TOKEN: ${{ secrets.KITCHEN_TESTER_PROD_TOKEN }}
+          KITCHEN_TESTER_USERNAME: ${{ secrets.KITCHEN_TESTER_USERNAME }}
+          ORG_MEMBER_TOKEN: ${{ secrets.ORG_MEMBER_PROD_TOKEN }}
+          ORG_MEMBER_USERNAME: ${{ secrets.ORG_MEMBER_USERNAME }}
+        run: pytest --level release tests -k "cluster_list and not aws and not gcp"
         timeout-minutes: 60
 
   # making sure that the clusters were terminated after the test runs.
@@ -241,6 +273,7 @@ jobs:
       - ondemand-gcp-tests
       - kubernetes-tests
       - ondemand-aws-multinode-tests
+      - cluster-list-tests
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -1252,7 +1252,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
 
     @pytest.mark.level("local")
     @pytest.mark.clustertest
-    def test_cluster_list_and_create_process(self, cluster):
+    def test_cluster_create_and_list_process(self, cluster):
         assert DEFAULT_PROCESS_NAME in cluster.list_processes()
 
         # create a process manually with the create_process functionality


### PR DESCRIPTION
For some reason, when running the cluster list tests as part of the whole test suite in CI env, they fail (when running them locally they pass, with no consistency issues). Splitting the cluster list tests of static & k8 clusters solved the issues I was seeing. 