### PR TITLE
remove container name from loki query filter

### DIFF
--- a/python_client/kubetorch/cli_utils.py
+++ b/python_client/kubetorch/cli_utils.py
@@ -36,7 +36,7 @@ from kubetorch.constants import MAX_PORT_TRIES
 from kubetorch.resources.compute.utils import is_port_available
 from kubetorch.servers.http.utils import stream_logs_websocket_helper, StreamType
 from kubetorch.serving.utils import wait_for_port_forward
-from kubetorch.utils import get_container_name, hours_to_ns, http_not_found
+from kubetorch.utils import hours_to_ns, http_not_found
 
 from .constants import BULLET_UNICODE, CPU_RATE, DOUBLE_SPACE_UNICODE, GPU_RATE
 
@@ -772,19 +772,19 @@ def stream_logs_websocket(uri, stop_event, print_pod_name: bool = False):
 def generate_logs_query(name: str, namespace: str, selected_pod: str, deployment_mode):
     from kubetorch.serving.trainjob_service_manager import TrainJobServiceManager
 
-    container_name = get_container_name(deployment_mode)
-
     if not selected_pod:
         if deployment_mode in ["knative", "deployment"] + TrainJobServiceManager.SUPPORTED_KINDS:
             # we need to get the pod names first since Loki doesn't have a service_name label
             pods = validate_pods_exist(name, namespace)
             pod_names = [pod["metadata"]["name"] for pod in pods]
-            return f'{{k8s_pod_name=~"{"|".join(pod_names)}",k8s_container_name="{container_name}"}} | json'
+            # Don't filter by container name to support BYO manifests with custom container names
+            return f'{{k8s_pod_name=~"{"|".join(pod_names)}"}} | json'
         else:
             console.print(f"[red]Logs does not support deployment mode: {deployment_mode}[/red]")
             return None
     else:
-        return f'{{k8s_pod_name=~"{selected_pod}",k8s_container_name="{container_name}"}} | json'
+        # Don't filter by container name to support BYO manifests with custom container names
+        return f'{{k8s_pod_name=~"{selected_pod}"}} | json'
 
 
 def follow_logs_in_cli(

--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -27,13 +27,7 @@ from kubetorch.servers.http.utils import (
     is_running_in_kubernetes,
 )
 from kubetorch.serving.utils import has_k8s_credentials, KubernetesCredentialsError
-from kubetorch.utils import (
-    extract_host_port,
-    get_container_name,
-    get_kt_install_url,
-    iso_timestamp_to_nanoseconds,
-    ServerLogsFormatter,
-)
+from kubetorch.utils import extract_host_port, get_kt_install_url, iso_timestamp_to_nanoseconds, ServerLogsFormatter
 
 logger = get_logger(__name__)
 
@@ -924,10 +918,9 @@ class Module:
             deployment_timestamp: Timestamp to filter logs after
         """
         try:
-            # Use the correct container name based on job type to exclude queue-proxy (e.g. Knative sidecars) container logs which
-            # are spammy with tons of healthcheck calls
-            container_name = get_container_name(self.compute.kind)
-            pod_query = f'{{k8s_container_name="{container_name}"}} | json | request_id="{request_id}"'
+            # Filter by namespace and request_id - request_id is unique per launch sequence
+            # and allows logs from any container name (not just "kubetorch")
+            pod_query = f'{{k8s_namespace_name="{self.namespace}"}} | json | request_id="{request_id}"'
             event_query = f'{{service_name="unknown_service"}} | json | k8s_object_name=~"{self.service_name}.*" | k8s_namespace_name="{self.namespace}"'
 
             encoded_pod_query = urllib.parse.quote_plus(pod_query)
@@ -992,10 +985,9 @@ class Module:
             deployment_timestamp: Timestamp to filter logs after
         """
         try:
-            # Only use correct container to exclude queue-proxy (e.g. Knative sidecars) container logs which
-            # are spammy with tons of healthcheck calls
-            container_name = get_container_name(self.compute.kind)
-            pod_query = f'{{k8s_container_name="{container_name}"}} | json | request_id="{request_id}"'
+            # Filter by namespace and request_id - request_id is unique per launch sequence
+            # and allows logs from any container name (not just "kubetorch")
+            pod_query = f'{{k8s_namespace_name="{self.namespace}"}} | json | request_id="{request_id}"'
             event_query = f'{{service_name="unknown_service"}} | json | k8s_object_name=~"{self.service_name}.*" | k8s_namespace_name="{self.namespace}"'
 
             encoded_pod_query = urllib.parse.quote_plus(pod_query)

--- a/python_client/kubetorch/utils.py
+++ b/python_client/kubetorch/utils.py
@@ -299,13 +299,3 @@ def http_conflict(e: Exception) -> bool:
     # Fallback to string matching for edge cases
     err_str = str(e).lower()
     return "409" in err_str or "already exists" in err_str
-
-
-def get_container_name(kind: str = None) -> str:
-    """Get the container name for the service based on its kind."""
-    from kubetorch.serving.trainjob_service_manager import TrainJobServiceManager
-
-    if kind and kind in TrainJobServiceManager.SUPPORTED_KINDS:
-        config = TrainJobServiceManager._get_config(kind)
-        return config["container_name"]
-    return "kubetorch"


### PR DESCRIPTION
Relevant when users apply custom manifests to create pods, either with `kt.Compute()` or thru K8s directly