### PR TITLE
Update how process groups form with TCPStore instead

### DIFF
--- a/python_client/kubetorch/globals.py
+++ b/python_client/kubetorch/globals.py
@@ -151,9 +151,6 @@ def _ensure_pf(service_name: str, namespace: str, remote_port: int, health_endpo
     # Cache key includes port to support multiple ports per service
     cache_key = f"{service_name}:{remote_port}"
 
-    # Cache key includes port to support multiple ports per service
-    cache_key = f"{service_name}:{remote_port}"
-
     # Fast path: check without lock first
     h = _port_forwards.get(cache_key)
     if h and h.process.poll() is None:
@@ -218,9 +215,6 @@ async def _ensure_pf_async(service_name: str, namespace: str, remote_port: int, 
     """Async version of _ensure_pf for use in async contexts."""
     from kubetorch.provisioning.utils import wait_for_port_forward
     from kubetorch.resources.compute.utils import find_available_port
-
-    # Cache key includes port to support multiple ports per service
-    cache_key = f"{service_name}:{remote_port}"
 
     # Cache key includes port to support multiple ports per service
     cache_key = f"{service_name}:{remote_port}"


### PR DESCRIPTION
When multiple different requests are made to the same putter, using global env var to set up multiple process groups is bad and leads to one of them trying to work on the wrong port and hanging. TCPStore makes it explicit. (Factored out the setup in multiple methods)

But we still might have multiple requests trying and spin up multiple process groups at the same time. At the cost of worse performance, the simple approach was adding a semaphore. The right approach might be doing work in a process pool and isolating them.