### PR TITLE
simplify custom vpc setting

### DIFF
--- a/docs/tutorials/api-clusters.rst
+++ b/docs/tutorials/api-clusters.rst
@@ -100,23 +100,7 @@ If you would like to launch on-demand clusters using existing VPCs,
 you can easily set it up by specifying the :code:`vpc_name` argument when initializing a cluster.
 Without setting VPC, we launch in the default VPC in the region of the cluster.
 
-You can optionally set a `default_vpc` in your `~/.rh/config.yaml` file to specify the default VPC to use
-for all subsequent clusters.
-
-.. code:: ipython3
-
-    aws:
-        vpc_name: my-vpc-name
-
-And for Google Cloud you need:
-
-.. code:: ipython3
-
-    gcp:
-      vpc_name: my-vpc-name
-
-If you need support for more advanced enterprise configurations,
-please email support@run.house for more information.
+If you need support for more advanced enterprise configurations, please email support@run.house for more information.
 
 On-Demand Clusters with TLS exposed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/runhouse/resources/hardware/cluster_factory.py
+++ b/runhouse/resources/hardware/cluster_factory.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional, Union
 
-from runhouse.globals import configs, rns_client
+from runhouse.globals import rns_client
 
 from runhouse.logger import get_logger
 from runhouse.resources.hardware.cluster import Cluster
@@ -303,7 +303,6 @@ def ondemand_cluster(
         >>> # Load cluster from above
         >>> reloaded_cluster = rh.ondemand_cluster(name="rh-4-a100s")
     """
-    vpc_name = vpc_name or configs.get("default_vpc")
     if vpc_name and launcher == "local":
         raise ValueError(
             "Custom VPCs are not supported with local launching. To use a custom VPC, please use the "


### PR DESCRIPTION
`default_vpc` is a little tricky to handle across various cloud providers. so for now removing it until we get more feedback on how that support should look