### PR TITLE
Add cluster-wide secrets read permissions to controller RBAC

### DIFF
--- a/charts/kubetorch/templates/controller/rbac.yaml
+++ b/charts/kubetorch/templates/controller/rbac.yaml
@@ -152,6 +152,11 @@ rules:
     resources: ["services"]
     verbs: ["get", "list", "watch"]
 
+  # Secrets (cluster-wide list to discover secrets across namespaces)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+
   # RayCluster CRDs
   - apiGroups: ["ray.io"]
     resources: ["rayclusters"]


### PR DESCRIPTION
Allow the kubetorch-controller to list/get/watch secrets across all
namespaces: 

```
 k8s.core_v1.list_secret_for_all_namespaces,
 label_selector=label_selector,
```

otherwise we get:

```
2026-01-21 09:00:24,897 | secrets.py | ERROR | Failed to list secrets across all namespaces: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': '909f86ed-3037-4398-8057-e45e3adacf3b', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': '8be003d6-23d2-4069-9ad4-5e997a1381b0', 'X-Kubernetes-Pf-Prioritylevel-Uid': '3b63d2bb-0120-457c-872e-1ede1de6e865', 'Date': 'Wed, 21 Jan 2026 09:00:24 GMT', 'Content-Length': '298'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"secrets is forbidden: User \"system:serviceaccount:kubetorch:kubetorch-controller\" cannot list resource \"secrets\" in API group \"\" at the cluster scope","reason":"Forbidden","details":{"kind":"secrets"},"code":403}


INFO:     127.0.0.1:0 - "GET /controller/secrets HTTP/1.1" 403 Forbidden
```

