### PR TITLE
Improved labelling for queries

### DIFF
--- a/python_client/kubetorch/serving/base_service_manager.py
+++ b/python_client/kubetorch/serving/base_service_manager.py
@@ -1,8 +1,9 @@
+import hashlib
 import importlib
 import re
 from abc import abstractmethod
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import yaml
 from jinja2 import Template
@@ -81,6 +82,26 @@ class BaseServiceManager:
 
     def _get_deployment_timestamp(self) -> str:
         return datetime.now(timezone.utc).isoformat()
+
+    def _generate_deployment_id(self, service_name: str, timestamp: str) -> str:
+        """Generate a unique deployment ID from service name + timestamp.
+
+        Returns a string like 'username-myapp-a1b2c3' where the suffix is a
+        6-character hash derived from the timestamp.
+        """
+        hash_input = f"{service_name}-{timestamp}"
+        short_hash = hashlib.sha256(hash_input.encode()).hexdigest()[:6]
+        return f"{service_name}-{short_hash}"
+
+    def _get_deployment_timestamp_and_id(self, service_name: str) -> Tuple[str, str]:
+        """Get both deployment timestamp and deployment ID together.
+
+        Returns:
+            Tuple of (timestamp, deployment_id)
+        """
+        timestamp = self._get_deployment_timestamp()
+        deployment_id = self._generate_deployment_id(service_name, timestamp)
+        return timestamp, deployment_id
 
     def _clean_module_name(self, module_name: str) -> str:
         """Clean module name to remove invalid characters for Kubernetes labels."""

--- a/python_client/kubetorch/serving/constants.py
+++ b/python_client/kubetorch/serving/constants.py
@@ -39,6 +39,8 @@ KT_USERNAME_LABEL = "kubetorch.com/username"
 KT_POD_TYPE_LABEL = "kubetorch.com/pod-type"
 KT_TEMPLATE_LABEL = "kubetorch.com/template"
 KT_SECRET_NAME_LABEL = "kubetorch.com/secret-name"
+KT_APP_LABEL = "app"  # Stable app identifier for easy querying
+KT_DEPLOYMENT_ID_LABEL = "kubetorch.com/deployment-id"  # Unique per deployment run
 
 # Templates
 TTL_CONTROLLER_CONFIGMAP_NAME = "kubetorch-ttl-controller-config"

--- a/python_client/kubetorch/serving/deployment_service_manager.py
+++ b/python_client/kubetorch/serving/deployment_service_manager.py
@@ -76,16 +76,20 @@ class DeploymentServiceManager(BaseServiceManager):
     def _update_launchtime_manifest(self, manifest: dict, service_name: str, module_name: str) -> dict:
         """Update manifest with service name and deployment timestamp."""
         clean_module_name = self._clean_module_name(module_name)
-        deployment_timestamp = self._get_deployment_timestamp()
+        deployment_timestamp, deployment_id = self._get_deployment_timestamp_and_id(service_name)
 
         deployment = manifest.copy()
         deployment["metadata"]["name"] = service_name
         deployment["metadata"]["labels"][serving_constants.KT_SERVICE_LABEL] = service_name
         deployment["metadata"]["labels"][serving_constants.KT_MODULE_LABEL] = clean_module_name
+        deployment["metadata"]["labels"][serving_constants.KT_APP_LABEL] = service_name
+        deployment["metadata"]["labels"][serving_constants.KT_DEPLOYMENT_ID_LABEL] = deployment_id
         deployment["spec"]["selector"]["matchLabels"][serving_constants.KT_SERVICE_LABEL] = service_name
         deployment["spec"]["selector"]["matchLabels"][serving_constants.KT_MODULE_LABEL] = clean_module_name
         deployment["spec"]["template"]["metadata"]["labels"][serving_constants.KT_SERVICE_LABEL] = service_name
         deployment["spec"]["template"]["metadata"]["labels"][serving_constants.KT_MODULE_LABEL] = clean_module_name
+        deployment["spec"]["template"]["metadata"]["labels"][serving_constants.KT_APP_LABEL] = service_name
+        deployment["spec"]["template"]["metadata"]["labels"][serving_constants.KT_DEPLOYMENT_ID_LABEL] = deployment_id
 
         # Add deployment timestamp
         deployment["spec"]["template"]["metadata"]["annotations"][

--- a/python_client/kubetorch/serving/knative_service_manager.py
+++ b/python_client/kubetorch/serving/knative_service_manager.py
@@ -102,17 +102,22 @@ class KnativeServiceManager(BaseServiceManager):
     def _update_launchtime_manifest(self, manifest: dict, service_name: str, module_name: str) -> dict:
         """Update manifest with service name and deployment timestamp."""
         clean_module_name = self._clean_module_name(module_name)
+        deployment_timestamp, deployment_id = self._get_deployment_timestamp_and_id(service_name)
 
         service = manifest.copy()
         service["metadata"]["name"] = service_name
         service["metadata"]["labels"][serving_constants.KT_SERVICE_LABEL] = service_name
         service["metadata"]["labels"][serving_constants.KT_MODULE_LABEL] = clean_module_name
+        service["metadata"]["labels"][serving_constants.KT_APP_LABEL] = service_name
+        service["metadata"]["labels"][serving_constants.KT_DEPLOYMENT_ID_LABEL] = deployment_id
         service["spec"]["template"]["metadata"]["labels"][serving_constants.KT_SERVICE_LABEL] = service_name
         service["spec"]["template"]["metadata"]["labels"][serving_constants.KT_MODULE_LABEL] = clean_module_name
+        service["spec"]["template"]["metadata"]["labels"][serving_constants.KT_APP_LABEL] = service_name
+        service["spec"]["template"]["metadata"]["labels"][serving_constants.KT_DEPLOYMENT_ID_LABEL] = deployment_id
 
         service["spec"]["template"]["metadata"]["annotations"][
             "kubetorch.com/deployment_timestamp"
-        ] = self._get_deployment_timestamp()
+        ] = deployment_timestamp
 
         return service
 

--- a/python_client/kubetorch/serving/raycluster_service_manager.py
+++ b/python_client/kubetorch/serving/raycluster_service_manager.py
@@ -53,12 +53,14 @@ class RayClusterServiceManager(BaseServiceManager):
     def _update_launchtime_manifest(self, manifest: dict, service_name: str, module_name: str) -> dict:
         """Update manifest with service name and deployment timestamp."""
         clean_module_name = self._clean_module_name(module_name)
-        deployment_timestamp = self._get_deployment_timestamp()
+        deployment_timestamp, deployment_id = self._get_deployment_timestamp_and_id(service_name)
 
         raycluster = manifest.copy()
         raycluster["metadata"]["name"] = service_name
         raycluster["metadata"]["labels"][serving_constants.KT_SERVICE_LABEL] = service_name
         raycluster["metadata"]["labels"][serving_constants.KT_MODULE_LABEL] = clean_module_name
+        raycluster["metadata"]["labels"][serving_constants.KT_APP_LABEL] = service_name
+        raycluster["metadata"]["labels"][serving_constants.KT_DEPLOYMENT_ID_LABEL] = deployment_id
 
         # Collect all pod templates to update (head + all worker groups)
         pod_templates = []
@@ -84,6 +86,8 @@ class RayClusterServiceManager(BaseServiceManager):
                 metadata["labels"] = {}
             metadata["labels"][serving_constants.KT_SERVICE_LABEL] = service_name
             metadata["labels"][serving_constants.KT_MODULE_LABEL] = clean_module_name
+            metadata["labels"][serving_constants.KT_APP_LABEL] = service_name
+            metadata["labels"][serving_constants.KT_DEPLOYMENT_ID_LABEL] = deployment_id
 
             if "annotations" not in metadata:
                 metadata["annotations"] = {}

--- a/python_client/tests/test_autodown.py
+++ b/python_client/tests/test_autodown.py
@@ -90,6 +90,20 @@ def test_autodown_deployment():
     assert service.metadata.labels[serving_constants.KT_MODULE_LABEL] is not None
     assert service.metadata.annotations[serving_constants.INACTIVITY_TTL_ANNOTATION] == inactivity_ttl
 
+    # Check that the new app and deployment-id labels exist on the pod
+    pod_labels = pod.metadata.labels
+    assert pod_labels.get(serving_constants.KT_APP_LABEL) == remote_fn.service_name
+    assert pod_labels.get(serving_constants.KT_DEPLOYMENT_ID_LABEL) is not None
+    assert pod_labels.get(serving_constants.KT_DEPLOYMENT_ID_LABEL).startswith(remote_fn.service_name)
+
+    # Check that the Deployment also has the new labels
+    apps_v1_api = client.AppsV1Api()
+    deployment = apps_v1_api.read_namespaced_deployment(name=remote_fn.service_name, namespace=namespace)
+    deployment_labels = deployment.metadata.labels
+    assert deployment_labels.get(serving_constants.KT_APP_LABEL) == remote_fn.service_name
+    assert deployment_labels.get(serving_constants.KT_DEPLOYMENT_ID_LABEL) is not None
+    assert deployment_labels.get(serving_constants.KT_DEPLOYMENT_ID_LABEL).startswith(remote_fn.service_name)
+
     # Check that the namespace is in the watch namespaces
     cronjob_configmap = core_api.read_namespaced_config_map(
         name=serving_constants.TTL_CONTROLLER_CONFIGMAP_NAME,
@@ -144,6 +158,12 @@ def test_autodown_raycluster():
     # Check that the service has the autodown annotation
     assert service.metadata.labels[serving_constants.KT_MODULE_LABEL] is not None
     assert service.metadata.annotations[serving_constants.INACTIVITY_TTL_ANNOTATION] == inactivity_ttl
+
+    # Check that the new app and deployment-id labels exist on the pod
+    pod_labels = pod.metadata.labels
+    assert pod_labels.get(serving_constants.KT_APP_LABEL) == remote_fn.service_name
+    assert pod_labels.get(serving_constants.KT_DEPLOYMENT_ID_LABEL) is not None
+    assert pod_labels.get(serving_constants.KT_DEPLOYMENT_ID_LABEL).startswith(remote_fn.service_name)
 
 
 @pytest.mark.skip("Long running test, skipping for now")


### PR DESCRIPTION
Add `app` and `deployment-id` labels for easier querying of all Kubetorch deployments (Deployment, Knative, RayCluster):

| Label | Example | Purpose |
|-------|---------|---------|
| `app` | `matt-myapp` | Stable app identifier across runs |
| `kubetorch.com/deployment-id` | `matt-myapp-7f3a2c` | Unique per deployment run |

### Why?

- `app` is a standard Kubernetes label recognized by many tools (Prometheus, Grafana, etc.)
- `deployment-id` allows distinguishing between different runs of the same service (e.g., after teardown and redeploy)

### Example queries

```bash
# All pods for this app (any run)
kubectl get pods -l app=matt-myapp
```

```bash
# Pods from a specific deployment run  
kubectl get pods -l kubetorch.com/deployment-id=matt-myapp-7f3a2c
```
