### PR TITLE
cli commands improvements

### DIFF
--- a/runhouse/cli_utils.py
+++ b/runhouse/cli_utils.py
@@ -207,6 +207,10 @@ def print_cluster_config(cluster_config: Dict, status_type: str = StatusType.clu
             else:
                 val = cluster_config.get(key, None)
 
+            # don't print keys whose values are None
+            if val is None:
+                continue
+
             console.print(
                 f"{DOUBLE_SPACE_UNICODE}{BULLET_UNICODE} {key.replace('_', ' ')}: {val}"
             ) if status_type == StatusType.cluster else console.print(

--- a/runhouse/main.py
+++ b/runhouse/main.py
@@ -1020,6 +1020,10 @@ def server_status(
         print_cluster_config(
             cluster_config=status.get("cluster_config"), status_type=StatusType.server
         )
+        if rh.here == "file":
+            console.print(
+                "[reset]For more detailed information about the cluster, please use [italic bold]`runhouse cluster status <cluster_name>`[/italic bold]"
+            )
     except (ObjStoreError, ConnectionError):
         console.print("Could not connect to Runhouse server. Is it up?")
 


### PR DESCRIPTION
@jlewitt1 Decided to leave out printing the launcher type in `rh cluster status` for now, since our go-to is to launch clusters primarily using Den.