### PR TITLE
fix nightly release tests setup

### DIFF
--- a/.github/workflows/setup_release_testing/action.yaml
+++ b/.github/workflows/setup_release_testing/action.yaml
@@ -33,6 +33,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
     - name: Check out repository code
       uses: actions/checkout@v3
 
@@ -43,7 +48,7 @@ runs:
         export KUBECONFIG=$HOME/.kube/config
         kubectl config view
         sudo apt-get update
-        sudo apt-get install -y socat netcat
+        sudo apt-get install -y socat netcat-openbsd
       shell: bash
 
     - name: Configure & Authenticate to AWS
@@ -68,7 +73,7 @@ runs:
     - name: Install & check skypilot configuration
       run: |
         python -m pip install --upgrade pip
-        pip install skypilot[aws,gcp,kubernetes]
+        pip install "skypilot[aws,gcp,kubernetes]"
         sky check
         sky status
       shell: bash


### PR DESCRIPTION
skypilot supports only up to [python 3.11](https://docs.skypilot.co/en/latest/getting-started/installation.html), so we need to verify that the nightly release tests are using the supported python version. 