### PR TITLE
Make data store PVC access mode configurable

### DIFF
--- a/charts/kubetorch/README.md
+++ b/charts/kubetorch/README.md
@@ -26,6 +26,7 @@ A Helm chart for kubetorch
 | dataStore.maxVerbosity | int | `0` |  |
 | dataStore.memory.request | string | `"4Gi"` |  |
 | dataStore.metadataPort | int | `8081` |  |
+| dataStore.storage.accessMode | string | `"ReadWriteOnce"` |  |
 | dataStore.storage.size | string | `"100Gi"` |  |
 | dataStore.storage.storageClassName | string | `""` |  |
 | dataStore.timeout | int | `600` |  |

--- a/charts/kubetorch/templates/data-store/namespace-data-store.yaml
+++ b/charts/kubetorch/templates/data-store/namespace-data-store.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: {{ . }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ $.Values.dataStore.storage.accessMode | default "ReadWriteOnce" }}
   resources:
     requests:
       storage: {{ $.Values.dataStore.storage.size | default "100Gi" }}

--- a/charts/kubetorch/values.yaml
+++ b/charts/kubetorch/values.yaml
@@ -90,6 +90,7 @@ dataStore:
   storage:
     size: 100Gi  # Size of persistent volume
     storageClassName: ""  # Leave empty to use default storage class
+    accessMode: ReadWriteOnce  # Use ReadWriteMany with RWX storage class for better availability
   cleanupCron:
     enabled: false # set to true to enable pod cleanup
   tolerations: []


### PR DESCRIPTION
Allow users to configure the data store PVC access mode via Helm values.                                                                                                                                                               
                                                                                                                                                                                                                                       
With `ReadWriteOnce` (default), if the data store pod gets evicted and the                                                                                                                                                             
PVC doesn't cleanly detach from the old node, the new pod can't start -                                                                                                                                                                
blocking rsync for all workloads.  