### PR TITLE
Auth endpoint setting and token setting test

### DIFF
--- a/charts/kubetorch/README.md
+++ b/charts/kubetorch/README.md
@@ -55,6 +55,7 @@ A Helm chart for kubetorch
 | kubetorchConfig.metricsEnabled | bool | `true` |  |
 | kubetorchConfig.serviceAccountAnnotations | object | `{}` |  |
 | kubetorchController.affinity | object | `{}` |  |
+| kubetorchController.authEndpoint | string | `""` |  |
 | kubetorchController.connectionPoolSize | int | `20` |  |
 | kubetorchController.eventWatcher.batchSize | int | `10` |  |
 | kubetorchController.eventWatcher.enabled | bool | `true` |  |

--- a/charts/kubetorch/templates/controller/deployment.yaml
+++ b/charts/kubetorch/templates/controller/deployment.yaml
@@ -74,6 +74,8 @@ spec:
               value: {{ .Values.kubetorchController.connectionPoolSize | quote }}
             - name: KUBETORCH_DB_PATH
               value: "/data/kubetorch.db"
+            - name: AUTH_ENDPOINT
+              value: {{ .Values.kubetorchController.authEndpoint | default "" | quote }}
             # Event watcher configuration
             - name: EVENT_WATCH_ENABLED
               value: {{ .Values.kubetorchController.eventWatcher.enabled | quote }}

--- a/charts/kubetorch/values.yaml
+++ b/charts/kubetorch/values.yaml
@@ -26,6 +26,10 @@ kubetorchController:
     batchSize: 10  # Number of events to batch before pushing to Loki
     flushInterval: 1.0  # Max seconds between flushes (lower = faster delivery)
 
+  # Authentication endpoint (leave empty to disable auth)
+  # Example: "http://kubetorch-mgmt-controller-api.kubetorch.svc.cluster.local:8000/api/v1/auth/validate"
+  authEndpoint: ""
+
   resources:
     cpu:
       request: "200m"   # Minimum guaranteed CPU (0.2 cores)

--- a/python_client/kubetorch/config.py
+++ b/python_client/kubetorch/config.py
@@ -21,6 +21,7 @@ ENV_MAPPINGS = {
     "volumes": "KT_VOLUMES",
     "api_url": "KT_API_URL",
     "cluster_config": "KT_CLUSTER_CONFIG",
+    "token": "KT_TOKEN",
 }
 
 DEFAULT_INSTALL_NAMESPACE = "kubetorch"
@@ -38,6 +39,7 @@ class KubetorchConfig:
         self._namespace = None
         self._stream_logs = None
         self._stream_metrics = None
+        self._token = None
         self._username = None
         self._volumes = None
 
@@ -148,6 +150,25 @@ class KubetorchConfig:
     @api_url.setter
     def api_url(self, value: str):
         self._api_url = value
+
+    @property
+    def token(self):
+        """Authentication token for Kubetorch API requests.
+
+        When set, this token is included as a Bearer token in the Authorization header
+        for all requests to the Kubetorch controller.
+        """
+        if not self._token:
+            if self._get_env_var("token"):
+                self._token = self._get_env_var("token")
+            else:
+                self._token = self.file_cache.get("token")
+        return self._token
+
+    @token.setter
+    def token(self, value: str):
+        """Set authentication token for current process."""
+        self._token = value
 
     @property
     def namespace(self):

--- a/python_client/kubetorch/globals.py
+++ b/python_client/kubetorch/globals.py
@@ -387,6 +387,8 @@ class ControllerClient:
 
         # No default timeout - long-running operations (e.g.: deploy, check-ready) should not time out
         self.session = httpx.Client(headers={"Content-Type": "application/json"}, timeout=None)
+        if config.token:
+            self.session.headers.update({"Authorization": f"Bearer {config.token}"})
 
     def _request(self, method: str, path: str, ignore_not_found=False, timeout=None, **kwargs) -> httpx.Response:
         """Make HTTP request to controller.


### PR DESCRIPTION
Adds fields to `values.yaml` for setting auth endpoint. Leaving it blank disables auth on the controller and setting it will require a valid token.

Be sure to restart the controller after upgrading:
```
kubectl rollout restart -n kubetorch deployment/kubetorch-controller
```