### PR TITLE
increase `KT_LAUNCH_TIMEOUT` for CI tests

### DIFF
--- a/python_client/tests/test_autodown.py
+++ b/python_client/tests/test_autodown.py
@@ -11,7 +11,7 @@ from .utils import create_random_name_prefix, simple_summer
 def setup_test_env():
     os.environ["KT_GPU_ANTI_AFFINITY"] = "True"
     # Keep the launch timeout low for this test suite, unless overridden (ex: for GPU tests)
-    os.environ["KT_LAUNCH_TIMEOUT"] = "120"
+    os.environ["KT_LAUNCH_TIMEOUT"] = "150"
     yield
 
 

--- a/python_client/tests/test_deployment_fixtures.py
+++ b/python_client/tests/test_deployment_fixtures.py
@@ -19,7 +19,7 @@ class OSInfoRequest(BaseModel):
 @pytest.fixture(autouse=True, scope="session")
 def setup_test_env():
     # Keep the launch timeout low for this test suite, unless overridden (ex: for GPU tests)
-    os.environ["KT_LAUNCH_TIMEOUT"] = "120"
+    os.environ["KT_LAUNCH_TIMEOUT"] = "150"
     # Only set TEST_COMPUTE_TYPE if it's not already set (to allow override from environment)
     if "TEST_COMPUTE_TYPE" not in os.environ:
         os.environ["TEST_COMPUTE_TYPE"] = "deployment"

--- a/python_client/tests/test_imperative.py
+++ b/python_client/tests/test_imperative.py
@@ -29,7 +29,7 @@ from .utils import (
 @pytest.fixture(autouse=True, scope="session")
 def setup_test_env():
     # Keep the launch timeout low for this test suite, unless overridden (ex: for GPU tests)
-    os.environ["KT_LAUNCH_TIMEOUT"] = "120"
+    os.environ["KT_LAUNCH_TIMEOUT"] = "150"
     yield
 
 

--- a/python_client/tests/test_pod_from_pod.py
+++ b/python_client/tests/test_pod_from_pod.py
@@ -8,7 +8,7 @@ from .utils import create_random_name_prefix, service_deployer, service_deployer
 @pytest.fixture(autouse=True, scope="session")
 def setup_test_env():
     # Keep the launch timeout low for this test suite, unless overridden (ex: for GPU tests)
-    os.environ["KT_LAUNCH_TIMEOUT"] = "120"
+    os.environ["KT_LAUNCH_TIMEOUT"] = "150"
     os.environ["KT_STREAM"] = "true"
     yield
 

--- a/python_client/tests/test_python_path.py
+++ b/python_client/tests/test_python_path.py
@@ -14,7 +14,7 @@ from .utils import get_test_fn_name, python_version_and_path
 @pytest.fixture(autouse=True, scope="session")
 def setup_test_env():
     # Keep the launch timeout low for this test suite, unless overridden (ex: for GPU tests)
-    os.environ["KT_LAUNCH_TIMEOUT"] = "120"
+    os.environ["KT_LAUNCH_TIMEOUT"] = "150"
     yield
 
 


### PR DESCRIPTION
increasing KT_LAUNCH_TIMEOUT env var value set for some tests, in case resource triggers autoscaler to create another node.