### PR TITLE
Only sync file if working directory not found

### DIFF
--- a/python_client/kubetorch/resources/callables/cls/cls.py
+++ b/python_client/kubetorch/resources/callables/cls/cls.py
@@ -1,6 +1,6 @@
 from kubetorch.logger import get_logger
 from kubetorch.resources.callables.module import Module
-from kubetorch.resources.callables.utils import _extract_pointers, SHELL_COMMANDS
+from kubetorch.resources.callables.utils import extract_pointers, SHELL_COMMANDS
 
 logger = get_logger(__name__)
 
@@ -31,7 +31,7 @@ class Cls(Module):
         self._init_args = init_args
         if not pointers:
             # local to the class definition
-            pointers = _extract_pointers(self.__class__)
+            pointers = extract_pointers(self.__class__)
 
         super().__init__(name=name, pointers=pointers)
 
@@ -132,7 +132,7 @@ def cls(class_obj=None, name: str = None, get_if_exists=True, reload_prefixes=No
         result = remote_cls.my_method(1, 2)
     """
     if class_obj:
-        cls_pointers = _extract_pointers(class_obj)
+        cls_pointers = extract_pointers(class_obj)
         name = name or (cls_pointers[2] if cls_pointers else cls.__name__)
         new_cls = Cls(
             name=name,

--- a/python_client/kubetorch/resources/callables/fn/fn.py
+++ b/python_client/kubetorch/resources/callables/fn/fn.py
@@ -1,6 +1,6 @@
 from kubetorch.logger import get_logger
 from kubetorch.resources.callables.module import Module
-from kubetorch.resources.callables.utils import _extract_pointers
+from kubetorch.resources.callables.utils import extract_pointers
 
 logger = get_logger(__name__)
 
@@ -108,7 +108,7 @@ def fn(function_obj=None, name: str = None, get_if_exists=True, reload_prefixes=
         result = remote_fn(1, 2)
     """
     if function_obj:
-        fn_pointers = _extract_pointers(function_obj)
+        fn_pointers = extract_pointers(function_obj)
         name = name or (fn_pointers[2] if fn_pointers else function_obj.__name__)
         new_fn = Fn(
             name=name,

--- a/python_client/kubetorch/resources/callables/utils.py
+++ b/python_client/kubetorch/resources/callables/utils.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 SHELL_COMMANDS = {"ssh", "run_bash", "rsync"}
 
 
-def _extract_pointers(raw_cls_or_fn: Union[Type, Callable]):
+def extract_pointers(raw_cls_or_fn: Union[Type, Callable]):
     """Get the path to the module, module name, and function name to be able to import it on the server"""
     if not (isinstance(raw_cls_or_fn, Type) or isinstance(raw_cls_or_fn, Callable)):
         raise TypeError(f"Expected Type or Callable but received {type(raw_cls_or_fn)}")
@@ -82,6 +82,15 @@ def _extract_module_path(raw_cls_or_fn: Union[Type, Callable]):
 
 
 def locate_working_dir(start_dir=None):
+    """
+    Locate the working directory of the project.
+
+    Args:
+        start_dir (str, optional): The directory to start searching from. Defaults to the current working directory.
+
+    Returns:
+        tuple: A tuple containing the working directory and a boolean indicating if a project directory was found.
+    """
     if start_dir is None:
         start_dir = os.getcwd()
 
@@ -97,8 +106,8 @@ def locate_working_dir(start_dir=None):
     dir_with_target = _find_directory_containing_any_file(
         start_dir, target_files, searched_dirs=set()
     )
-
-    return dir_with_target if dir_with_target is not None else start_dir
+    found_project_dir = dir_with_target is not None
+    return (dir_with_target if found_project_dir else start_dir), found_project_dir
 
 
 def _find_directory_containing_any_file(dir_path, files, searched_dirs=None):

--- a/python_client/kubetorch/resources/compute/utils.py
+++ b/python_client/kubetorch/resources/compute/utils.py
@@ -183,7 +183,7 @@ def _get_rsync_exclude_options() -> str:
         )
         return os.environ["KT_RSYNC_FILTERS"]
 
-    repo_root = locate_working_dir(os.getcwd())
+    repo_root, _ = locate_working_dir(os.getcwd())
     gitignore_path = os.path.join(repo_root, ".gitignore")
     kt_ignore_path = os.path.join(repo_root, ".ktignore")
 
@@ -854,7 +854,7 @@ def _get_sync_package_paths(
         package_path = (
             Path(package).expanduser()
             if Path(package).expanduser().is_absolute()
-            else Path(locate_working_dir()) / package
+            else Path(locate_working_dir()[0]) / package
         )
         dest_dir = str(package_path.name)
     else:


### PR DESCRIPTION
Initial rsync can hang if trying to run a file outside of a Python package or git repo, in a directory with large files, e.g. `~/Downloads/hello_world.py`