### PR TITLE
Add `PodDisruptionBudget` for controller to prevent autoscaler evictions

### DIFF
--- a/charts/kubetorch/README.md
+++ b/charts/kubetorch/README.md
@@ -78,6 +78,7 @@ A Helm chart for kubetorch
 | kubetorchController.nginx.resources.cpu.request | string | `"200m"` |  |
 | kubetorchController.nginx.resources.memory.request | string | `"256Mi"` |  |
 | kubetorchController.nodeSelector | object | `{}` |  |
+| kubetorchController.pdb.enabled | bool | `true` |  |
 | kubetorchController.port | int | `8081` |  |
 | kubetorchController.resources.cpu.request | string | `"1"` |  |
 | kubetorchController.resources.memory.request | string | `"2Gi"` |  |

--- a/charts/kubetorch/templates/controller/pdb.yaml
+++ b/charts/kubetorch/templates/controller/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubetorchController.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kubetorch-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kubetorch-controller
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: kubetorch-controller
+{{- end }}

--- a/charts/kubetorch/values.yaml
+++ b/charts/kubetorch/values.yaml
@@ -50,6 +50,10 @@ kubetorchController:
   nodeSelector: {}
   affinity: {}
 
+  # PodDisruptionBudget - prevents cluster autoscaler from evicting the controller
+  pdb:
+    enabled: true
+
   # TTL configuration
   ttl:
     enabled: true


### PR DESCRIPTION
Where it gets scheduled is the user's responsibility to configure via nodeSelector / affinity