### PR TITLE
Removes redundant ssh_creds from teardown

### DIFF
--- a/runhouse/resources/hardware/launcher_utils.py
+++ b/runhouse/resources/hardware/launcher_utils.py
@@ -298,18 +298,11 @@ class DenLauncher(Launcher):
     @classmethod
     def teardown(cls, cluster, verbose: bool = True):
         """Tearing down a cluster via Den."""
-        from runhouse.resources.secrets import Secret
-
-        ssh_creds = cluster._creds
-        if isinstance(ssh_creds, Secret):
-            ssh_creds = ssh_creds.rns_address
-
         cluster_name = cluster.rns_address or cluster.name
 
         payload = {
             "cluster_name": cluster_name,
             "delete_from_den": False,
-            "ssh_creds": ssh_creds,
             "verbose": verbose,
         }
 


### PR DESCRIPTION
Cleanup of the params sent to the Launcher for teardown. Pending an update to Den to remove `ssh_creds` as required and instead infer them from the resource itself.