### PR TITLE
add support for  `kt teardown` of a training job

### DIFF
--- a/python_client/kubetorch/cli.py
+++ b/python_client/kubetorch/cli.py
@@ -1436,6 +1436,7 @@ def kt_teardown(
         service_info = resources["services"][name]
         configmaps = service_info["configmaps"]
         service_type = service_info.get("type", "knative")
+        service_group = service_info.get("group", None)
         service_types.add(service_type)
 
         delete_resources_for_service(
@@ -1445,6 +1446,7 @@ def kt_teardown(
             namespace=namespace,
             console=console,
             force=force,
+            group=service_group,
         )
 
     # Force delete any remaining pods if --force flag is set


### PR DESCRIPTION
`kt teardown` was broken for BYO manifest, which caused CI cluster to contain a lot of obsolete manifest resources. 