### PR TITLE
Adds workload CRD for controller

### DIFF
--- a/charts/kubetorch/crds/kubetorchworkload-crd.yaml
+++ b/charts/kubetorch/crds/kubetorchworkload-crd.yaml
@@ -1,0 +1,215 @@
+---
+# KubetorchWorkload CRD - Represents a logical compute workload
+#
+# A workload is a group of pods that can receive calls and execute user code.
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubetorchworkloads.kubetorch.com
+  labels:
+    app.kubernetes.io/name: kubetorch
+    app.kubernetes.io/component: controller
+spec:
+  group: kubetorch.com
+  names:
+    kind: KubetorchWorkload
+    listKind: KubetorchWorkloadList
+    plural: kubetorchworkloads
+    singular: kubetorchworkload
+    shortNames:
+      - ktworkload
+      - ktworkloads
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - selector
+              properties:
+                selector:
+                  type: object
+                  description: Label selector to identify pods in this workload
+                  additionalProperties:
+                    type: string
+                serviceConfig:
+                  type: object
+                  description: How to route traffic to this workload
+                  properties:
+                    url:
+                      type: string
+                      description: User-provided service URL (e.g., Knative)
+                    selector:
+                      type: object
+                      description: Custom selector for routing (e.g., Ray head only)
+                      additionalProperties:
+                        type: string
+                    name:
+                      type: string
+                      description: Custom service name
+                module:
+                  type: object
+                  description: Code/application deployed on this workload
+                  properties:
+                    type:
+                      type: string
+                      description: Module type
+                      enum:
+                        - fn
+                        - cls
+                        - cmd
+                        - app
+                    dispatch:
+                      type: string
+                      description: Call dispatch mode
+                      enum:
+                        - regular
+                        - spmd
+                        - load_balanced
+                      default: regular
+                    procs:
+                      description: Number of processes or process indices
+                      x-kubernetes-int-or-string: true
+                    pointers:
+                      type: object
+                      description: Information to locate and load the callable
+                      properties:
+                        filePath:
+                          type: string
+                          description: Path to the Python file
+                        moduleName:
+                          type: string
+                          description: Python module name
+                        clsOrFnName:
+                          type: string
+                          description: Class or function name
+                        projectRoot:
+                          type: string
+                          description: Root directory for imports
+                        initArgs:
+                          type: object
+                          description: Arguments for initialization
+                          x-kubernetes-preserve-unknown-fields: true
+                workloadMetadata:
+                  type: object
+                  description: Metadata about the workload deployment
+                  properties:
+                    username:
+                      type: string
+                      description: User who created this workload
+                    deploymentMode:
+                      type: string
+                      description: How the workload was deployed (serverless, persistent, distributed, byo)
+                    distributedConfig:
+                      type: object
+                      description: Configuration for distributed workloads
+                      x-kubernetes-preserve-unknown-fields: true
+                    runtimeConfig:
+                      type: object
+                      description: Runtime settings pushed to pods
+                      properties:
+                        logStreamingEnabled:
+                          type: boolean
+                          default: true
+                        metricsEnabled:
+                          type: boolean
+                          default: true
+                        inactivityTtl:
+                          type: string
+                          description: Auto-shutdown after inactivity (e.g., 30m, 1h)
+                        logLevel:
+                          type: string
+                          description: Python log level
+                        allowedSerialization:
+                          type: string
+                          description: Serialization mode
+                serverPort:
+                  type: integer
+                  description: Port pods listen on
+                  default: 32300
+                resourceKind:
+                  type: string
+                  description: K8s resource type backing this workload (Deployment, PyTorchJob, etc.)
+                resourceName:
+                  type: string
+                  description: Name of the backing K8s resource
+                dockerfile:
+                  type: string
+                  description: Build instructions for hot-reload
+                createHeadlessService:
+                  type: boolean
+                  description: Create headless service for pod-to-pod discovery
+                  default: false
+            status:
+              type: object
+              properties:
+                serviceUrl:
+                  type: string
+                  description: URL to reach this workload
+                podIps:
+                  type: array
+                  description: IPs of connected pods
+                  items:
+                    type: string
+                podCount:
+                  type: integer
+                  description: Number of connected pods
+                lastDeployedAt:
+                  type: string
+                  format: date-time
+                  description: Timestamp of last module deployment
+                conditions:
+                  type: array
+                  description: Standard K8s conditions
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - "Unknown"
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Resource
+          type: string
+          jsonPath: .spec.resourceKind
+        - name: User
+          type: string
+          jsonPath: .spec.workloadMetadata.username
+        - name: Pods
+          type: integer
+          jsonPath: .status.podCount
+        - name: Service URL
+          type: string
+          jsonPath: .status.serviceUrl
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
## Overview

A **KubetorchWorkload** represents a logical group of pods that can receive calls and execute user code. It serves as the metadata layer that ties together:
- Pod discovery (via label selector)
- Service routing configuration
- Module/application deployment info
- Runtime configuration

### Why a CRD?

| Concern | SQLite | CRD |
|---------|--------|-----|
| Storage | Requires PVC | Uses etcd (built-in) |
| HA | Single-file bottleneck | Distributed via etcd |
| Observability | Opaque | `kubectl get ktworkloads` |
| Namespace isolation | Logical (column) | Native K8s namespacing |
| GitOps | Not possible | Full support |
| Event-driven | Poll-based | Watch/informer support |
| Backup | Custom scripts | etcd snapshots, Velero |

---

## Resource Definition

```yaml
apiVersion: kubetorch.com/v1alpha1
kind: KubetorchWorkload
metadata:
  name: my-workload          # Must be DNS-subdomain safe (lowercase, alphanumeric, '-')
  namespace: default
spec:
  selector: { ... }          # Required: Label selector to identify pods
  serviceConfig: { ... }     # Optional: How to route traffic to this workload
  module: { ... }            # Optional: Code/application deployed on the workload
  workloadMetadata: { ... }  # Optional: User info, runtime config, distributed settings
  serverPort: 32300          # Optional: Port pods listen on
  resourceKind: Deployment   # Optional: K8s resource type backing this workload
  resourceName: my-deploy    # Optional: Name of backing K8s resource
  dockerfile: "..."          # Optional: Build instructions for hot-reload
  createHeadlessService: false
status:
  serviceUrl: "..."
  podIps: [...]
  podCount: 0
  lastDeployedAt: "..."
  conditions: [...]
```

---

## Spec Fields

### `spec.selector` (required)

**Type:** `map[string]string`

The label selector used to identify which pods belong to this workload. The controller uses this to:
1. Watch for matching pods
2. Create K8s Services that route to these pods
3. Match incoming WebSocket connections to the correct workload

**Example:**
```yaml
spec:
  selector:
    app: my-ml-service
    kubetorch.com/service: my-workload
```

**Behavior:**
- All key-value pairs must match (AND semantics)
- Used for both pod tracking and service routing (unless `serviceConfig.selector` overrides)

**Constraints:**
- Must contain at least one key-value pair
- Keys and values must be valid K8s label values

---

### `spec.serviceConfig` (optional)

**Type:** `object` (one of three variants)

Controls how traffic is routed to this workload. If not specified, a ClusterIP Service is auto-created using `spec.selector`.

#### Variant 1: User-provided URL
```yaml
spec:
  serviceConfig:
    url: "http://my-knative-service.default.svc.cluster.local"
```

Use when the workload is backed by a resource that manages its own service (e.g., Knative, external load balancer). No Service is created by Kubetorch.

**Fields:**
- `url` (string): Full URL to reach the workload

---

#### Variant 2: Custom routing selector
```yaml
spec:
  serviceConfig:
    selector:
      ray.io/node-type: head
```

Use when you want to track all pods (via `spec.selector`) but route traffic to a subset (e.g., Ray head node only).

**Fields:**
- `selector` (map[string]string): Label selector for the Service to use

**Example use case:** RayCluster where `spec.selector` matches all pods for tracking, but `serviceConfig.selector` routes only to the head node.

---

#### Variant 3: Custom service name
```yaml
spec:
  serviceConfig:
    name: my-custom-svc-name
```

Use when you want Kubetorch to create a Service but with a specific name (instead of using the workload name).

**Fields:**
- `name` (string): Name for the auto-created Service

---

### `spec.module` (optional)

**Type:** `object`

Describes the code/application deployed on this workload. This information is pushed to pods via WebSocket when they connect, enabling hot-reload and dynamic module loading.

```yaml
spec:
  module:
    type: cls                    # fn | cls | cmd | app
    dispatch: regular            # regular | spmd | load_balanced
    procs: 1                     # Number of processes or process indices
    pointers:
      filePath: "/app/model.py"
      moduleName: "model"
      clsOrFnName: "MyModel"
      projectRoot: "/app"
      initArgs:
        model_name: "llama-7b"
```

#### `module.type` (required within module)

**Type:** `string` (enum)

| Value | Description |
|-------|-------------|
| `fn` | A function to be called |
| `cls` | A class to be instantiated |
| `cmd` | A shell command to execute |
| `app` | A full application/server |

---

#### `module.dispatch` (optional)

**Type:** `string` (enum), default: `regular`

| Value | Description |
|-------|-------------|
| `regular` | Route calls to any available pod |
| `spmd` | Single Program Multiple Data - broadcast to all pods |
| `load_balanced` | Route based on load metrics |

---

#### `module.procs` (optional)

**Type:** `integer` or `array[integer]`, default: `1`

- Integer: Number of processes per pod
- Array: Specific process indices to target

---

#### `module.pointers` (optional)

**Type:** `object`

Information needed to locate and load the callable on the pod.

| Field | Type | Description |
|-------|------|-------------|
| `filePath` | string | Path to the Python file containing the callable |
| `moduleName` | string | Python module name (e.g., `my_package.model`) |
| `clsOrFnName` | string | Name of the class or function to load |
| `projectRoot` | string | Root directory for relative imports |
| `initArgs` | object | Arguments passed to class `__init__` or function |

---

### `spec.workloadMetadata` (optional)

**Type:** `object`

Metadata about the workload deployment, including user info and runtime configuration.

```yaml
spec:
  workloadMetadata:
    username: "alice@example.com"
    deploymentMode: "serverless"
    distributedConfig:
      numReplicas: 4
      backend: "nccl"
    runtimeConfig:
      logStreamingEnabled: true
      metricsEnabled: true
      inactivityTtl: "30m"
      logLevel: "INFO"
      allowedSerialization: "pickle"
```

#### `workloadMetadata.username` (optional)

**Type:** `string`

The user who created/owns this workload. Used for:
- Access control filtering
- Quota tracking
- Audit logging

---

#### `workloadMetadata.deploymentMode` (optional)

**Type:** `string`

Describes how the workload was deployed. Common values:
- `serverless` - Knative-backed, scales to zero
- `persistent` - Always-on Deployment
- `distributed` - Multi-replica training job
- `byo` - Bring Your Own (user-managed pods)

---

#### `workloadMetadata.distributedConfig` (optional)

**Type:** `object` (free-form)

Configuration for distributed workloads (SPMD, data parallel, etc.).

| Common Field | Type | Description |
|--------------|------|-------------|
| `numReplicas` | integer | Number of worker replicas |
| `backend` | string | Communication backend (nccl, gloo, mpi) |
| `masterAddr` | string | Address of rank-0 node |
| `masterPort` | integer | Port for distributed coordination |

This is passed through to pods and used by the Runhouse runtime to configure distributed execution.

---

#### `workloadMetadata.runtimeConfig` (optional)

**Type:** `object`

Runtime settings pushed to pods via WebSocket. Can be updated without restarting pods.

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `logStreamingEnabled` | boolean | `true` | Stream logs to controller |
| `metricsEnabled` | boolean | `true` | Report metrics to controller |
| `inactivityTtl` | string | `null` | Auto-shutdown after inactivity (e.g., "30m", "1h") |
| `logLevel` | string | `null` | Python log level (DEBUG, INFO, WARNING, ERROR) |
| `allowedSerialization` | string | `null` | Serialization mode ("pickle", "json", etc.) |

---

### `spec.serverPort` (optional)

**Type:** `integer`, default: `32300`

The port that pods in this workload listen on for incoming requests. Used when creating the auto-managed Service.

---

### `spec.resourceKind` (optional)

**Type:** `string`

The Kubernetes resource type that backs this workload. Used for:
- Determining readiness check strategy
- Teardown/cleanup logic
- Display in UI

**Common values:**
- `Deployment`
- `StatefulSet`
- `DaemonSet`
- `KnativeService`
- `RayCluster`
- `PyTorchJob`
- `TFJob`
- `MPIJob`

If not provided, the controller attempts to discover it from pod `ownerReferences`.

---

### `spec.resourceName` (optional)

**Type:** `string`

Name of the backing K8s resource. Defaults to the workload name if not specified.

Useful when the K8s resource name differs from the logical workload name (e.g., auto-generated suffixes).

---

### `spec.dockerfile` (optional)

**Type:** `string`

Dockerfile or build instructions for hot-reload scenarios. When a new module is deployed, this can be used to rebuild the container image without full redeployment.

**Note:** This is stored as metadata; actual build execution is handled separately.

---

### `spec.createHeadlessService` (optional)

**Type:** `boolean`, default: `false`

When `true`, creates an additional headless Service (`<name>-headless`) for direct pod-to-pod communication. Required for:
- SPMD/distributed workloads
- Applications that need to discover peer pod IPs
- StatefulSet-style stable network identities

The headless service uses `spec.selector` (not `serviceConfig.selector`) to include all pods.

---

## Status Fields

The `status` subresource is managed by the controller and reflects the current state of the workload.

### `status.serviceUrl`

**Type:** `string`

The URL to reach this workload. Either:
- Auto-generated: `<name>.<namespace>.svc.cluster.local`
- User-provided: From `spec.serviceConfig.url`
- Knative URL: From Knative service status

---

### `status.podIps`

**Type:** `array[string]`

List of IP addresses for pods currently connected to this workload via WebSocket.

Updated in real-time as pods connect/disconnect.

---

### `status.podCount`

**Type:** `integer`

Number of pods currently connected to this workload.

---

### `status.lastDeployedAt`

**Type:** `string` (RFC3339 timestamp)

Timestamp of the last successful deployment (module push) to this workload.

---

### `status.conditions`

**Type:** `array[Condition]`

Standard Kubernetes conditions for the workload.

| Condition Type | Meaning |
|----------------|---------|
| `Ready` | Workload has at least one ready pod |
| `ServiceCreated` | Auto-managed Service exists |
| `ModuleDeployed` | Module successfully pushed to pods |
| `Degraded` | Some pods unhealthy but workload functional |

Each condition has:
- `type`: Condition name
- `status`: "True", "False", or "Unknown"
- `lastTransitionTime`: When the condition last changed
- `reason`: Machine-readable reason code
- `message`: Human-readable description

---

## Naming Conventions

Workload names must conform to Kubernetes naming rules:

- **DNS Subdomain**: lowercase, alphanumeric, `-` allowed
- **Max length**: 253 characters
- **Start/end**: Must start and end with alphanumeric character
- **Regex**: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`

**Examples:**
| Valid | Invalid |
|-------|---------|
| `my-workload` | `My_Workload` (uppercase, underscore) |
| `llama-7b-inference` | `llama.7b` (dot not allowed) |
| `user-alice-job-123` | `-starts-with-dash` |

The controller should sanitize or reject invalid names at the API level.

---

## Example Resources

### Minimal Workload (selector-only mode)

```yaml
apiVersion: kubetorch.com/v1alpha1
kind: KubetorchWorkload
metadata:
  name: my-service
  namespace: ml-team
spec:
  selector:
    app: my-service
```

### Deployment-backed Workload with Module

```yaml
apiVersion: kubetorch.com/v1alpha1
kind: KubetorchWorkload
metadata:
  name: embedding-service
  namespace: ml-team
spec:
  selector:
    kubetorch.com/service: embedding-service
  resourceKind: Deployment
  resourceName: embedding-service
  serverPort: 32300
  module:
    type: cls
    dispatch: load_balanced
    pointers:
      moduleName: "embedding_model"
      clsOrFnName: "EmbeddingService"
      initArgs:
        model_name: "sentence-transformers/all-MiniLM-L6-v2"
  workloadMetadata:
    username: "alice@example.com"
    deploymentMode: "persistent"
    runtimeConfig:
      logStreamingEnabled: true
      inactivityTtl: "1h"
```

### Distributed PyTorchJob Workload

```yaml
apiVersion: kubetorch.com/v1alpha1
kind: KubetorchWorkload
metadata:
  name: llama-finetune
  namespace: training
spec:
  selector:
    training.kubeflow.org/job-name: llama-finetune
  resourceKind: PyTorchJob
  resourceName: llama-finetune
  createHeadlessService: true
  module:
    type: fn
    dispatch: spmd
    procs: 4
    pointers:
      filePath: "/app/train.py"
      clsOrFnName: "train_model"
  workloadMetadata:
    username: "bob@example.com"
    deploymentMode: "distributed"
    distributedConfig:
      numReplicas: 4
      backend: "nccl"
```

### RayCluster Workload (custom service selector)

```yaml
apiVersion: kubetorch.com/v1alpha1
kind: KubetorchWorkload
metadata:
  name: ray-inference
  namespace: ml-team
spec:
  selector:
    ray.io/cluster: ray-inference   # Track all pods
  serviceConfig:
    selector:
      ray.io/node-type: head        # Route to head only
  resourceKind: RayCluster
  resourceName: ray-inference
  workloadMetadata:
    username: "carol@example.com"
```

### Knative Serverless Workload

```yaml
apiVersion: kubetorch.com/v1alpha1
kind: KubetorchWorkload
metadata:
  name: serverless-api
  namespace: production
spec:
  selector:
    serving.knative.dev/service: serverless-api
  serviceConfig:
    url: "http://serverless-api.production.svc.cluster.local"
  resourceKind: KnativeService
  resourceName: serverless-api
  module:
    type: app
    pointers:
      moduleName: "api"
      clsOrFnName: "create_app"
  workloadMetadata:
    deploymentMode: "serverless"
```