### PR TITLE
Ensure launcher ssh creds use username

### DIFF
--- a/runhouse/resources/hardware/launcher_utils.py
+++ b/runhouse/resources/hardware/launcher_utils.py
@@ -343,6 +343,9 @@ class DenLauncher(Launcher):
             )
         try:
             # Note: we still need to load them down locally to use for certain cluster operations (ex: rsync)
+            if "/" not in default_ssh_key:
+                # SSH key should use username, current_folder used in from_name may differ
+                default_ssh_key = f"{rns_client.username}/{default_ssh_key}"
             secret = rh.Secret.from_name(default_ssh_key)
             if not Path(secret.path).expanduser().exists():
                 # Ensure this specific keypair is written down locally


### PR DESCRIPTION
Wanted to keep this as isolated as possible.

Alternatively, it might be better to update `rns_client.default_ssh_key` to return the full RNS address of the key:
```
/mkandler/sky-ssh-key
```
vs.
```
sky-ssh-key
```

Because the latter could be confused with `/<org-username>/sky-ssh-key` in cases where the `current_folder` is not the user's username.

Ran into this bug once but it was flaky, not sure why it wasn't consistently failing.