### PR TITLE
Fix to to_async()

### DIFF
--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -494,7 +494,7 @@ class Module:
                     return existing_service
             except Exception as e:
                 logger.info(
-                    f"Service {self.compute.service_name} not found in namespace {self.compute.namespace} "
+                    f"Service {self.service_name} not found in namespace {compute.namespace} "
                     f"with reload_prefixes={reload_prefixes}: {str(e)}"
                 )
 


### PR DESCRIPTION
Minor fix to avoid when "get_if_exists" is set to True but the service is not already up. Logging message tries to access service name incorrectly (and differently from regular sync to)