### PR TITLE
Add custom manifest support for existing service types

### DIFF
--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -409,6 +409,10 @@ class Module:
                 "Kubernetes credentials not found. Please ensure you are running in a Kubernetes cluster or have a valid kubeconfig file."
             )
 
+        if compute.service_name and compute.service_name != self.service_name:
+            logger.info(f"Renaming service to match compute service name {compute.service_name}")
+            self.service_name = compute.service_name
+
         if get_if_exists:
             try:
                 existing_service = self._get_existing_service(reload_prefixes)
@@ -491,6 +495,10 @@ class Module:
                 stream_logs=True
             )
         """
+        if compute.service_name and compute.service_name != self.service_name:
+            logger.info(f"Renaming service to match compute service name {compute.service_name}")
+            self.service_name = compute.service_name
+
         if get_if_exists:
             try:
                 existing_service = await self._get_existing_service_async(reload_prefixes)

--- a/python_client/kubetorch/serving/base_service_manager.py
+++ b/python_client/kubetorch/serving/base_service_manager.py
@@ -3,7 +3,7 @@ import importlib
 import re
 from abc import abstractmethod
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Type
 
 import yaml
 from jinja2 import Template
@@ -74,6 +74,23 @@ class BaseServiceManager:
             logger.info(f"Configuring auto-down after idle timeout ({inactivity_ttl})")
 
         return annotations
+
+    @staticmethod
+    def _get_service_manager_class(kind: str) -> Type["BaseServiceManager"]:
+        from kubetorch.serving.service_manager import (
+            DeploymentServiceManager,
+            KnativeServiceManager,
+            RayClusterServiceManager,
+        )
+
+        if kind == "Deployment":
+            return DeploymentServiceManager
+        elif kind == "Service":
+            return KnativeServiceManager
+        elif kind == "RayCluster":
+            return RayClusterServiceManager
+        else:
+            raise ValueError(f"Invalid service manager class for kind: {kind}")
 
     def _get_deployment_timestamp(self) -> str:
         return datetime.now(timezone.utc).isoformat()

--- a/python_client/kubetorch/serving/templates/pod_template.yaml
+++ b/python_client/kubetorch/serving/templates/pod_template.yaml
@@ -37,7 +37,6 @@ tolerations:
 {% endfor %}
 {% endif %}
 
-timeoutSeconds: {{ launch_timeout }}
 containers:
   - name: kubetorch
     image: {{ server_image }}

--- a/python_client/tests/test_byo_manifest.py
+++ b/python_client/tests/test_byo_manifest.py
@@ -1,0 +1,176 @@
+import copy
+import os
+
+import pytest
+
+from .utils import summer
+
+
+def _get_basic_manifest(kind: str):
+    """Generate a minimal manifest for the given kind with test values."""
+    base_metadata = {
+        "name": "",
+        "namespace": "default",
+        "labels": {"test-label": "test-app"},
+        "annotations": {"test-annotation": "original-value"},
+    }
+
+    if kind == "Deployment":
+        return {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": base_metadata,
+            "spec": {
+                "replicas": 2,  # Initial value to be overridden
+                "selector": {"matchLabels": {"test-label": "test-app"}},
+                "template": {
+                    "metadata": {"labels": {"test-label": "test-app"}},
+                    "spec": {"containers": []},
+                },
+            },
+        }
+    elif kind == "Service":  # Knative
+        return {
+            "apiVersion": "serving.knative.dev/v1",
+            "kind": "Service",
+            "metadata": base_metadata,
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "autoscaling.knative.dev/min-scale": "1",
+                            "autoscaling.knative.dev/max-scale": "10",
+                        },
+                        "labels": {"test-label": "test-app"},
+                    },
+                    "spec": {"containers": []},
+                },
+            },
+        }
+    elif kind == "RayCluster":
+        return {
+            "apiVersion": "ray.io/v1",
+            "kind": "RayCluster",
+            "metadata": base_metadata,
+            "spec": {
+                "headGroupSpec": {
+                    "serviceType": "ClusterIP",
+                    "rayStartParams": {"dashboard-host": "0.0.0.0"},
+                    "template": {"spec": {"containers": []}},
+                },
+                "workerGroupSpecs": [
+                    {
+                        "replicas": 1,
+                        "minReplicas": 1,
+                        "maxReplicas": 10,
+                        "groupName": "small-group",
+                        "rayStartParams": {},
+                        "template": {"spec": {"containers": []}},
+                    }
+                ],
+            },
+        }
+    else:
+        raise ValueError(f"Unknown manifest kind: {kind}")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def setup_test_env():
+    os.environ["KT_LAUNCH_TIMEOUT"] = "300"
+    yield
+
+
+@pytest.mark.level("minimal")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["Deployment", "Service", "RayCluster"])
+async def test_byo_manifest_with_overrides(kind):
+    """Test BYO manifest with comprehensive kwargs overrides and containers."""
+    import kubetorch as kt
+
+    # Get manifest with test values already set (deep copy to avoid modifying the original)
+    test_manifest = copy.deepcopy(_get_basic_manifest(kind))
+
+    # Add a container with some initial values
+    container = {
+        "name": "user-container",
+        "image": "user-image:latest",
+        "resources": {
+            "requests": {
+                "cpu": "0.3",
+                "memory": "512Mi",
+            },
+        },
+        "env": [
+            {"name": "ORIGINAL_ENV", "value": "original_value"},
+            {"name": "CONTAINER_ENV", "value": "container_value"},
+        ],
+    }
+
+    # Add container to the appropriate location based on manifest type
+    if test_manifest["kind"] == "Deployment":
+        test_manifest["spec"]["template"]["spec"]["containers"] = [container]
+    elif test_manifest["kind"] == "Service":  # Knative
+        test_manifest["spec"]["template"]["spec"]["containers"] = [container]
+    elif test_manifest["kind"] == "RayCluster":
+        test_manifest["spec"]["headGroupSpec"]["template"]["spec"]["containers"] = [container]
+        test_manifest["spec"]["workerGroupSpecs"][0]["template"]["spec"]["containers"] = [container]
+
+    image_type = "Ray" if kind == "RayCluster" else "Debian"
+    image = getattr(kt.images, image_type)()
+
+    # Create compute with comprehensive overrides
+    compute = kt.Compute(
+        manifest=test_manifest,
+        cpus="0.5",
+        memory="2Gi",
+        replicas=3,
+        labels={"custom-label": "custom-value"},
+        annotations={"test-annotation": "overridden-value"},
+        env_vars={"TEST_ENV": "test_value", "ORIGINAL_ENV": "overridden_value"},
+        image=image,
+        gpu_anti_affinity=True,
+    )
+    service_name = f"{kt.config.username}-byo-{kind.lower()}"
+    compute.service_name = service_name
+
+    # Verify overrides are applied using compute properties
+    assert compute.cpus == "0.5"
+    assert compute.memory == "2Gi"
+    assert compute.replicas == 3
+    assert compute.labels["custom-label"] == "custom-value"
+    assert compute.annotations["test-annotation"] == "overridden-value"
+    assert compute.env_vars["TEST_ENV"] == "test_value"
+    assert compute.server_image == image.image_id
+    assert compute.gpu_anti_affinity is True
+    assert compute.env_vars["ORIGINAL_ENV"] == "overridden_value"
+    assert compute.env_vars["CONTAINER_ENV"] == "container_value"
+
+    # Deploy and test function
+    fn = await kt.fn(summer).to_async(compute)
+    assert fn.service_name == service_name
+
+    result = fn(5, 10)
+    assert result == 15
+
+
+@pytest.mark.level("minimal")
+def test_byo_manifest_extracts_values():
+    """Test that values are extracted from manifest when not provided as kwargs."""
+    import kubetorch as kt
+
+    # Create manifest with annotations
+    manifest = copy.deepcopy(_get_basic_manifest("Deployment"))
+    manifest["metadata"]["annotations"]["kubetorch.com/kubeconfig-path"] = "/path/to/kubeconfig"
+    manifest["metadata"]["annotations"]["kubetorch.com/inactivity-ttl"] = "1h"
+
+    compute = kt.Compute(
+        manifest=manifest,
+        cpus="0.3",
+        memory="512Mi",
+        image=kt.images.Debian(),
+        gpu_anti_affinity=True,
+    )
+
+    # Verify extracted values are preserved in annotations
+    assert compute.kubeconfig_path == "/path/to/kubeconfig"
+    assert compute.inactivity_ttl == "1h"


### PR DESCRIPTION
add support for handling byo manifest in compute init, for existing service types (deployment, ksvc, raycluster), and supplement with kubetorch defaults, env vars, and formatting. additional kwargs will override manifest values
* extract user values from byo manifest
* generate new pod template and manifest with the following priority: kwargs -> user_value -> kubetorch default
* merge new pod spec into original pod spec. override differences, and add in missing components. rest of the user manifest stays the same