### PR TITLE
Split up image install_packages

### DIFF
--- a/docs/api/python/image.rst
+++ b/docs/api/python/image.rst
@@ -23,6 +23,9 @@ ImageSteupStepType
     .. autoattribute:: RSYNC
     .. autoattribute:: SYNC_SECRETS
     .. autoattribute:: SET_ENV_VARS
+    .. autoattribute:: PIP_INSTALL
+    .. autoattribute:: CONDA_INSTALL
+    .. autoattribute:: SYNC_PACKAGE
 
 ImageSetupStep
 ~~~~~~~~~~~~~~

--- a/runhouse/resources/hardware/utils.py
+++ b/runhouse/resources/hardware/utils.py
@@ -208,6 +208,24 @@ def _do_setup_step_for_node(cluster, setup_step, node, env_vars):
             contents=setup_step.kwargs.get("contents"),
             filter_options=setup_step.kwargs.get("filter_options"),
         )
+    elif setup_step.step_type == ImageSetupStepType.PIP_INSTALL:
+        cluster.pip_install(
+            setup_step.kwargs.get("reqs"),
+            conda_env_name=setup_step.kwargs.get("conda_env_name"),
+            node=node,
+        )
+    elif setup_step.step_type == ImageSetupStepType.CONDA_INSTALL:
+        cluster.conda_install(
+            setup_step.kwargs.get("reqs"),
+            conda_env_name=setup_step.kwargs.get("conda_env_name"),
+            node=node,
+        )
+    elif setup_step.step_type == ImageSetupStepType.SYNC_PACKAGE:
+        cluster.sync_package(
+            setup_step.kwargs.get("package"),
+            conda_env_name=setup_step.kwargs.get("conda_env_name"),
+            node=node,
+        )
 
 
 def _setup_creds_from_dict(ssh_creds: Dict, cluster_name: str):

--- a/runhouse/resources/images/builtin_images.py
+++ b/runhouse/resources/images/builtin_images.py
@@ -2,12 +2,12 @@ from runhouse.resources.images.image import Image
 
 
 def dask():
-    return Image().install_packages(["dask[distributed,dataframe]", "dask-ml"])
+    return Image().pip_install(["dask[distributed,dataframe]", "dask-ml"])
 
 
 def pytorch():
-    return Image().install_packages(["torch"])
+    return Image().pip_install(["torch"])
 
 
 def ray():
-    return Image().install_packages(["ray[tune,data,train]"])
+    return Image().pip_install(["ray[tune,data,train]"])

--- a/runhouse/resources/images/image.py
+++ b/runhouse/resources/images/image.py
@@ -11,6 +11,9 @@ class ImageSetupStepType(Enum):
     RSYNC = "rsync"
     SYNC_SECRETS = "sync_secrets"
     SET_ENV_VARS = "set_env_vars"
+    PIP_INSTALL = "pip_install"
+    CONDA_INSTALL = "conda_install"
+    SYNC_PACKAGE = "sync_package"
 
 
 class ImageSetupStep:
@@ -48,7 +51,7 @@ class Image:
             >>>         conda_env_name="base_env",
             >>>         conda_config={"dependencies": ["python=3.11"], "name": "base_env"},
             >>>     )
-            >>>     .install_packages(["numpy", "pandas"])
+            >>>     .pip_install(["numpy", "pandas"])
             >>>     .set_env_vars({"OMP_NUM_THREADS": 1})
             >>> )
         """
@@ -187,6 +190,64 @@ class Image:
                 step_type=ImageSetupStepType.PACKAGES,
                 reqs=reqs,
                 conda_env_name=conda_env_name or self.conda_env_name,
+            )
+        )
+        return self
+
+    def pip_install(
+        self, reqs: List[Union["Package", str]], conda_env_name: Optional[str] = None
+    ):
+        """Pip install the given packages.
+
+        Args:
+            reqs (List[Package or str]): List of packages to pip install on cluster and env.
+            conda_env_name (str, optional): Name of conda env to install the package in, if relevant. If left empty,
+                defaults to base environment. (Default: ``None``)
+        """
+
+        self.setup_steps.append(
+            ImageSetupStep(
+                step_type=ImageSetupStepType.PIP_INSTALL,
+                reqs=reqs,
+                conda_env_name=conda_env_name or self.conda_env_name,
+            )
+        )
+        return self
+
+    def conda_install(
+        self, reqs: List[Union["Package", str]], conda_env_name: Optional[str] = None
+    ):
+        """Conda install the given packages.
+
+        Args:
+            reqs (List[Package or str]): List of packages to conda install on cluster and env.
+            conda_env_name (str, optional): Name of conda env to install the package in, if relevant. If left empty,
+                defaults to base environment. (Default: ``None``)
+        """
+
+        self.setup_steps.append(
+            ImageSetupStep(
+                step_type=ImageSetupStepType.CONDA_INSTALL,
+                reqs=reqs,
+                conda_env_name=conda_env_name or self.conda_env_name,
+            )
+        )
+        return self
+
+    def sync_package(
+        self,
+        package: Union["Package", str],
+    ):
+        """Sync local package over, and add to path.
+
+        Args:
+            package (Package or str): Package to sync. Either the name of a local editably installed package, or
+                the path to the folder to sync over.
+        """
+        self.setup_steps.append(
+            ImageSetupStep(
+                step_type=ImageSetupStepType.SYNC_PACKAGE,
+                package=package,
             )
         )
         return self

--- a/tests/fixtures/docker_cluster_fixtures.py
+++ b/tests/fixtures/docker_cluster_fixtures.py
@@ -364,7 +364,7 @@ def docker_cluster_pk_ssh(request, test_org_rns_folder):
     default_image = (
         Image(name="default_image")
         .set_env_vars(env_vars=TEST_ENV_VARS)
-        .install_packages(reqs=TEST_REQS + ["ray==2.30.0"])
+        .pip_install(reqs=TEST_REQS + ["ray==2.30.0"])
     )
 
     local_cluster, cleanup = set_up_local_cluster(
@@ -460,7 +460,7 @@ def docker_cluster_pk_http_exposed(request, test_rns_folder):
             conda_env_name="base_env",
             conda_config={"dependencies": ["python=3.11"], "name": "base_env"},
         )
-        .install_packages(TEST_REQS)
+        .pip_install(TEST_REQS)
     )
 
     local_cluster, cleanup = set_up_local_cluster(

--- a/tests/fixtures/on_demand_cluster_fixtures.py
+++ b/tests/fixtures/on_demand_cluster_fixtures.py
@@ -81,7 +81,7 @@ def local_launched_ondemand_aws_docker_cluster(request, test_rns_folder):
     image = (
         Image(name="default_image")
         .from_docker("rayproject/ray:latest-py311-cpu")
-        .install_packages(TEST_REQS + ["ray==2.30.0"])
+        .pip_install(TEST_REQS + ["ray==2.30.0"])
         .set_env_vars(TEST_ENV_VARS)
     )
     cluster_name = (
@@ -111,7 +111,7 @@ def den_launched_ondemand_aws_docker_cluster(request, test_rns_folder):
     image = (
         Image(name="default_image")
         .from_docker("rayproject/ray:latest-py311-cpu")
-        .install_packages(TEST_REQS + ["ray==2.30.0"])
+        .pip_install(TEST_REQS + ["ray==2.30.0"])
         .set_env_vars(TEST_ENV_VARS)
     )
     cluster_name = (
@@ -169,7 +169,7 @@ def ondemand_gcp_cluster(request, test_rns_folder):
             conda_env_name="base_env",
             conda_config={"dependencies": ["python=3.11"], "name": "base_env"},
         )
-        .install_packages(TEST_REQS + ["ray==2.30.0"], conda_env_name="base_env")
+        .pip_install(TEST_REQS + ["ray==2.30.0"], conda_env_name="base_env")
         .set_env_vars(env_vars=TEST_ENV_VARS)
     )
     cluster_name = (
@@ -280,7 +280,7 @@ def ondemand_k8s_docker_cluster(request, test_rns_folder):
         "instance_type": "CPU:1",
         "image": Image(name="default_image")
         .from_docker("rayproject/ray:latest-py311-cpu")
-        .install_packages(TEST_REQS),
+        .pip_install(TEST_REQS),
     }
     cluster = setup_test_cluster(args, request)
     yield cluster
@@ -363,7 +363,7 @@ def multinode_cpu_docker_conda_cluster(request):
             conda_env_name="base_env",
             conda_config={"dependencies": ["python=3.11"], "name": "base_env"},
         )
-        .install_packages(TEST_REQS + ["ray==2.30.0"], conda_env_name="base_env")
+        .pip_install(TEST_REQS + ["ray==2.30.0"], conda_env_name="base_env")
     )
     args = {
         "name": "rh-cpu-multinode",

--- a/tests/test_resources/test_clusters/cluster_tests.py
+++ b/tests/test_resources/test_clusters/cluster_tests.py
@@ -49,7 +49,7 @@ def test_read_shared_cluster(local_launched_ondemand_aws_docker_cluster):
 
 
 def test_install(cluster):
-    cluster.install_packages(
+    cluster.pip_install(
         [
             "./",
             "torch==1.12.1",
@@ -113,7 +113,7 @@ def test_byo_cluster_with_https(static_cpu_pwd_cluster):
     assert Path(local_cert_path).exists()
 
     # Confirm we can send https requests to the cluster
-    static_cpu_pwd_cluster.install_packages(["numpy"])
+    static_cpu_pwd_cluster.pip_install(["numpy"])
 
 
 def test_byo_proxy(static_cpu_pwd_cluster, local_folder):

--- a/tests/test_resources/test_clusters/test_cluster.py
+++ b/tests/test_resources/test_clusters/test_cluster.py
@@ -834,7 +834,7 @@ class TestCluster(tests.test_resources.test_resource.TestResource):
         reqs = []
         if cluster.image:
             for step in cluster.image.setup_steps:
-                if step.step_type == ImageSetupStepType.PACKAGES:
+                if step.step_type == ImageSetupStepType.PIP_INSTALL:
                     reqs += step.kwargs.get("reqs")
         for req in reqs:
             if isinstance(req, str) and "_" in req:

--- a/tests/test_resources/test_data/test_package.py
+++ b/tests/test_resources/test_data/test_package.py
@@ -62,7 +62,7 @@ class TestPackage(tests.test_resources.test_resource.TestResource):
         [
             "numpy",
             "pip:numpy",
-            "conda:numpy" "requirements.txt",
+            "conda:numpy",
             "local:./",
         ],
     )
@@ -127,7 +127,7 @@ class TestPackage(tests.test_resources.test_resource.TestResource):
     @pytest.mark.level("local")
     def test_local_package_version_gets_installed(self, cluster):
         run_with_logs("pip install beautifulsoup4==4.11.1")
-        cluster.install_packages(["beautifulsoup4"])
+        cluster.pip_install(["beautifulsoup4"])
 
         process = cluster.ensure_process_created("temp_env")
         remote_fn = rh.function(get_bs4_version).to(cluster, process=process)

--- a/tests/test_resources/test_modules/test_folders/test_packages/test_package.py
+++ b/tests/test_resources/test_modules/test_folders/test_packages/test_package.py
@@ -94,7 +94,7 @@ def test_install_cmd_for_torch_on_cluster(request, ondemand_cluster):
     for install_cmd in install_commands_for_cluster:
         # Run the complete install command on the cluster
         try:
-            ondemand_cluster.install_packages([install_cmd])
+            ondemand_cluster.pip_install([install_cmd])
         except subprocess.CalledProcessError:
             assert False, f"Failed to install {install_cmd}"
 

--- a/tests/test_resources/test_modules/test_functions/test_function.py
+++ b/tests/test_resources/test_modules/test_functions/test_function.py
@@ -141,7 +141,7 @@ class TestFunction:
 
     @pytest.mark.level("local")
     def test_function_in_new_process_with_multiprocessing(self, cluster):
-        cluster.install_packages(["numpy"])
+        cluster.pip_install(["numpy"])
         new_process = cluster.ensure_process_created("numpy_process")
         multiproc_remote_sum = rh.function(multiproc_np_sum, name="test_function").to(
             cluster, process=new_process
@@ -227,7 +227,7 @@ class TestFunction:
         """Test functioning a module from reqs, not from working_dir"""
         import numpy as np
 
-        cluster.install_packages(["numpy"])
+        cluster.pip_install(["numpy"])
         re_fn = rh.function(np.sum).to(cluster)
         res = re_fn(np.arange(5))
         assert int(res) == 10
@@ -236,7 +236,7 @@ class TestFunction:
     # originally used local_launched_ondemand_aws_docker_cluster, therefore marked as minimal
     @pytest.mark.level("minimal")
     def test_notebook(self, cluster):
-        cluster.install_packages(["numpy"])
+        cluster.pip_install(["numpy"])
         nb_sum = lambda x: multiproc_np_sum(x)
         re_fn = rh.function(nb_sum).to(cluster)
 

--- a/tests/test_resources/test_resource_sharing.py
+++ b/tests/test_resources/test_resource_sharing.py
@@ -93,7 +93,7 @@ class TestResourceSharing:
 
         # Should not be able to install packages on the cluster with read access
         try:
-            cluster.install_packages(["numpy", "pandas"])
+            cluster.pip_install(["numpy", "pandas"])
         except Exception as e:
             assert "No read or write access to requested resource" in str(e)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -144,7 +144,7 @@ def setup_test_base(cluster, logged_in=False):
         f"echo '{yaml.safe_dump(rh.configs.defaults_cache)}' > ~/.rh/config.yaml"
     ]
 
-    cluster.install_packages(TEST_REQS)
+    cluster.pip_install(TEST_REQS)
     cluster.set_process_env_vars(DEFAULT_PROCESS_NAME, TEST_ENV_VARS)
     if logged_in:
         cluster.run_bash(setup_cmds)


### PR DESCRIPTION
* split up `install_packages` into `pip_install`, `conda_install` and `sync_package`
* update logic for locally installed packages - `pip_install` can detect non-editable/non-dev preferred version, but for dev/local editable package versions, should use `sync_package` to rsync over the package + add to path, and then use `pip_install(package)` after to perform the pip install