### PR TITLE
Print pod names in events of multipod resources

### DIFF
--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -1127,14 +1127,19 @@ class Module:
                                             # If parsing fails, just print the event as is
                                             pass
 
+                                        is_multi_pod = len(self.compute.pods()) > 1
+                                        k8_object_type = labels.get("k8s_object_kind")
+                                        k8_object_name = labels.get("k8s_object_name")
+                                        add_pod_info = is_multi_pod and k8_object_type == "Pod"
+                                        pod_info = f" | {k8_object_name} |" if add_pod_info else ""
                                         if event_type == "Normal":
                                             if log_verbosity in [
                                                 LogVerbosity.INFO,
                                                 LogVerbosity.DEBUG,
                                             ]:
-                                                print(f'[EVENT] reason={reason} "{msg}"')
+                                                print(f'[EVENT]{pod_info} reason={reason} "{msg}"')
                                         else:
-                                            print(f'[EVENT] type={event_type} reason={reason} "{msg}"')
+                                            print(f'[EVENT]{pod_info} type={event_type} reason={reason} "{msg}"')
                                         continue
 
                                     # Skip if we've already seen this timestamp


### PR DESCRIPTION
A pod name will be printed next to an event if out resource has multiple pods, and the printed event is a pod event. 

New output example:

<img width="1922" height="225" alt="image" src="https://github.com/user-attachments/assets/22675830-14bf-4bee-a2e1-4e739c99f8f2" />
