### PR TITLE
Update kt config behavior

### DIFF
--- a/python_client/kubetorch/cli.py
+++ b/python_client/kubetorch/cli.py
@@ -341,8 +341,8 @@ def kt_config(
             raise typer.Exit(1)
 
         try:
-            value = config.set(key, value)
-            config.write()
+            value = config.set(key, value)  # validate value
+            config.write({key: value})
             console.print(f"[green]{key} set to:[/green] [blue]{value}[/blue]")
         except ValueError as e:
             console.print(f"[red]Error setting {key}:[/red] {str(e)}")
@@ -354,8 +354,8 @@ def kt_config(
             raise typer.Exit(1)
 
         try:
-            config.write({key: None})
             config.set(key, None)
+            config.write({key: None})
             console.print(f"[green]{key.capitalize()} unset[/green]")
         except ValueError as e:
             console.print(f"[red]Error unsetting {key}:[/red] {str(e)}")

--- a/python_client/kubetorch/globals.py
+++ b/python_client/kubetorch/globals.py
@@ -98,7 +98,7 @@ def _ensure_pf(service_name: str, namespace: str, remote_port: int, health_endpo
             cluster_config = wait_for_port_forward(proc, local_port, health_endpoint=health_endpoint)
             if isinstance(cluster_config, dict):
                 config.cluster_config = cluster_config
-                config.write()
+                config.write(values={"cluster_config": cluster_config})
         else:
             # Minimal TCP wait (no HTTP probe)
             deadline = time.time() + 10

--- a/python_client/tests/test_cli.py
+++ b/python_client/tests/test_cli.py
@@ -285,6 +285,7 @@ def test_cli_kt_config_set():
     original_username = kt.config.username  # str type value
     original_stream_logs = kt.config.stream_logs  # bool type value
     original_log_verbosity = kt.config.log_verbosity  # LogVerbosity (enum) value
+    original_file_values = kt.config._load_from_file()
 
     try:
         # Part A: set supported keys
@@ -313,8 +314,6 @@ def test_cli_kt_config_set():
         result = runner.invoke(app, ["config", "set", "username"], color=False)
         assert result.exit_code == 1
         assert "Both key and value are required for 'set'" in result.stdout
-
-        kt.config.username = original_username
 
         # Part D: set supported key, but provide a value of a wrong type
         # D.1: unsupported username
@@ -361,14 +360,16 @@ def test_cli_kt_config_set():
         kt.config.username = original_username
         kt.config.stream_logs = original_stream_logs
         kt.config.log_verbosity = original_log_verbosity
-        kt.config.write()
+        kt.config.write(original_file_values)
 
 
 @pytest.mark.level("unit")
 def test_cli_kt_config_unset():
+    # making hard copy, so this value won't change during `kt config unset`.
     original_username = kt.config.username  # str type value
     original_stream_logs = kt.config.stream_logs  # bool type value
     original_log_verbosity = kt.config.log_verbosity  # LogVerbosity (enum) value
+    original_file_values = kt.config._load_from_file()
     try:
         # Part A: supported keys
         config_keys = ["username", "stream_logs", "log_verbosity"]
@@ -395,7 +396,7 @@ def test_cli_kt_config_unset():
         kt.config.username = original_username
         kt.config.stream_logs = original_stream_logs
         kt.config.log_verbosity = original_log_verbosity
-        kt.config.write()
+        kt.config.write(original_file_values)
 
 
 @pytest.mark.level("unit")


### PR DESCRIPTION
fix overwriting local username in tests
- don't write down config during port forward
- don't write down config based on local values in cli tests, but based on original file

in the process, update kt config write/set/unset behavior to only modify a specific key if provided, rather than keys potentially set through env vars
