### PR TITLE
update list of retried exceptions for controller client

### DIFF
--- a/python_client/kubetorch/globals.py
+++ b/python_client/kubetorch/globals.py
@@ -483,8 +483,8 @@ class ControllerClient:
                 # Don't retry HTTP errors (except 502/503 handled above)
                 raise
 
-            except (httpx.ConnectError, httpx.TimeoutException) as e:
-                # Retry connection errors (controller pod down/restarting)
+            except (httpx.ConnectError, httpx.TimeoutException, httpx.RemoteProtocolError) as e:
+                # Retry connection errors (controller pod down/restarting, stale keep-alive)
                 if attempt < max_attempts:
                     retry_delay = base_delay * attempt
                     logger.warning(


### PR DESCRIPTION
Add RemoteProtocolError to the list of retried exceptions in ControllerClient._request(). This error occurs when the server
(or nginx proxy) closes a keep-alive connection while the client attempts to reuse it, resulting in "Server disconnected without sending a response".
