### PR TITLE
Consolidate controller API calls with generic list_resources endpoint

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -32,11 +32,11 @@ jobs:
       - name: Setup Test Cluster
         uses: ./.github/workflows/setup_test_cluster
         with:
-          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+          KUBECONFIG: ${{ secrets.KT_TEST_KUBECONFIG }}
 
       - name: Get GKE credentials
         run: |
-          gcloud container clusters get-credentials ${{ secrets.CI_CLUSTER_NAME }} \
+          gcloud container clusters get-credentials ${{ secrets.KT_TEST_CLUSTER_NAME }} \
             --region ${{ secrets.CI_CLUSTER_REGION }} \
             --project ${{ secrets.GCP_PROJECT_ID }}
 
@@ -125,7 +125,7 @@ jobs:
       - name: Setup Test Cluster
         uses: ./.github/workflows/setup_test_cluster
         with:
-          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+          KUBECONFIG: ${{ secrets.KT_TEST_KUBECONFIG }}
 
       - name: Set Test Hash
         run: |

--- a/.github/workflows/kubetorch-release.yaml
+++ b/.github/workflows/kubetorch-release.yaml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Get GKE credentials
         run: |
-          gcloud container clusters get-credentials ${{ secrets.CI_CLUSTER_NAME }} \
+          gcloud container clusters get-credentials ${{ secrets.KT_TEST_CLUSTER_NAME }} \
             --region ${{ secrets.CI_CLUSTER_REGION }} \
             --project ${{ secrets.GCP_PROJECT_ID }}
 

--- a/.github/workflows/minimal_tests.yaml
+++ b/.github/workflows/minimal_tests.yaml
@@ -36,6 +36,146 @@ env:
   KUBETORCH_IGNORE_VERSION_MISMATCH: 1
 
 jobs:
+  base-minimal-tests:
+    concurrency:
+      group: cpu-${{ github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Install Basic Dependencies
+        uses: ./.github/workflows/install_basic_dependencies
+
+      - name: Setup authentications
+        uses: ./.github/workflows/gke_authentications
+        with:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Setup Test Cluster
+        uses: ./.github/workflows/setup_test_cluster
+        with:
+          KUBECONFIG: ${{ secrets.KT_TEST_KUBECONFIG }}
+
+      - name: Get GKE credentials
+        run: |
+          gcloud container clusters get-credentials ${{ secrets.KT_TEST_CLUSTER_NAME }} \
+            --region ${{ secrets.CI_CLUSTER_REGION }} \
+            --project ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Set Python Source Root
+        run: echo "PYTHONPATH=$(pwd)/python_client" >> $GITHUB_ENV
+
+      - name: Set Test Hash
+        run: |
+          TEST_HASH="t-$(echo $GITHUB_SHA | cut -c1-5)-minimal"
+          echo "TEST_HASH=$TEST_HASH" >> $GITHUB_ENV
+          echo "Using test hash $TEST_HASH"
+
+      - name: Generate Namespace value from branch name
+        shell: bash
+        id: generate_ns
+        run: |
+          BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+
+          # create namespace only of the branch in in a format {namespace}---{featurename}".
+          # Namespace will be {namespace}
+
+          if [[ "$BRANCH" == *"---"* ]]; then
+            # Get part before '---'
+            NAMESPACE="${BRANCH%%---*}"
+            # If branch has a slash (e.g., sb/prefix---feature), keep what's after '/'
+            NAMESPACE="${NAMESPACE##*/}"
+          else
+            NAMESPACE="${BRANCH##*/}"
+          fi
+
+          # Sanitize for k8s namespace
+          NAMESPACE=$(echo "$NAMESPACE" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's#[^a-z0-9]#-#g' \
+            | sed 's/--*/-/g' \
+            | sed 's/^-//;s/-$//' \
+            | cut -c1-63)
+
+          echo "NAMESPACE=$NAMESPACE" >> $GITHUB_OUTPUT
+
+      - name: Update kt config with controller test namespace, if exists
+        shell: bash
+        id: controller-ns
+        run: |
+
+          NAMESPACE=${{ steps.generate_ns.outputs.NAMESPACE }}
+
+          # Check if namespace exists
+          if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+            echo "Namespace $NAMESPACE exists, setting kt config"
+            kt config set namespace "$NAMESPACE"
+            kt config set install_namespace "$NAMESPACE"
+          else
+            echo "Namespace $NAMESPACE does not exist, kt config remains unchanged"
+          fi
+
+      - name: Configure test namespace RBAC
+        run: |
+          TEST_NS="kt-test-$TEST_HASH"
+          echo "Creating test namespace $TEST_NS and configuring RBAC..."
+          kubectl create namespace $TEST_NS --dry-run=client -o yaml | kubectl apply -f -
+
+          # Use controller-ns output or fallback to 'kubetorch' (service account setup)
+          CONTROLLER_NS="${{ steps.controller-ns.outputs.NAMESPACE }}"
+          CONTROLLER_NS="${CONTROLLER_NS:-kubetorch}"
+
+          # Create Role for the test namespace
+          kubectl apply -f - <<EOF
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: kubetorch-controller-role-$TEST_NS
+            namespace: $TEST_NS
+          rules:
+            - apiGroups: [""]
+              resources: ["persistentvolumeclaims", "pods", "services", "configmaps", "secrets", "events"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["pods/exec", "pods/log"]
+              verbs: ["create", "get"]
+            - apiGroups: ["apps"]
+              resources: ["deployments", "deployments/status", "replicasets", "replicasets/status"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: ["networking.k8s.io"]
+              resources: ["ingresses"]
+              verbs: ["get", "list", "watch"]
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: kubetorch-controller-rolebinding-$TEST_NS
+            namespace: $TEST_NS
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: kubetorch-controller-role-$TEST_NS
+          subjects:
+            - kind: ServiceAccount
+              name: kubetorch-controller
+              namespace: $CONTROLLER_NS
+          EOF
+
+      - name: Run base minimal tests
+        run: |
+          cd python_client
+          pytest -v --durations=100 --level minimal -m "not gpu_test" -k "not distributed and not monitoring and not cli and not deploy" --ignore=tests/test_deployment_fixtures.py --ignore=tests/test_pod_from_pod.py --ignore=tests/test_python_path.py --ignore=tests/test_secret.py --ignore=tests/test_declarative.py --ignore=tests/test_app.py --ignore tests/test_byo_manifest.py
+        timeout-minutes: 60
+        env:
+          KT_STREAM_LOGS: false
+          KT_STREAM_METRICS: false
+
   cli-tests:
     concurrency:
       group: cli-${{ github.ref }}

--- a/python_client/kubetorch/globals.py
+++ b/python_client/kubetorch/globals.py
@@ -532,11 +532,6 @@ class ControllerClient:
         """Delete a PersistentVolumeClaim."""
         return self.delete(f"/controller/volumes/{namespace}/{name}", ignore_not_found=True)
 
-    def list_pvcs(self, namespace: str, label_selector: Optional[str] = None) -> Dict[str, Any]:
-        """List PersistentVolumeClaims."""
-        params = {"label_selector": label_selector} if label_selector else {}
-        return self.get(f"/controller/volumes/{namespace}", params=params)
-
     # Services
     def create_service(self, namespace: str, body: Dict[str, Any], params: Dict = None) -> Dict[str, Any]:
         """Create a Service"""
@@ -612,9 +607,8 @@ class ControllerClient:
         return self.patch(f"/controller/secrets/{namespace}/{name}", json=body)
 
     def list_secrets(self, namespace: str, label_selector: Optional[str] = None) -> Dict[str, Any]:
-        """List secrets in a namespace."""
-        params = {"label_selector": label_selector} if label_selector else {}
-        return self.get(f"/controller/secrets/{namespace}", params=params)
+        """List Secrets"""
+        return self.list_resources("secrets", namespace=namespace, label_selector=label_selector)
 
     def delete_secret(self, namespace: str, name: str) -> Dict[str, Any]:
         """Delete a secret."""
@@ -627,9 +621,8 @@ class ControllerClient:
 
     # Pods
     def list_pods(self, namespace: str, label_selector: Optional[str] = None) -> Dict[str, Any]:
-        """List pods in a namespace."""
-        params = {"label_selector": label_selector} if label_selector else {}
-        return self.get(f"/controller/pods/{namespace}", params=params)
+        """List Pods"""
+        return self.list_resources("pods", namespace=namespace, label_selector=label_selector)
 
     def get_pod(self, namespace: str, name: str, ignore_not_found=False) -> Dict[str, Any]:
         """Get a specific pod."""
@@ -654,26 +647,93 @@ class ControllerClient:
             logger.error(f"GET {url} - {e}")
             raise
 
+    # Namespaces
+    def get_namespace(self, name: str) -> Dict[str, Any]:
+        """Get a Namespace"""
+        return self.get(f"/api/v1/namespaces/{name}")
+
+    def list_namespaces(self) -> Dict[str, Any]:
+        """List Namespaces"""
+        return self.list_resources("namespaces")
+
     # Nodes
     def list_nodes(self, label_selector: Optional[str] = None) -> Dict[str, Any]:
-        """List cluster nodes."""
-        params = {"label_selector": label_selector} if label_selector else {}
-        return self.get("/controller/nodes", params=params)
+        """List Nodes"""
+        return self.list_resources("nodes", label_selector=label_selector)
+
+    def get_node(self, name: str) -> Dict[str, Any]:
+        """Get a Node"""
+        return self.get(f"/api/v1/nodes/{name}")
 
     # StorageClasses
     def list_storage_classes(self) -> Dict[str, Any]:
-        """List available storage classes."""
-        return self.get("/controller/storage-classes")
+        """List StorageClasses"""
+        return self.list_resources("storageclasses")
 
-    # ConfigMaps
-    def list_config_maps(self, namespace: str, label_selector: Optional[str] = None) -> Dict[str, Any]:
-        """List ConfigMaps"""
-        params = {"label_selector": label_selector} if label_selector else {}
-        return self.get(f"/controller/configmaps/{namespace}", params=params)
+    def get_storage_class(self, name: str) -> Dict[str, Any]:
+        """Get a StorageClass"""
+        return self.get(f"/apis/storage.k8s.io/v1/storageclasses/{name}")
 
-    def list_ingresses(self, namespace: str, label_selector: str = None):
+    def get_config_map(self, namespace: str, name: str) -> Dict[str, Any]:
+        """Get a ConfigMap"""
+        return self.get(f"/api/v1/namespaces/{namespace}/configmaps/{name}")
+
+    # Custom Resource Definitions (CRDs)
+    def create_namespaced_custom_object(
+        self, group: str, version: str, namespace: str, plural: str, body: Dict[str, Any], params: Dict[str, Any] = None
+    ) -> Dict[str, Any]:
+        """Create a custom resource"""
+        return self.post(f"/apis/{group}/{version}/namespaces/{namespace}/{plural}", json=body, params=params)
+
+    def get_namespaced_custom_object(
+        self, group: str, version: str, namespace: str, plural: str, name: str, ignore_not_found=False
+    ) -> Dict[str, Any]:
+        """Get a custom resource"""
+        return self.get(
+            f"/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}", ignore_not_found=ignore_not_found
+        )
+
+    def patch_namespaced_custom_object(
+        self, group: str, version: str, namespace: str, plural: str, name: str, body: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Patch a custom resource"""
+        return self.patch(f"/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}", json=body)
+
+    def list_namespaced_custom_object(
+        self,
+        group: str,
+        version: str,
+        namespace: str,
+        plural: str,
+        label_selector: Optional[str] = None,
+        ignore_not_found=False,
+    ) -> Dict[str, Any]:
+        """List custom resources in a namespace"""
         params = {"label_selector": label_selector} if label_selector else {}
-        return self.get(f"/controller/ingresses/{namespace}", params=params)
+        return self.get(
+            f"/apis/{group}/{version}/namespaces/{namespace}/{plural}",
+            params=params,
+            ignore_not_found=ignore_not_found,
+        )
+
+    def list_ingresses(self, namespace: str, label_selector: str = None) -> Dict[str, Any]:
+        """List Ingresses"""
+        return self.list_resources("ingresses", namespace=namespace, label_selector=label_selector)
+
+    def get_namespaced_replica_set(self, namespace: str, name: str) -> Dict[str, Any]:
+        """Get a ReplicaSet"""
+        return self.get(f"/apis/apps/v1/namespaces/{namespace}/replicasets/{name}")
+
+    def list_cluster_custom_object(
+        self,
+        group: str,
+        version: str,
+        plural: str,
+        label_selector: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List cluster-scoped custom resources"""
+        params = {"label_selector": label_selector} if label_selector else {}
+        return self.get(f"/apis/{group}/{version}/{plural}", params=params)
 
     def register_pool(
         self,
@@ -877,6 +937,63 @@ class ControllerClient:
             params["resource_type"] = resource_type
         return self.get(
             f"/controller/discover/{namespace}/{name}/status",
+            params=params if params else None,
+        )
+
+    def list_resources(
+        self,
+        resource_type: str,
+        namespace: str = None,
+        namespaces: List[str] = None,
+        label_selector: str = None,
+        field_selector: str = None,
+        include_events: bool = False,
+    ) -> Dict[str, Any]:
+        """List Kubernetes resources with Kubetorch-specific filtering.
+
+        This endpoint consolidates multiple K8s API calls into a single request,
+        applying Kubetorch-specific filters and returning only relevant data.
+
+        Supported resource types (namespace-scoped):
+        - pvcs: All PersistentVolumeClaims
+        - volumes: PVCs with kubetorch.com/mount-path annotation (Kubetorch volumes only)
+        - secrets: Secrets
+        - pods: Pods
+        - replicasets: ReplicaSets with optional events (for error checking)
+        - configmaps: ConfigMaps
+        - events: Kubernetes events (supports field_selector)
+        - ingresses: Ingresses
+
+        Supported resource types (cluster-scoped, namespace param ignored):
+        - namespaces: Namespaces
+        - nodes: Nodes
+        - storageclasses: StorageClasses
+
+        Args:
+            resource_type (str): Type of resource to list.
+            namespace (str, optional): Single namespace to search.
+            namespaces (List[str], optional): List of namespaces to search.
+            label_selector (str, optional): Kubernetes label selector to filter resources.
+            field_selector (str, optional): Kubernetes field selector (for events).
+            include_events (bool, optional): Include events for resources that support it.
+
+        Returns:
+            Dict with 'items' list containing resource data.
+        """
+        params = {}
+        if namespace:
+            params["namespace"] = namespace
+        if namespaces:
+            params["namespaces"] = ",".join(namespaces)
+        if label_selector:
+            params["label_selector"] = label_selector
+        if field_selector:
+            params["field_selector"] = field_selector
+        if include_events:
+            params["include_events"] = "true"
+
+        return self.get(
+            f"/controller/list/{resource_type}",
             params=params if params else None,
         )
 

--- a/python_client/kubetorch/resources/compute/utils.py
+++ b/python_client/kubetorch/resources/compute/utils.py
@@ -230,15 +230,12 @@ def load_configmaps(
     """List configmaps that start with a given service name."""
     controller_client = kubetorch.globals.controller_client()
     try:
-        configmaps = controller_client.list_config_maps(
+        result = controller_client.list_resources(
+            resource_type="configmaps",
             namespace=namespace,
             label_selector=f"kubetorch.com/service={service_name}",
         )
-        # Handle dict response from ControllerClient
-        if isinstance(configmaps, dict):
-            return [cm["metadata"]["name"] for cm in configmaps.get("items", [])]
-        # Handle object response from CoreV1Api (legacy)
-        return [cm.metadata.name for cm in configmaps.items]
+        return [cm["name"] for cm in result.get("items", [])]
     except Exception as e:
         if console:
             console.print(f"[yellow]Warning:[/yellow] Failed to list configmaps: {e}")

--- a/python_client/tests/test_controller.py
+++ b/python_client/tests/test_controller.py
@@ -229,8 +229,8 @@ def test_pvc_list_with_label_selector():
     """Test GET /api/v1/namespaces/{ns}/persistentvolumeclaims with label_selector"""
     controller_client = kt.globals.controller_client()
 
-    result = controller_client.list_pvcs(
-        namespace=kt.config.namespace, label_selector=f"kubetorch.com/username={kt.config.username}"
+    result = controller_client.list_resources(
+        "pvcs", namespace=kt.config.namespace, label_selector=f"kubetorch.com/username={kt.config.username}"
     )
 
     assert "items" in result
@@ -486,6 +486,15 @@ def test_all_list_operations_structure():
         assert "items" in result, f"{method_name} missing 'items'"
         assert isinstance(result["items"], list), f"{method_name} items not a list"
 
+    # Namespace-scoped resources available via list_resources endpoint
+    ns_resource_types = ["pvcs", "configmaps", "secrets", "pods", "replicasets", "events", "ingresses"]
+    for resource_type in ns_resource_types:
+        result = controller_client.list_resources(resource_type, namespace=namespace)
+
+        assert result is not None, f"list_resources({resource_type}) returned None"
+        assert "items" in result, f"list_resources({resource_type}) missing 'items'"
+        assert isinstance(result["items"], list), f"list_resources({resource_type}) items not a list"
+
 
 # =============================================================================
 # Deploy Endpoint Tests (/controller/deploy)
@@ -625,8 +634,17 @@ def test_configmap_operations():
     controller_client = kt.globals.controller_client()
     namespace = remote_fn.compute.namespace
 
-    configmaps = controller_client.list_config_maps(namespace=namespace)
+    configmaps = controller_client.list_resources("configmaps", namespace=namespace)
     assert "items" in configmaps
+
+    cms = controller_client.list_resources(
+        "configmaps", namespace=namespace, label_selector=f"kubetorch.com/service={service_name}"
+    )
+
+    if len(cms["items"]) > 0:
+        cm_name = cms["items"][0]["metadata"]["name"]
+        cm = controller_client.get_config_map(namespace=namespace, name=cm_name)
+        assert cm["kind"] == "ConfigMap"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
  - Reduces API calls to controller by using new consolidated `list_resources` endpoint
  - Replaces multiple pure K8s proxy calls with single consolidated calls that include server-side filtering and business logic

  ## Changes

  ### New client method
  - Added `list_resources(resource_type, namespace, label_selector, field_selector, include_events)` to `ControllerClient`

  ### Updated commands/functions to use consolidated endpoint
  - `kt volumes -A`: N calls → 1 call (was looping through namespaces)
  - `kt list`: N+1 calls → 2 calls (revision resources now fetched in batch)
  - `kt status`: Uses `resource` from `service_status()` instead of extra API call
  - `load_configmaps()`: Uses `list_resources("configmaps")`
  - `check_pod_events_for_errors()`: Uses `list_resources("events")`
  - `check_replicaset_events_for_errors()`: Uses `list_resources("replicasets", include_events=True)`

  ### Removed deprecated client methods
  - `list_pvcs()` → use `list_resources("volumes")`
  - `list_namespaced_replica_set()` → use `list_resources("replicasets")`
  - `list_config_maps()` → use `list_resources("configmaps")`
  - `list_events()` → use `list_resources("events")`