### PR TITLE
Update `kt teardown` prints

### DIFF
--- a/python_client/kubetorch/cli.py
+++ b/python_client/kubetorch/cli.py
@@ -1357,7 +1357,7 @@ def kt_teardown(
     if teardown_all or prefix:
         service_word = "service" if service_count == 1 else "services"
         if not services:
-            console.print("[yellow]No services are found[/yellow]")
+            console.print("[yellow]No services found[/yellow]")
             raise typer.Exit(0)
         else:
             console.print(f"[yellow]Found [bold]{service_count}[/bold] {service_word} to delete.[/yellow]")
@@ -1370,29 +1370,6 @@ def kt_teardown(
     if not yes and service_count > 1:
         for service_name in services:
             console.print(f" • {service_name}")
-
-    # List out resources to be deleted for each service
-    console.print("\n[yellow]The following resources will be deleted:[/yellow]")
-    for name in services:
-        service_info = resources["services"][name]
-        configmaps = service_info["configmaps"]
-        service_type = service_info.get("type", "unknown")
-
-        if service_type == "deployment":
-            console.print(f"• Deployment: [blue]{name}[/blue]")
-            console.print(f"• Service: [blue]{name}[/blue]")
-        elif service_type == "knative":
-            console.print(f"• Knative Service: [blue]{name}[/blue]")
-        elif service_type == "raycluster":
-            console.print(f"• RayCluster: [blue]{name}[/blue]")
-            console.print(f"• Service: [blue]{name}[/blue]")
-        else:
-            console.print(f"• Service: [blue]{name}[/blue]")
-
-        if configmaps:
-            console.print("• ConfigMaps:")
-            for cm in configmaps:
-                console.print(f"  - [blue]{cm}[/blue]")
 
     # Confirmation prompt for single service
     if not yes and not force:  # if --force is provided, we don't need additional confirmation

--- a/python_client/tests/test_cli.py
+++ b/python_client/tests/test_cli.py
@@ -79,15 +79,12 @@ def validate_logs_fn_service_info(list_output: str, service_name: str, compute_t
 
 
 def validate_teardown_output(teardown_output: str, service_name: str, force_delete: bool = False):
-    assert "The following resources will be deleted:\n" in teardown_output
-    assert f"• Deployment: {service_name}\n• Service: {service_name}" in teardown_output
 
     assert "Force deleting resources..." if force_delete else "Deleting resources..." in teardown_output
-
     assert f"✓ Deleted deployment {service_name}\n✓ Deleted service {service_name}" in teardown_output
 
     if force_delete:
-        time.sleep(3)
+        time.sleep(5)
 
     list_result = runner.invoke(app, ["list"], color=False, env={"COLUMNS": "200"})
 
@@ -668,7 +665,7 @@ def test_cli_kt_teardown_wrong_usage():
     assert teardown_result.exit_code == 0
     output = teardown_result.output
     assert f"Deleting all services with prefix {service_name} in default namespace" in output
-    assert "No services are found" in output
+    assert "No services found" in output
 
     # Part D: teardown service but provide wrong namespace
     remote_fn = remote_fn_for_teardown()


### PR DESCRIPTION
New prints:
* with `--yes` flag (`kt teardown -y -p sashab`):

<img width="781" height="191" alt="image" src="https://github.com/user-attachments/assets/fd7634b1-7133-46af-bae2-015b3f782512" />


* without `--yes` flag (`kt teardown -p sync`):

<img width="769" height="354" alt="image" src="https://github.com/user-attachments/assets/80a5028e-1cfe-4886-8a9c-427acbfd968d" />
