### PR TITLE
Quick check for missing credentials

### DIFF
--- a/python_client/kubetorch/__init__.py
+++ b/python_client/kubetorch/__init__.py
@@ -30,6 +30,7 @@ from kubetorch.servers.http.utils import (  # noqa: F401
     StartupError,
     WorkerMembershipChanged,
 )
+from kubetorch.serving.utils import KubernetesCredentialsError
 
 from .resources import images
 
@@ -39,6 +40,7 @@ images = images
 # Registry of all kubetorch exceptions for serialization/deserialization
 EXCEPTION_REGISTRY = {
     "ImagePullError": ImagePullError,
+    "KubernetesCredentialsError": KubernetesCredentialsError,
     "PodContainerError": PodContainerError,
     "ResourceNotAvailableError": ResourceNotAvailableError,
     "ServiceHealthError": ServiceHealthError,

--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -29,6 +29,7 @@ from kubetorch.servers.http.utils import (
     generate_unique_request_id,
     is_running_in_kubernetes,
 )
+from kubetorch.serving.utils import has_k8s_credentials, KubernetesCredentialsError
 from kubetorch.utils import (
     extract_host_port,
     get_kt_install_url,
@@ -423,6 +424,11 @@ class Module:
                 stream_logs=True
             )
         """
+        if not has_k8s_credentials():
+            raise KubernetesCredentialsError(
+                "Kubernetes credentials not found. Please ensure you are running in a Kubernetes cluster or have a valid kubeconfig file."
+            )
+
         if get_if_exists:
             try:
                 existing_service = self._get_existing_service(reload_prefixes)

--- a/python_client/kubetorch/serving/utils.py
+++ b/python_client/kubetorch/serving/utils.py
@@ -4,6 +4,7 @@ import time
 import warnings
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal, Optional, Union
 
 import httpx
@@ -170,6 +171,27 @@ class RequestedPodResources:
             return float(cpu_value.rstrip("+"))
 
         return float(cpu_value)
+
+
+class KubernetesCredentialsError(Exception):
+    pass
+
+
+def has_k8s_credentials():
+    """
+    Fast check for K8s credentials - works both in-cluster and external.
+    No network calls, no imports needed.
+    """
+    # Check 1: In-cluster service account
+    if (
+        Path("/var/run/secrets/kubernetes.io/serviceaccount/token").exists()
+        and Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt").exists()
+    ):
+        return True
+
+    # Check 2: Kubeconfig file
+    kubeconfig_path = os.environ.get("KUBECONFIG", os.path.expanduser("~/.kube/config"))
+    return Path(kubeconfig_path).exists()
 
 
 def check_kubetorch_versions(response):


### PR DESCRIPTION
A missing kube config previously shows a confusing error message:
```
INFO | 2025-11-04 11:30:43 | kubetorch.resources.callables.module:614 | Package root not found; syncing file /Users/matthewkandler/Downloads/helloworld.py
Traceback (most recent call last):
  File "/Users/matthewkandler/Downloads/helloworld.py", line 14, in <module>
    remote_hello = kt.fn(hello_world).to(compute)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/resources/callables/module.py", line 459, in to
    self._rsync_repo_and_image_patches(install_url, use_editable, init_args)
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/resources/callables/module.py", line 633, in _rsync_repo_and_image_patches
    self._construct_and_rsync_files(rsync_dirs, service_dockerfile)
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/resources/callables/module.py", line 818, in _construct_and_rsync_files
    self.compute.rsync(rsync_dirs)
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/resources/compute/compute.py", line 2231, in rsync
    websocket_port, ws_url = self._get_websocket_info(local_port)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/resources/compute/compute.py", line 2199, in _get_websocket_info
    base_url = globals.service_url()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/globals.py", line 241, in service_url
    h = _ensure_pf(service_name, namespace, remote_port, health_endpoint)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/globals.py", line 99, in _ensure_pf
    raise RuntimeError(
RuntimeError: kubectl port-forward exited (rc=1): E1104 11:30:43.650702    7876 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
E1104 11:30:43.652419    7876 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
E1104 11:30:43.654110    7876 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
E1104 11:30:43.655750    7876 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```
now:
```
Traceback (most recent call last):
  File "/Users/matthewkandler/Downloads/helloworld.py", line 14, in <module>
    remote_hello = kt.fn(hello_world).to(compute)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matthewkandler/python/kubetorch/python_client/kubetorch/resources/callables/module.py", line 428, in to
    raise KubernetesCredentialsError(
kubetorch.KubernetesCredentialsError: Kubernetes credentials not found. Please ensure you are running in a Kubernetes cluster or have a valid kubeconfig file.
```