### PR TITLE
Optimizations: Adjusts timeouts, worker pool singleton

### DIFF
--- a/python_client/kubetorch/provisioning/templates/pod_template.yaml
+++ b/python_client/kubetorch/provisioning/templates/pod_template.yaml
@@ -113,6 +113,7 @@ containers:
         path: /health
         port: {{ server_port }}
       periodSeconds: 3
+      timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 5
     # Ongoing health monitoring with less frequent checks
@@ -121,7 +122,7 @@ containers:
         path: /health
         port: {{ server_port }}
       periodSeconds: 30
-      timeoutSeconds: 1
+      timeoutSeconds: 5
       failureThreshold: 3
 
 volumes:


### PR DESCRIPTION
@dongreenberg - some minor optimizations from running the scale test.
- Updated pod_template timeouts to stop showing so many `Readiness probe failed:` warnings
- Retry backoff for pod IPs
- Singleton to skip RemoteWorkerPool recreation on consecutive runs

Main slowness is still recreating ProcessPool after a .to - might need to check a code hash or something to determine if we can keep existing subprocesses.