### PR TITLE
[WIP] add namespace env var to data store config

### DIFF
--- a/charts/kubetorch/templates/data-store/namespace-data-store.yaml
+++ b/charts/kubetorch/templates/data-store/namespace-data-store.yaml
@@ -75,6 +75,11 @@ spec:
             - containerPort: 873   # rsync daemon
             - containerPort: 8080  # HTTP/WebSocket tunnel
             - containerPort: 8081  # Metadata server API
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - name: data-store-storage
               mountPath: /data


### PR DESCRIPTION
Root cause:
  - When files are uploaded via rsync, they go to /`data/{namespace}/{service_name}/` (e.g., `/data/kubetorch/t-02936d-summer/`)
  - When the metadata server checks if files exist, it uses `POD_NAMESPACE` to construct the filesystem path
  - The data store deployment was missing the `POD_NAMESPACE` env var, so it defaulted to `"default"`
  - The metadata server was looking at `/data/default/t-02936d-summer/` instead of `/data/kubetorch/t-02936d-summer/`
  - This let to the metadata server failing to find the key  (in `has_store_pod()`) 
