### PR TITLE
Disable service links in data store

### DIFF
--- a/charts/kubetorch/templates/data-store/namespace-data-store.yaml
+++ b/charts/kubetorch/templates/data-store/namespace-data-store.yaml
@@ -69,6 +69,7 @@ spec:
       {{- if $.Values.dataStore.serviceAccount }}
       serviceAccountName: {{ $.Values.dataStore.serviceAccount }}
       {{- end }}
+      enableServiceLinks: false
       containers:
         - name: data-store
           image: {{ $.Values.dataStore.image }}


### PR DESCRIPTION
Kubernetes auto-injects environment variables for every service in the                                                                                                                                                                namespace (~5-6 vars per service). In namespaces with many services,                                                                                                                                                                  this exceeds the kernel's ARG_MAX limit (~2MB), causing the data store pod to crash                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
Setting `enableServiceLinks: false` disables this injection. The data                                                                                                                                                                  
store doesn't need service discovery env vars - it uses DNS for any                                                                                                                                                                    
external connections.          

https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service