### PR TITLE
bump data store image version

### DIFF
--- a/charts/kubetorch/README.md
+++ b/charts/kubetorch/README.md
@@ -34,7 +34,7 @@ A Helm chart for kubetorch
 | dataStore.cpu.request | int | `1` |  |
 | dataStore.ephemeralStorage.limit | string | `"10Gi"` |  |
 | dataStore.ephemeralStorage.request | string | `"5Gi"` |  |
-| dataStore.image | string | `"ghcr.io/run-house/kubetorch-data-store:v1"` |  |
+| dataStore.image | string | `"ghcr.io/run-house/kubetorch-data-store:v2"` |  |
 | dataStore.imagePullPolicy | string | `"Always"` |  |
 | dataStore.maxConnections | int | `500` |  |
 | dataStore.maxConnectionsPerModule | int | `0` |  |

--- a/charts/kubetorch/values.yaml
+++ b/charts/kubetorch/values.yaml
@@ -30,7 +30,7 @@ nvidia-device-plugin:
       effect: "NoSchedule"
 
 dataStore:
-  image: ghcr.io/run-house/kubetorch-data-store:v1
+  image: ghcr.io/run-house/kubetorch-data-store:v2
   imagePullPolicy: Always
   # serviceAccount: kubetorch-service-account  # Optional: use specific service account for Workload Identity
   maxConnections: 500  # Maximum concurrent rsync connections (increase for many worker pods)


### PR DESCRIPTION
Should be merged once:
1. data store image changes are merged into `kt-internal` main: https://github.com/run-house/kubetorch-internal/pull/939
2. New image (v2) is pushed to GHCR. 