### PR TITLE
Add check for serializability

### DIFF
--- a/python_client/kubetorch/serving/http_server.py
+++ b/python_client/kubetorch/serving/http_server.py
@@ -1464,8 +1464,10 @@ def package_exception(exc: Exception):
     if hasattr(exc, "__getstate__"):
         try:
             state = exc.__getstate__()
+            json.dumps(state)
         except Exception as e:
             logger.debug(f"Could not serialize exception state for {error_type}: {e}")
+            state = None
 
     error_response = ErrorResponse(
         error_type=error_type,


### PR DESCRIPTION
Fixes when `exc.__getstate__()` gets something non-serializable

>   File "/kt_app/python_client/kubetorch/serving/execution_supervisor.py", line 155, in call
>     raise result
> TypeError: Object of type Response is not JSON serializable