### PR TITLE
Remove resource limits, keep only requests

### DIFF
--- a/charts/kubetorch/templates/nginx-proxy/deployment.yaml
+++ b/charts/kubetorch/templates/nginx-proxy/deployment.yaml
@@ -48,9 +48,6 @@ spec:
             requests:
               cpu: "100m"
               memory: "128Mi"
-            limits:
-              cpu: "500m"
-              memory: "256Mi"
       volumes:
         - name: nginx-config
           configMap:

--- a/charts/kubetorch/templates/rsync/namespace-rsync.yaml
+++ b/charts/kubetorch/templates/rsync/namespace-rsync.yaml
@@ -68,10 +68,6 @@ spec:
               cpu: {{ $.Values.rsync.cpu.request }}
               memory: {{ $.Values.rsync.memory.request }}
               ephemeral-storage: {{ $.Values.rsync.ephemeralStorage.request }}
-            limits:
-              cpu: {{ $.Values.rsync.cpu.limit }}
-              memory: {{ $.Values.rsync.memory.limit }}
-              ephemeral-storage: {{ $.Values.rsync.ephemeralStorage.limit }}
 
       volumes:
         - name: rsync-data


### PR DESCRIPTION
Kubernetes best practice is to set only resource requests for most workloads,
allowing pods to burst when resources are available. Limits can cause
unnecessary throttling and OOM kills.

Changes:
- nginx-proxy: Remove CPU/memory limits
- rsync: Remove CPU/memory/ephemeral-storage limits
- compute.py: Remove limits logic from resource configuration