### PR TITLE
remove kubetorch namespace from nginx config values

### DIFF
--- a/charts/kubetorch/README.md
+++ b/charts/kubetorch/README.md
@@ -72,12 +72,7 @@ A Helm chart for kubetorch
 | metrics.scrapeKubelet | bool | `true` |  |
 | nginx.resolver | string | `"kube-dns.kube-system.svc.cluster.local"` |  |
 | nginxProxy.backends.health.route | string | `"/health"` |  |
-| nginxProxy.backends.logging.host | string | `"loki-gateway.kubetorch.svc.cluster.local"` |  |
 | nginxProxy.backends.logging.route | string | `"/loki"` |  |
-| nginxProxy.backends.metrics.ephemeral.host | string | `"kubetorch-metrics.kubetorch.svc.cluster.local"` |  |
-| nginxProxy.backends.metrics.ephemeral.port | int | `9090` |  |
-| nginxProxy.backends.metrics.persistent.host | string | `"runhouse-kube-prometheus-s-prometheus.runhouse.svc.cluster.local"` |  |
-| nginxProxy.backends.metrics.persistent.port | int | `9090` |  |
 | nginxProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginxProxy.image.repository | string | `"nginx"` |  |
 | nginxProxy.image.tag | string | `"1.29.0-alpine"` |  |

--- a/charts/kubetorch/templates/nginx-proxy/configmap.yaml
+++ b/charts/kubetorch/templates/nginx-proxy/configmap.yaml
@@ -47,13 +47,7 @@ data:
             ##############################################
             location ^~ /prometheus/ {
                 resolver {{ .Values.nginx.resolver }} valid=5s;
-                {{- if .Values.metrics.enabled }}
-                # Route to ephemeral Prometheus inside the same namespace
-                set $prom_host "{{ .Values.nginxProxy.backends.metrics.ephemeral.host }}:{{ .Values.nginxProxy.backends.metrics.ephemeral.port }}";
-                {{- else }}
-                # Route to persistent (Runhouse) Prometheus
-                set $prom_host "{{ .Values.nginxProxy.backends.metrics.persistent.host }}:{{ .Values.nginxProxy.backends.metrics.persistent.port }}";
-                {{- end }}
+                set $prom_host "kubetorch-metrics.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.metrics.prometheus.port }}";
                 # Strip the /prometheus/ prefix before forwarding
                 rewrite ^/prometheus/(.*)$ /$1 break;
                 proxy_pass http://$prom_host;
@@ -69,11 +63,7 @@ data:
             ##############################################
             location ^~ {{ .Values.nginxProxy.backends.logging.route }}/ {
                 resolver {{ .Values.nginx.resolver }} valid=5s;
-                {{- if .Values.logStreaming.enabled }}
-                set $loki_host "{{ .Values.nginxProxy.backends.logging.host }}:{{ .Values.logStreaming.port }}";
-                {{- else }}
-                set $loki_host "{{ .Values.nginxProxy.backends.logging.host }}:80";
-                {{- end }}
+                set $loki_host "loki-gateway.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.logStreaming.port }}";
                 proxy_pass http://$loki_host;
                 proxy_http_version 1.1;
                 # WebSocket headers

--- a/charts/kubetorch/values.yaml
+++ b/charts/kubetorch/values.yaml
@@ -58,14 +58,6 @@ nginxProxy:
   backends:
     logging:
       route: "/loki"
-      host: loki-gateway.kubetorch.svc.cluster.local
-    metrics:
-      persistent:
-        host: runhouse-kube-prometheus-s-prometheus.runhouse.svc.cluster.local
-        port: 9090
-      ephemeral:
-        host: kubetorch-metrics.kubetorch.svc.cluster.local
-        port: 9090
     health:
       route: "/health"
 


### PR DESCRIPTION
necessary for log streaming to work in other namespaces