### PR TITLE
Fix `allowed_serialization` not persisting through `from_manifest` reconstruction

### DIFF
--- a/python_client/kubetorch/provisioning/constants.py
+++ b/python_client/kubetorch/provisioning/constants.py
@@ -29,6 +29,7 @@ DEFAULT_SERVICE_ACCOUNT_NAME = "kubetorch-service-account"
 # Annotations
 INACTIVITY_TTL_ANNOTATION = "kubetorch.com/inactivity-ttl"
 KUBECONFIG_PATH_ANNOTATION = "kubetorch.com/kubeconfig-path"
+ALLOWED_SERIALIZATION_ANNOTATION = "kubetorch.com/allowed-serialization"
 
 # Labels
 KT_SERVICE_LABEL = "kubetorch.com/service"


### PR DESCRIPTION
The `allowed_serialization` property was returning None when a Compute object was reconstructed via `from_manifest()`.

With this fix, we persist `allowed_serialization` to a manifest annotation (`kubetorch.com/allowed-serialization`), following the same pattern as `inactivity_ttl`

Example failure: https://github.com/run-house/kubetorch/actions/runs/20861906860/job/60001089734
