### PR TITLE
Handle kt whl install syncing

### DIFF
--- a/python_client/kubetorch/resources/compute/compute.py
+++ b/python_client/kubetorch/resources/compute/compute.py
@@ -1500,7 +1500,7 @@ class Compute:
                 self.server_image, self.otel_enabled, self.inactivity_ttl
             ),
             server_image=self.server_image,
-            rsync_kt_editable_cmd=startup_rsync_command,
+            rsync_kt_local_cmd=startup_rsync_command,
             server_port=self.server_port,
         )
         return setup_script

--- a/python_client/kubetorch/serving/templates/kt_setup_template.sh.j2
+++ b/python_client/kubetorch/serving/templates/kt_setup_template.sh.j2
@@ -62,16 +62,25 @@ export KT_PIP_INSTALL_CMD="$uv_pip_cmd"
 mkdir -p .kt
 echo "$uv_pip_cmd" > .kt/kt_pip_install_cmd
 
-{% if install_url %}
+{% if rsync_kt_local_cmd %}
+  {{ rsync_kt_local_cmd }}
+  {% if install_url and install_url.endswith('.whl') %}
+    {% set normalized_path = install_url.replace('\\', '/') %}
+    {% set wheel_filename = normalized_path.split('/')[-1] %}
+    $uv_pip_cmd "{{ wheel_filename }}[server]"
+    {% if install_otel %}
+      $uv_pip_cmd "{{ wheel_filename }}[otel]"
+    {% endif %}
+  {% else %}
+    $uv_pip_cmd -e "python_client[server]"
+    {% if install_otel %}
+      $uv_pip_cmd -e "python_client[otel]"
+    {% endif %}
+  {% endif %}
+{% else %}
   $uv_pip_cmd "kubetorch[server]=={{ install_url }}"
   {% if install_otel %}
     $uv_pip_cmd "kubetorch[otel]=={{ install_url }}"
-  {% endif %}
-{% else %}
-  {{ rsync_kt_editable_cmd }}
-  $uv_pip_cmd -e "python_client[server]"
-  {% if install_otel %}
-    $uv_pip_cmd -e "python_client[otel]"
   {% endif %}
 {% endif %}
 

--- a/python_client/kubetorch/utils.py
+++ b/python_client/kubetorch/utils.py
@@ -119,6 +119,8 @@ def get_kt_install_url(freeze: bool = False):
     local_kt_path = get_local_install_path("kubetorch")
     if local_kt_path and (Path(local_kt_path) / "pyproject.toml").exists():
         return local_kt_path, True
+    elif local_kt_path and local_kt_path.endswith(".whl"):
+        return local_kt_path, False
     else:
         import kubetorch as kt
 


### PR DESCRIPTION
Add support for syncing over and installing from whl when kt is installed locally from whl. Useful for testing local developments. 

```
cd python_client
poetry build --force-reinstall
pip install dist/***.whl

# run kt code as normally
```

Follow up - have CI generate and use whl builds
