### PR TITLE
update debug config in http server and fix logging and import errors

### DIFF
--- a/python_client/kubetorch/resources/callables/utils.py
+++ b/python_client/kubetorch/resources/callables/utils.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Type, Union
 
 from kubetorch.globals import DebugConfig
 from kubetorch.logger import get_logger
-from kubetorch.serving.constants import DEFAULT_DEBUG_PORT
+from kubetorch.provisioning.constants import DEFAULT_DEBUG_PORT
 
 logger = get_logger(__name__)
 

--- a/python_client/kubetorch/serving/http_server.py
+++ b/python_client/kubetorch/serving/http_server.py
@@ -1224,7 +1224,7 @@ def execute_callable(
         # Default JSON handling
         args = params.get("args", [])
         kwargs = params.get("kwargs", {})
-        debugger: dict = params.pop("debugger", None)
+        debugger: dict = params.get("debugger", None) if params else None
         if debugger:
             debug_mode = debugger.get("mode")
             debug_port = debugger.get("port")

--- a/python_client/tests/conftest.py
+++ b/python_client/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 TEST_SESSION_HASH = None
+KUBETORCH_IMAGE = "ghcr.io/run-house/kubetorch:fix-debug-config-and-imports"  # TODO update tag to "main"
 
 
 @pytest.fixture

--- a/python_client/tests/test_monitoring.py
+++ b/python_client/tests/test_monitoring.py
@@ -150,6 +150,9 @@ async def test_monitoring_with_custom_structlog():
         remote_worker = kt.cls(LoggingTestWorker).to(compute)
         service_name = remote_worker.service_name
 
+        # Trigger class instantiation by calling a method (class __init__ only runs on first method call)
+        _ = remote_worker.process_with_logs(1)
+
         # Poll for initialization logs and events with timeout
         # Events flow through K8s API -> Controller -> Loki -> Log stream, so may take time
         init_out = ""


### PR DESCRIPTION
## Summary

  - Moves debugger configuration extraction into `execute_callable()` instead of passing as separate function parameters
  - Fixes import path for `DEFAULT_DEBUG_PORT` after directory restructure
  - Fixes subprocess log capture so logger calls (not just print) are captured when user code reconfigures logging

## Changes

  - `process_worker.py`: Remove debug_port/debug_mode extraction and parameter passing, and store `log_capture` as instance variable and call `ensure_handler()` after loading user code
  - `http_server.py`: Extract debugger dict from params inside execute_callable()
  - `utils.py`: Fix import from `provisioning.constants`
  - Update `test_declarative_fn_freeze` test to use arbitrary function baked into image 
