### PR TITLE
Make the username prefix on service names optional

### DIFF
--- a/python_client/kubetorch/cli_utils.py
+++ b/python_client/kubetorch/cli_utils.py
@@ -120,19 +120,19 @@ def get_deployment_mode(name: str, namespace: str) -> str:
         original_name = name
         deployment_mode = detect_deployment_mode(name, namespace)
         username = globals.config.username
-        # If service not found and not already prefixed with username, try with username prefix
+        # If not found by the exact name, fall back to the username-prefixed name.
         if not deployment_mode and username and not name.startswith(username + "-"):
-            name = f"{username}-{name}"
-            deployment_mode = detect_deployment_mode(name, namespace)
+            prefixed_name = f"{username}-{name}"
+            prefixed_mode = detect_deployment_mode(prefixed_name, namespace)
+            if prefixed_mode:
+                name = prefixed_name
+                deployment_mode = prefixed_mode
 
         if not deployment_mode:
             console.print(f"[red]Failed to load service [bold]{original_name}[/bold] in namespace {namespace}[/red]")
             raise typer.Exit(1)
         console.print(f"Found [green]{deployment_mode}[/green] service [blue]{name}[/blue]")
-        if (
-            username and username not in name
-        ):  # the user provided remote_fn.name / remote_cls.name instead of service name that included the username as prefix
-            name = f"{username}-{name}"
+        # Return whichever name actually matched (exact bare name or the prefixed fallback).
         return name, deployment_mode
 
     except Exception as e:

--- a/python_client/kubetorch/config.py
+++ b/python_client/kubetorch/config.py
@@ -17,6 +17,7 @@ ENV_MAPPINGS = {
     "install_url": "KT_INSTALL_URL",
     "stream_logs": "KT_STREAM_LOGS",
     "stream_metrics": "KT_STREAM_METRICS",
+    "prefix_username": "KT_PREFIX_USERNAME",
     "volumes": "KT_VOLUMES",
     "api_url": "KT_API_URL",
     "cluster_config": "KT_CLUSTER_CONFIG",
@@ -34,6 +35,7 @@ class KubetorchConfig:
         self._install_namespace = None
         self._install_url = None
         self._namespace = None
+        self._prefix_username = None
         self._stream_logs = None
         self._stream_metrics = None
         self._username = None
@@ -93,6 +95,35 @@ class KubetorchConfig:
         if validated != value:
             logger.info(f"Username was validated and changed to {validated} to be Kubernetes-compatible.")
         self._username = validated
+
+    @property
+    def prefix_username(self):
+        """Whether to prepend the username to deployed service names.
+
+        When enabled (default), a service named ``train-cnn-r4`` launched by user ``shaped``
+        is deployed as ``shaped-train-cnn-r4``. When disabled, the service keeps its bare name.
+        Can be overridden per-call via the ``prefix_username`` argument on ``fn``/``cls``/``to``.
+        Default is ``True``.
+        """
+        if self._prefix_username is None:
+            if self._get_env_var("prefix_username"):
+                self._prefix_username = self._get_env_var("prefix_username").lower() == "true"
+            else:
+                self._prefix_username = self.file_cache.get("prefix_username", True)  # Default to True
+        return self._prefix_username
+
+    @prefix_username.setter
+    def prefix_username(self, value):
+        """Set username prefixing for current process."""
+        bool_value = value
+        if not isinstance(value, bool):
+            if value is None:
+                pass  # unsetting prefix_username, None is a valid value
+            elif isinstance(value, str) and value.lower() in ["true", "false"]:
+                bool_value = value.lower() == "true"
+            else:
+                raise ValueError("prefix_username must be a boolean value")
+        self._prefix_username = bool_value
 
     @property
     def volumes(self):
@@ -366,9 +397,10 @@ class KubetorchConfig:
         Note: Some config values are excluded from pod templates because they are
         client-side only and would cause pod recreation if they change:
         - cluster_config: Changes based on port-forward state, not needed by server
+        - prefix_username: Client-side naming control only, excluded to avoid pod recreation
         """
         # Config keys that should NOT be in pod templates (client-side only)
-        excluded_keys = {"cluster_config"}
+        excluded_keys = {"cluster_config", "prefix_username"}
 
         env_vars = {}
         for key, value in dict(self).items():

--- a/python_client/kubetorch/resources/callables/cls/cls.py
+++ b/python_client/kubetorch/resources/callables/cls/cls.py
@@ -216,7 +216,7 @@ def cls(
     if get_if_exists is False:
         raise ValueError("Either provide a class object or a name with get_if_exists=True to reload an existing class")
 
-    reloaded_cls = Cls.from_name(name, reload_prefixes=reload_prefixes)
+    reloaded_cls = Cls.from_name(name, reload_prefixes=reload_prefixes, prefix_username=prefix_username)
     return reloaded_cls
 
 

--- a/python_client/kubetorch/resources/callables/cls/cls.py
+++ b/python_client/kubetorch/resources/callables/cls/cls.py
@@ -149,6 +149,7 @@ def cls(
     name: str = None,
     get_if_exists=True,
     reload_prefixes=None,
+    prefix_username: bool = None,
     sync_dir: Union[str, Path, bool] = None,
     remote_dir: Union[str, Path] = None,
     remote_import_path: str = None,
@@ -173,6 +174,9 @@ def cls(
         reload_prefixes (Union[str, List[str]], optional):
             A list of prefixes to use when reloading the class (e.g., ["qa", "prod", "git-branch-name"]).
             If not provided, will use the current username, git branch, and prod.
+        prefix_username (bool, optional): Whether to prepend the configured username to the
+            service name. If None (default), uses the global ``kt.config.prefix_username``
+            (default True). Set to False to deploy under the bare ``name`` with no prefix.
         sync_dir (str, Path, or bool, optional): Controls which directory to sync to compute.
             If None (default), auto-detect and sync package directory.
             If False, skip syncing files (assumes files are already on compute).
@@ -203,6 +207,7 @@ def cls(
         )
         new_cls.get_if_exists = get_if_exists
         new_cls.reload_prefixes = reload_prefixes or []
+        new_cls.prefix_username = prefix_username
         return new_cls
 
     if name is None:

--- a/python_client/kubetorch/resources/callables/fn/fn.py
+++ b/python_client/kubetorch/resources/callables/fn/fn.py
@@ -124,6 +124,7 @@ def fn(
     name: str = None,
     get_if_exists=True,
     reload_prefixes=None,
+    prefix_username: bool = None,
     sync_dir: Union[str, Path, bool] = None,
     remote_dir: Union[str, Path] = None,
     remote_import_path: str = None,
@@ -148,6 +149,9 @@ def fn(
         reload_prefixes (Union[str, List[str]], optional):
             A list of prefixes to use when reloading the function (e.g., ["qa", "prod", "git-branch-name"]).
             If not provided, will use the current username, git branch, and prod.
+        prefix_username (bool, optional): Whether to prepend the configured username to the
+            service name. If None (default), uses the global ``kt.config.prefix_username``
+            (default True). Set to False to deploy under the bare ``name`` with no prefix.
         sync_dir (str, Path, or bool, optional): Controls which directory to sync to compute.
             If None (default), auto-detect and sync package directory.
             If False, skip syncing files (assumes files are already on compute).
@@ -181,6 +185,7 @@ def fn(
         )
         new_fn.get_if_exists = get_if_exists
         new_fn.reload_prefixes = reload_prefixes or []
+        new_fn.prefix_username = prefix_username
         return new_fn
 
     if name is None:

--- a/python_client/kubetorch/resources/callables/fn/fn.py
+++ b/python_client/kubetorch/resources/callables/fn/fn.py
@@ -196,7 +196,7 @@ def fn(
             "Either provide a function object or a name with get_if_exists=True to reload an existing function"
         )
 
-    reloaded_fn = Fn.from_name(name, reload_prefixes=reload_prefixes)
+    reloaded_fn = Fn.from_name(name, reload_prefixes=reload_prefixes, prefix_username=prefix_username)
     return reloaded_fn
 
 

--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -442,6 +442,7 @@ class Module:
                 raise ValueError(f"Unknown module type: {callable_type}")
 
             reloaded_module.service_name = candidate
+            reloaded_module._prefix_username = prefix_username
             reloaded_module.compute = compute
             return reloaded_module
 

--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -365,6 +365,7 @@ class Module:
         name: str,
         namespace: str = None,
         reload_prefixes: Union[str, List[str]] = [],
+        prefix_username: bool = None,
     ):
         """Reload an existing callable by its service name."""
         import kubetorch as kt
@@ -374,7 +375,11 @@ class Module:
         namespace = namespace or config.namespace
         if isinstance(reload_prefixes, str):
             reload_prefixes = [reload_prefixes]
-        potential_names = get_names_for_reload_fallbacks(name=name, prefixes=reload_prefixes)
+        if prefix_username is None:
+            prefix_username = config.prefix_username
+        potential_names = get_names_for_reload_fallbacks(
+            name=name, prefixes=reload_prefixes, prefix_username=prefix_username
+        )
 
         all_services = ServiceManager.discover_services(namespace=namespace)
 
@@ -465,6 +470,7 @@ class Module:
                 name=self.service_name,
                 namespace=namespace,
                 reload_prefixes=reload_prefixes,
+                prefix_username=self._prefix_username,
             )
 
             # Update settable attributes with reloaded module values
@@ -692,6 +698,7 @@ class Module:
                 self.service_name,
                 namespace=self.namespace,
                 reload_prefixes=reload_prefixes,
+                prefix_username=self._prefix_username,
             )
             if existing_service:
                 if self.compute:
@@ -714,6 +721,7 @@ class Module:
                 self.service_name,
                 namespace=self.namespace,
                 reload_prefixes=reload_prefixes,
+                prefix_username=self._prefix_username,
             )
             if existing_service:
                 if self.compute:

--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -75,6 +75,7 @@ class Module:
         self._http_client = None
         self._get_if_exists = True
         self._reload_prefixes = None
+        self._prefix_username = None
         self._serialization = "json"  # Default serialization format
         self._async = False
         self._remote_root_path = None
@@ -130,6 +131,22 @@ class Module:
             raise ValueError("`reload_prefixes` must be a string or a list.")
 
     @property
+    def prefix_username(self):
+        """Whether to prepend the configured username to this module's service name.
+
+        If ``None`` (default), defers to the global ``config.prefix_username`` (which defaults
+        to ``True``). Set to ``False`` to deploy under the bare name with no username prefix.
+        """
+        return self._prefix_username
+
+    @prefix_username.setter
+    def prefix_username(self, value: Union[bool, None]):
+        if value is not None and not isinstance(value, bool):
+            raise ValueError("`prefix_username` must be a boolean or None.")
+        self._prefix_username = value
+        self._service_name = None  # invalidate cache so the next access re-resolves
+
+    @property
     def namespace(self):
         """Namespace where the service is deployed."""
         if self.compute is not None:
@@ -144,7 +161,15 @@ class Module:
 
         service_name = self.name
 
-        if config.username and not self.reload_prefixes and not service_name.startswith(config.username + "-"):
+        prefix_username = (
+            self._prefix_username if self._prefix_username is not None else config.prefix_username
+        )
+        if (
+            config.username
+            and prefix_username
+            and not self.reload_prefixes
+            and not service_name.startswith(config.username + "-")
+        ):
             service_name = f"{config.username}-{service_name}"
 
         self._service_name = clean_and_validate_k8s_name(service_name, allow_full_length=True)

--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -161,9 +161,7 @@ class Module:
 
         service_name = self.name
 
-        prefix_username = (
-            self._prefix_username if self._prefix_username is not None else config.prefix_username
-        )
+        prefix_username = self._prefix_username if self._prefix_username is not None else config.prefix_username
         if (
             config.username
             and prefix_username

--- a/python_client/kubetorch/resources/callables/module.py
+++ b/python_client/kubetorch/resources/callables/module.py
@@ -515,6 +515,7 @@ class Module:
         stream_logs: Union[bool, None] = None,
         get_if_exists: bool = False,
         reload_prefixes: Union[str, List[str]] = [],
+        prefix_username: bool = None,
         dryrun: bool = False,
     ) -> ModuleT:
         """
@@ -534,6 +535,8 @@ class Module:
             reload_prefixes (Union[str, List[str]], optional): A list of prefixes to use when reloading the function
                 (e.g., ["qa", "prod", "git-branch-name"]). If not provided, will use the current username,
                 git branch, and prod.
+            prefix_username (bool, optional): Whether to prepend the configured username to the
+                service name. If None (default), uses the per-module / global config setting.
             dryrun (bool, optional): Whether to setup and return the object as a dryrun (``True``),
                 or to actually launch the compute and service (``False``).
         Returns:
@@ -551,6 +554,8 @@ class Module:
                 stream_logs=True
             )
         """
+        if prefix_username is not None:
+            self.prefix_username = prefix_username
         if not has_k8s_credentials():
             raise KubernetesCredentialsError(
                 "Kubernetes credentials not found. Please ensure you are running in a Kubernetes cluster or have a valid kubeconfig file."
@@ -603,6 +608,7 @@ class Module:
         stream_logs: Union[bool, None] = None,
         get_if_exists: bool = False,
         reload_prefixes: Union[str, List[str]] = [],
+        prefix_username: bool = None,
         dryrun: bool = False,
     ) -> ModuleT:
         """
@@ -622,6 +628,8 @@ class Module:
             reload_prefixes (Union[str, List[str]], optional): A list of prefixes to use when reloading the function
                 (e.g., ["qa", "prod", "git-branch-name"]). If not provided, will use the current username,
                 git branch, and prod.
+            prefix_username (bool, optional): Whether to prepend the configured username to the
+                service name. If None (default), uses the per-module / global config setting.
             dryrun (bool, optional): Whether to setup and return the object as a dryrun (``True``),
                 or to actually launch the compute and service (``False``).
         Returns:
@@ -639,6 +647,8 @@ class Module:
                 stream_logs=True
             )
         """
+        if prefix_username is not None:
+            self.prefix_username = prefix_username
         if compute.service_name and compute.service_name != self.service_name:
             logger.info(f"Renaming service to match compute service name {compute.service_name}")
             self.service_name = compute.service_name

--- a/python_client/kubetorch/resources/callables/utils.py
+++ b/python_client/kubetorch/resources/callables/utils.py
@@ -183,7 +183,7 @@ def find_locally_installed_version(package_name: str) -> Optional[str]:
         return None
 
 
-def get_names_for_reload_fallbacks(name: str, prefixes: list[str] = []):
+def get_names_for_reload_fallbacks(name: str, prefixes: list[str] = [], prefix_username: bool = True):
     from kubetorch.globals import config
     from kubetorch.serving.utils import clean_and_validate_k8s_name
     from kubetorch.utils import current_git_branch, validate_username
@@ -192,6 +192,10 @@ def get_names_for_reload_fallbacks(name: str, prefixes: list[str] = []):
 
     if prefixes:
         fallback_prefixes = prefixes
+    elif not prefix_username:
+        # Username prefixing disabled: only look for the exact (bare) name.
+        # Callers pass an already-cleaned service name, so no re-validation is needed here.
+        return [name]
     else:
         # try reloading based on current username or current git branch (in that order)
         branch = current_git_branch()

--- a/python_client/kubetorch/resources/compute/decorators.py
+++ b/python_client/kubetorch/resources/compute/decorators.py
@@ -28,7 +28,12 @@ class PartialModule:
 # @kubetorch.compute decorator that the user can use to wrap a function they want to deploy to a cluster,
 # and then deploy it with `kt deploy my_app.py` (we collect all the decorated functions imported in the file
 # to deploy them).
-def compute(get_if_exists: bool = False, reload_prefixes: Union[str, List[str]] = [], **kwargs):
+def compute(
+    get_if_exists: bool = False,
+    reload_prefixes: Union[str, List[str]] = [],
+    prefix_username: bool = None,
+    **kwargs,
+):
     def decorator(func_or_cls):
         from kubetorch.globals import disable_decorators
 
@@ -61,6 +66,7 @@ def compute(get_if_exists: bool = False, reload_prefixes: Union[str, List[str]] 
                 name=module_name,
                 get_if_exists=get_if_exists,
                 reload_prefixes=reload_prefixes,
+                prefix_username=prefix_username,
             )
         else:
             new_module = fn(
@@ -68,6 +74,7 @@ def compute(get_if_exists: bool = False, reload_prefixes: Union[str, List[str]] 
                 name=module_name,
                 get_if_exists=get_if_exists,
                 reload_prefixes=reload_prefixes,
+                prefix_username=prefix_username,
             )
 
         if async_:

--- a/python_client/tests/test_config.py
+++ b/python_client/tests/test_config.py
@@ -247,3 +247,80 @@ def test_reload_fallbacks_explicit_prefixes_win_over_prefix_username_false():
         assert "summer" not in names
     finally:
         config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_get_deployment_mode_exact_match_not_reprefixed(monkeypatch):
+    """A service found by its exact (bare) name is returned as-is, not re-prefixed."""
+    from kubetorch import cli_utils
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        monkeypatch.setattr(
+            cli_utils,
+            "detect_deployment_mode",
+            lambda name, namespace: "Deployment" if name == "train-cnn-r4" else None,
+        )
+        name, mode = cli_utils.get_deployment_mode("train-cnn-r4", "ns")
+        assert name == "train-cnn-r4"
+        assert mode == "Deployment"
+    finally:
+        config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_get_deployment_mode_prefixed_fallback(monkeypatch):
+    """When the bare name is not found, the username-prefixed name is used."""
+    from kubetorch import cli_utils
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        monkeypatch.setattr(
+            cli_utils,
+            "detect_deployment_mode",
+            lambda name, namespace: "Deployment" if name == "test-user-summer" else None,
+        )
+        name, mode = cli_utils.get_deployment_mode("summer", "ns")
+        assert name == "test-user-summer"
+        assert mode == "Deployment"
+    finally:
+        config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_get_deployment_mode_not_found_raises_exit(monkeypatch):
+    """Neither the bare name nor the prefixed name found -> typer.Exit."""
+    import typer
+
+    from kubetorch import cli_utils
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        monkeypatch.setattr(cli_utils, "detect_deployment_mode", lambda name, namespace: None)
+        with pytest.raises(typer.Exit):
+            cli_utils.get_deployment_mode("nonexistent", "ns")
+    finally:
+        config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_get_deployment_mode_already_prefixed_name(monkeypatch):
+    """A name already starting with the username prefix is returned as-is, not double-prefixed."""
+    from kubetorch import cli_utils
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        monkeypatch.setattr(
+            cli_utils,
+            "detect_deployment_mode",
+            lambda name, namespace: "Deployment" if name == "test-user-summer" else None,
+        )
+        name, mode = cli_utils.get_deployment_mode("test-user-summer", "ns")
+        assert name == "test-user-summer"
+        assert mode == "Deployment"
+    finally:
+        config.set("username", org)

--- a/python_client/tests/test_config.py
+++ b/python_client/tests/test_config.py
@@ -173,3 +173,34 @@ def test_service_name_prefix_username_invalidates_cache():
         assert f.service_name == "summer"  # cache invalidated, re-resolved to bare name
     finally:
         config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_fn_prefix_username_param_false():
+    """fn(prefix_username=False) yields a bare service name."""
+    import kubetorch as kt
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        f = kt.fn(summer, name="summer", prefix_username=False)
+        assert f.service_name == "summer"
+    finally:
+        config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_fn_prefix_username_param_overrides_config():
+    """Per-call prefix_username=True overrides global config False."""
+    import kubetorch as kt
+
+    org_user = config.username
+    org_prefix = config._prefix_username
+    try:
+        config.set("username", "test-user")
+        config.set("prefix_username", False)
+        f = kt.fn(summer, name="summer", prefix_username=True)
+        assert f.service_name == "test-user-summer"
+    finally:
+        config.set("username", org_user)
+        config._prefix_username = org_prefix

--- a/python_client/tests/test_config.py
+++ b/python_client/tests/test_config.py
@@ -70,3 +70,58 @@ def test_config_username_set_on_module():
         config.set("username", org_username)
 
     assert config.username == org_username
+
+
+@pytest.mark.level("unit")
+def test_config_prefix_username_default_true():
+    """prefix_username defaults to True when unset."""
+    org = config._prefix_username
+    try:
+        os.environ.pop("KT_PREFIX_USERNAME", None)
+        config._prefix_username = None
+        assert config.prefix_username is True
+    finally:
+        config._prefix_username = org
+
+
+@pytest.mark.level("unit")
+def test_config_prefix_username_from_env_var():
+    """prefix_username reads the KT_PREFIX_USERNAME env var."""
+    org = config._prefix_username
+    try:
+        os.environ["KT_PREFIX_USERNAME"] = "false"
+        config._prefix_username = None
+        assert config.prefix_username is False
+    finally:
+        os.environ.pop("KT_PREFIX_USERNAME", None)
+        config._prefix_username = org
+
+
+@pytest.mark.level("unit")
+def test_config_set_prefix_username():
+    """prefix_username can be set and validated via config.set."""
+    org = config._prefix_username
+    try:
+        config.set("prefix_username", False)
+        assert config.prefix_username is False
+        config.set("prefix_username", "true")
+        assert config.prefix_username is True
+        with pytest.raises(ValueError):
+            config.set("prefix_username", "maybe")
+    finally:
+        config._prefix_username = org
+
+
+@pytest.mark.level("unit")
+def test_config_set_prefix_username_none_unsets():
+    """Setting prefix_username to None unsets it; the property re-resolves to the default."""
+    org = config._prefix_username
+    try:
+        os.environ.pop("KT_PREFIX_USERNAME", None)
+        config.set("prefix_username", False)
+        assert config.prefix_username is False
+        config.set("prefix_username", None)
+        assert config._prefix_username is None
+        assert config.prefix_username is True
+    finally:
+        config._prefix_username = org

--- a/python_client/tests/test_config.py
+++ b/python_client/tests/test_config.py
@@ -125,3 +125,51 @@ def test_config_set_prefix_username_none_unsets():
         assert config.prefix_username is True
     finally:
         config._prefix_username = org
+
+
+@pytest.mark.level("unit")
+def test_service_name_prefix_username_attr_false():
+    """Setting prefix_username=False on a module yields a bare service name."""
+    import kubetorch as kt
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        f = kt.fn(summer, name="summer")
+        f.prefix_username = False
+        assert f.service_name == "summer"
+    finally:
+        config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_service_name_prefix_username_config_false():
+    """Global config prefix_username=False yields a bare service name."""
+    import kubetorch as kt
+
+    org_user = config.username
+    org_prefix = config._prefix_username
+    try:
+        config.set("username", "test-user")
+        config.set("prefix_username", False)
+        f = kt.fn(summer, name="summer")
+        assert f.service_name == "summer"
+    finally:
+        config.set("username", org_user)
+        config._prefix_username = org_prefix
+
+
+@pytest.mark.level("unit")
+def test_service_name_prefix_username_invalidates_cache():
+    """Changing prefix_username after service_name was accessed re-resolves the name."""
+    import kubetorch as kt
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        f = kt.fn(summer, name="summer")
+        assert f.service_name == "test-user-summer"  # populates the cache
+        f.prefix_username = False
+        assert f.service_name == "summer"  # cache invalidated, re-resolved to bare name
+    finally:
+        config.set("username", org)

--- a/python_client/tests/test_config.py
+++ b/python_client/tests/test_config.py
@@ -204,3 +204,46 @@ def test_fn_prefix_username_param_overrides_config():
     finally:
         config.set("username", org_user)
         config._prefix_username = org_prefix
+
+
+@pytest.mark.level("unit")
+def test_reload_fallbacks_prefix_username_false_exact_only():
+    """With prefix_username=False and no explicit prefixes, only the bare name is a candidate."""
+    from kubetorch.resources.callables.utils import get_names_for_reload_fallbacks
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        assert get_names_for_reload_fallbacks("summer", prefix_username=False) == ["summer"]
+    finally:
+        config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_reload_fallbacks_prefix_username_true_includes_prefixed():
+    """With prefix_username=True (default), the username-prefixed and bare names are candidates."""
+    from kubetorch.resources.callables.utils import get_names_for_reload_fallbacks
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        names = get_names_for_reload_fallbacks("summer", prefix_username=True)
+        assert "test-user-summer" in names
+        assert "summer" in names
+    finally:
+        config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_reload_fallbacks_explicit_prefixes_win_over_prefix_username_false():
+    """Explicit reload prefixes take precedence even when prefix_username=False."""
+    from kubetorch.resources.callables.utils import get_names_for_reload_fallbacks
+
+    org = config.username
+    try:
+        config.set("username", "test-user")
+        names = get_names_for_reload_fallbacks("summer", prefixes=["prod"], prefix_username=False)
+        assert "prod-summer" in names
+        assert "summer" not in names
+    finally:
+        config.set("username", org)

--- a/python_client/tests/test_config.py
+++ b/python_client/tests/test_config.py
@@ -324,3 +324,14 @@ def test_get_deployment_mode_already_prefixed_name(monkeypatch):
         assert mode == "Deployment"
     finally:
         config.set("username", org)
+
+
+@pytest.mark.level("unit")
+def test_prefix_username_excluded_from_pod_env_vars():
+    """prefix_username is client-side only and must not be injected into pod templates."""
+    org = config._prefix_username
+    try:
+        config.set("prefix_username", False)
+        assert "KT_PREFIX_USERNAME" not in config._get_config_env_vars()
+    finally:
+        config._prefix_username = org


### PR DESCRIPTION
## Summary
- Add an optional `prefix_username` control for the automatic `{username}-` prefix on service names: a per-call arg on `kt.fn`/`kt.cls`/`@kt.compute`/`.to()`/`.to_async()`, and a global `kt.config.prefix_username` / `KT_PREFIX_USERNAME` (default `True`).
- Per-call value overrides the global config; both default to prefixing on, so existing behavior is unchanged.
- Resolve the effective value consistently across the naming path (`Module.service_name`) and the reload-lookup paths (`from_name`, `_get_existing_service`, `_get_existing_service_async`, `_client`), so a bare-named service is reloaded correctly.
- Fix `get_deployment_mode` to resolve a service by its exact name first (username-prefixed name as a fallback), so `kt logs`/`status`/`teardown` work for bare-named services and a pre-existing bare/"prod" service is no longer re-prefixed to a non-existent name.

## Motivation
Currently, when a username is configured, kubetorch always prepends it to the service name (e.g. user `shaped` deploying `train-cnn-r4` gets `shaped-train-cnn-r4`), with no first-class way to opt out. This adds an explicit, backward-compatible toggle.

## Usage
```python
import kubetorch as kt

# Per call
kt.fn(train, name="train-cnn-r4", prefix_username=False).to(compute)  # -> "train-cnn-r4"

# Globally
kt.config.prefix_username = False        # or env: KT_PREFIX_USERNAME=false
```

## Test Plan
- 21 unit tests in `python_client/tests/test_config.py` (run with `--level unit`), all passing.
- pre-commit (black / ruff / ufmt) clean.