### PR TITLE
suppress 404 warnings on teardown

### DIFF
--- a/python_client/kubetorch/resources/compute/utils.py
+++ b/python_client/kubetorch/resources/compute/utils.py
@@ -830,6 +830,7 @@ def fetch_resources_for_teardown(
                         namespace=namespace,
                         plural=plural,
                         name=service_name,
+                        ignore_not_found=True,
                     )
                     if job_resource:
                         service_type = job_kind.lower()


### PR DESCRIPTION
```
❯ kt teardown move-deploy-into-deployment-summer
Finding resources for service move-deploy-into-deployment-summer in kubetorch namespace...
ERROR | 2025-12-11 22:41:46 | kubetorch.globals:435 | GET http://localhost:38080/apis/kubeflow.org/v1/namespaces/kubetorch/pytorchjobs/main-move-deploy-into-deployment-summer failed with status 404: pytorchjobs.kubeflow.org "main-move-deploy-into-deployment-summer" not found
ERROR | 2025-12-11 22:41:46 | kubetorch.globals:435 | GET http://localhost:38080/apis/kubeflow.org/v1/namespaces/kubetorch/tfjobs/main-move-deploy-into-deployment-summer failed with status 404: tfjobs.kubeflow.org "main-move-deploy-into-deployment-summer" not found
ERROR | 2025-12-11 22:41:46 | kubetorch.globals:435 | GET http://localhost:38080/apis/kubeflow.org/v1/namespaces/kubetorch/mxjobs/main-move-deploy-into-deployment-summer failed with status 404: mxjobs.kubeflow.org "main-move-deploy-into-deployment-summer" not found
ERROR | 2025-12-11 22:41:46 | kubetorch.globals:435 | GET http://localhost:38080/apis/kubeflow.org/v1/namespaces/kubetorch/xgboostjobs/main-move-deploy-into-deployment-summer failed with status 404: xgboostjobs.kubeflow.org "main-move-deploy-into-deployment-summer" not found
```