### PR TITLE
Update kt deploy reload flow

### DIFF
--- a/python_client/kubetorch/cli.py
+++ b/python_client/kubetorch/cli.py
@@ -443,6 +443,7 @@ def kt_deploy(
     @kt.compute in the file or module."""
     from kubetorch.resources.compute.utils import _collect_modules
 
+    os.environ["KT_CLI_DEPLOY_MODE"] = "1"
     to_deploy, target_fn_or_class = _collect_modules(target)
 
     if not target_fn_or_class:


### PR DESCRIPTION
we should only instantiate compute during `kt deploy <file>` cli workflow. otherwise, when importing, leave compute empty as it will be reloaded `from_name` when the module is called. this avoid unnecessary computation (esp once template building gets moved to compute init) or potentially out of date/mismatched compute objects that don't match 1-to-1 with the existing deployed compute.